### PR TITLE
feat: auto-create GitHub release on version bump to main

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,44 @@
+name: Auto Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create release on version bump
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 2
+
+      - name: Check for version bump
+        id: version
+        run: |
+          current=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          previous=$(git show HEAD~1:pyproject.toml 2>/dev/null \
+            | grep '^version = ' | sed 's/version = "\(.*\)"/\1/')
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          if [ "$current" != "$previous" ] && [ -n "$current" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create release
+        if: steps.version.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="v${{ steps.version.outputs.current }}"
+          if gh release view "$tag" &>/dev/null; then
+            echo "Release $tag already exists, skipping."
+          else
+            gh release create "$tag" --generate-notes --title "$tag"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,10 +172,11 @@ Steps:
 5. Verify signing succeeded: `git log -1 --show-signature` must show a valid signature before pushing
 6. `git push -u origin feat/description`
 7. `gh pr create --label <label> --assignee JasonPuglisi`
-8. Enable auto-merge: `gh pr merge --squash --delete-branch --auto`; CI will merge automatically once checks pass
-9. After merge: `git checkout main && git pull && git branch -d feat/description`
-9. Keep `README.md` up to date with any user-facing changes
-10. For any TODOs identified during work, create a GitHub issue assigned to JasonPuglisi and the appropriate milestone
+8. Enable auto-merge: `gh pr merge --squash --delete-branch --auto`
+9. Wait for merge: `gh pr checks <number> --watch`; once all pass and the PR merges, proceed
+10. After merge: `git checkout main && git pull && git branch -d feat/description`
+11. Keep `README.md` up to date with any user-facing changes
+12. For any TODOs identified during work, create a GitHub issue assigned to JasonPuglisi and the appropriate milestone
 
 ## Release Strategy
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/auto-release.yml` that triggers on every push to `main`
- Reads current and previous version from `pyproject.toml`; if changed, creates a GitHub release tagged `v{version}` with auto-generated notes
- Idempotent — skips silently if the tag already exists
- Triggers the existing `release.yml` (fires on `release: published`) to build and push the Docker image automatically

## Result
The release workflow is now fully automated: bump version in PR → merge → release created → Docker image pushed. No manual release creation needed.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)