### PR TITLE
feat: add misfire_grace_time to scheduler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,20 +110,11 @@ The image is built on `ghcr.io/astral-sh/uv:python3.14-bookworm-slim` and
 published to `ghcr.io/jasonpuglisi/e-note-ion` via GitHub Actions on each
 release. Multi-arch: `linux/amd64` and `linux/arm64`.
 
-Runtime configuration via environment variables (used by `entrypoint.sh`):
+Runtime env vars (via `entrypoint.sh`): `VESTABOARD_KEY` (required),
+`FLAGSHIP=true` (Flagship 6×22), `PUBLIC=true` (public templates only).
 
-| Variable        | Values        | Default | Effect                            |
-|-----------------|---------------|---------|-----------------------------------|
-| `VESTABOARD_KEY`| string        | —       | API key (required)                |
-| `FLAGSHIP`      | `true`/`false`| `false` | Targets Flagship (6×22) board     |
-| `PUBLIC`        | `true`/`false`| `false` | Restricts to public templates     |
-
-Sample content is bundled in the image at `/app/content` and runs
-automatically. A host path can be mounted over `/app/content` to use custom
-templates instead (optional). Example Unraid path:
-`/mnt/user/appdata/e-note-ion/content`.
-
-The Unraid Community Applications template is at `unraid/e-note-ion.xml`.
+Sample content is bundled at `/app/content`; optionally override by mounting
+a host path there. Unraid CA template: `unraid/e-note-ion.xml`.
 
 ## Development Workflow
 
@@ -146,12 +137,12 @@ Steps:
 2. Make changes; run the full check suite
 3. If release-worthy (see below), bump `version` in `pyproject.toml`
 4. Commit with `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
-5. Stop and ask the user to sign the commit before pushing
+5. Tell the user to sign (`git commit --amend --no-edit -S`) and wait for confirmation
 6. `git push -u origin feat/description`
-7. `gh pr create --label <label>`
+7. `gh pr create --label <label> --assignee JasonPuglisi`
 8. After merge: `git checkout main && git pull && git branch -d feat/description`
 9. Keep `README.md` up to date with any user-facing changes
-10. For any TODOs identified during work, create a GitHub issue and assign to the appropriate milestone
+10. For any TODOs identified during work, create a GitHub issue assigned to JasonPuglisi and the appropriate milestone
 
 ## Release Strategy
 

--- a/e-note-ion.py
+++ b/e-note-ion.py
@@ -265,7 +265,7 @@ def main() -> None:
 
   print('Current message:')
   print(vestaboard.get_state())
-  scheduler = BackgroundScheduler()
+  scheduler = BackgroundScheduler(misfire_grace_time=300)
   load_content(scheduler, public_mode=args.public)
   scheduler.start()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "E-NOTE-ION"
-version = "0.1.4"
+version = "0.1.5"
 description = "Automation for Vestaboard displays — with emotion!"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.1.0"
+version = "0.1.5"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- Sets `misfire_grace_time=300` on `BackgroundScheduler` so jobs missed during a container restart (within 5 minutes) fire immediately on startup rather than being silently skipped
- Closes #11

Also includes CLAUDE.md workflow cleanups from previous session (signing instruction wording, `--assignee` in PR command, Docker section condensation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)