### PR TITLE
fix: remove content/ from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,7 +9,6 @@ CLAUDE.md
 .pre-commit-config.yaml
 .DS_Store
 .python-version
-content/
 unraid/
 .github/
 README.md


### PR DESCRIPTION
## Summary

- `content/` was listed in `.dockerignore`, excluding it from the Docker build context and causing the v0.1.2 release build to fail
- Removing it allows the `COPY content/ ./content/` Dockerfile instruction to work correctly

## Test plan

- [ ] Release workflow builds successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)