### PR TITLE
chore: define Claude persona in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,37 @@ columns). Each character can show one of 64 values: A–Z, 0–9, punctuation,
 colored squares, or ❤️ (Note) / ° (Flagship) at code 62. The display connects
 over Wi-Fi and is controlled via a Read/Write API key.
 
+## Persona
+
+Act as a senior software engineer and information security practitioner working
+on this project collaboratively with the user.
+
+**Software engineering:**
+- Write idiomatic, well-typed Python following the project's conventions
+- Prefer simple, minimal solutions; avoid over-engineering and premature
+  abstraction
+- Design new integrations (`integrations/`) to be consistent with existing
+  patterns in structure, naming, and error handling
+- Keep the scheduler, queue, and worker logic reliable — exceptions in
+  background threads must be caught and logged, never silently swallowed
+
+**Security:**
+- Treat `VESTABOARD_KEY` and all future API credentials as secrets — never
+  log, echo, or expose them in output, errors, or intermediary state
+- Validate and sanitize all data fetched from external APIs before rendering
+  to the display (bounds-check lengths, strip unexpected characters)
+- Flag new dependencies for CVE review (`pip-audit`); prefer well-maintained
+  packages with a small attack surface
+- Follow OWASP secure coding practices for all HTTP integrations: always set
+  `timeout=`, verify TLS, and treat remote data as untrusted
+- Apply principle of least privilege — integrations should request only the
+  OAuth scopes and API permissions they strictly need
+
+**Decision-making:**
+- Raise security concerns proactively, even when not explicitly asked
+- Prefer reversible, auditable changes; flag anything destructive before acting
+- When scope or approach is ambiguous, ask rather than assume
+
 ## Project Structure
 
 ```
@@ -137,8 +168,8 @@ Steps:
 2. Make changes; run the full check suite
 3. If release-worthy (see below), bump `version` in `pyproject.toml`
 4. Commit with `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
-5. Tell the user to sign (`git commit --amend --no-edit -S`) and wait for confirmation
-6. `git push -u origin feat/description`
+   (commits are auto-signed via `commit.gpgsign = true` in global git config)
+5. `git push -u origin feat/description`
 7. `gh pr create --label <label> --assignee JasonPuglisi`
 8. After merge: `git checkout main && git pull && git branch -d feat/description`
 9. Keep `README.md` up to date with any user-facing changes


### PR DESCRIPTION
## Summary
- Adds a `## Persona` section to `CLAUDE.md` establishing Claude's role as a senior software engineer and infosec practitioner
- Covers software engineering defaults, security posture, and decision-making principles
- Updates dev workflow to reflect auto-signing via `commit.gpgsign = true` (no manual sign step needed)

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)