### PR TITLE
fix: bump version to 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "E-NOTE-ION"
-version = "0.1.2"
+version = "0.1.3"
 description = "Automation for Vestaboard displays - with emotion!"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [


### PR DESCRIPTION
## Summary

- Bumps version to 0.1.3 to produce a working release after v0.1.2's Docker image build failed (content/ was excluded by .dockerignore, fixed in #5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)