### PR TITLE
feat: add BART real-time departure integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ on this project collaboratively with the user.
 ```
 e-note-ion.py               # Entry point — scheduler, queue, worker
 integrations/vestaboard.py  # Vestaboard API client (get_state, set_state)
+integrations/bart.py        # BART real-time departures integration
 content/
   contrib/                  # Bundled community content (disabled by default)
     aria.json               # Example contrib file
@@ -106,6 +107,21 @@ Each content file belongs to a named person/context (e.g. `aria.json`).
 standalone `{variable}` entry expands to all lines of the chosen option. Lines
 are word-wrapped to fit `model.cols`; excess rows are silently dropped.
 
+### Integration templates
+
+Templates can include `"integration": "<name>"` instead of (or alongside) a
+static `variables` dict. When the job fires, the worker calls
+`integrations.<name>.get_variables()`, which returns the same
+`dict[str, list[list[str]]]` structure as static variables. This allows
+dynamic data (e.g. real-time API responses) to populate `{variable}`
+placeholders in the format. The `variables` key is optional when an
+integration is present.
+
+Color squares can be embedded in format strings and integration output using
+short tags: `[R]` `[O]` `[Y]` `[G]` `[B]` `[V]` `[W]` `[K]` (red, orange,
+yellow, green, blue, violet, white, black). Each tag encodes to the
+corresponding Vestaboard color square code (63–70).
+
 ## Priority Queue Behaviour
 
 - `PriorityQueue` is a min-heap; `QueuedMessage.__lt__` inverts priority so
@@ -131,6 +147,10 @@ Flags can be combined.
 ## Environment
 
 - `VESTABOARD_KEY` — Vestaboard Read/Write API key (required)
+- `BART_API_KEY` — BART API key (required for the BART integration)
+- `BART_STATION` — originating station code (e.g. `MLPT`)
+- `BART_LINE_1_DEST` — destination substring for first line (e.g. `Daly City`)
+- `BART_LINE_2_DEST` — optional second line destination
 - Python version managed via `.python-version` (uv)
 - Dependencies managed with `uv` / `pyproject.toml`
 - Dev tools: `ruff` (lint + format), `pyright` (type checking), `bandit`
@@ -220,6 +240,12 @@ Dependencies and pinned versions should be kept current:
 GitHub Actions are pinned to full commit SHAs with a `# vX.Y.Z` comment.
 Dependabot reads the comment to identify the version and will open PRs to bump
 both the SHA and comment when new releases are available.
+
+### Keeping integration data current
+
+Some integrations embed static lists (station codes, terminal destinations,
+etc.) that can go stale. See `content/README.md` for per-integration update
+instructions and authoritative data sources.
 
 ## To Do
 

--- a/content/README.md
+++ b/content/README.md
@@ -28,6 +28,41 @@ Sample content for Aria, a cat. Schedules breakfast and dinner reminders at
 08:00 and 20:00, with an hourly default message, each paired with a random
 cat-themed quip.
 
+#### `bart.json`
+
+BART real-time departure board. Shows upcoming departures from a configured
+originating station across 1–2 lines, with line colors as Vestaboard color
+squares. Runs every 5 minutes on weekday mornings (06:00–10:00).
+
+**Required env vars:** `BART_API_KEY`, `BART_STATION`, `BART_LINE_1_DEST`
+**Optional env vars:** `BART_LINE_2_DEST`
+
+Free API key: https://api.bart.gov/api/register.aspx
+
+##### Keeping BART data current
+
+The Unraid template (`unraid/e-note-ion.xml`) contains hardcoded dropdowns for
+station codes and terminal destinations. These need updating when BART opens
+new stations or changes line termini.
+
+**Station codes** — authoritative source:
+https://api.bart.gov/docs/overview/abbrev.aspx
+The `BART_STATION` dropdown uses `CODE - Display Name` format. `bart.py`
+parses only the code (splits on first space), so labels are for display only.
+
+**Terminal destinations** — the `BART_LINE_x_DEST` values are substring-
+matched against destination names returned by the BART ETD API. To see current
+destinations for a station, call the API directly (requires an API key):
+```
+https://api.bart.gov/api/etd.aspx?cmd=etd&orig=MLPT&key=<key>&json=y
+```
+For current lines and termini without an API key, check the schedule PDFs:
+https://www.bart.gov/schedules/pdfs
+
+When updating, change both the `Default=` dropdown list in
+`unraid/e-note-ion.xml` and verify that the destination strings match what
+the ETD API actually returns (the `destination` field in each `etd` entry).
+
 ## `user/`
 
 Your personal content. Files placed here are always loaded automatically —

--- a/content/contrib/bart.json
+++ b/content/contrib/bart.json
@@ -1,0 +1,17 @@
+{
+  "templates": {
+    "departures": {
+      "schedule": {
+        "cron": "*/5 6-10 * * 1-5",
+        "hold": 290,
+        "timeout": 60
+      },
+      "priority": 8,
+      "public": true,
+      "integration": "bart",
+      "templates": [
+        { "format": ["BART {station}", "{line1}", "{line2}"] }
+      ]
+    }
+  }
+}

--- a/integrations/bart.py
+++ b/integrations/bart.py
@@ -1,0 +1,108 @@
+# integrations/bart.py
+#
+# BART real-time departure integration.
+#
+# Fetches upcoming departure estimates from the BART API and returns them as
+# a variables dict for use with content templates. Line colors are read from
+# the API response automatically — no manual color configuration needed.
+#
+# Required env vars:
+#   BART_API_KEY    — API key (free at https://api.bart.gov/api/register.aspx)
+#   BART_STATION    — Originating station code (e.g. MLPT for Milpitas)
+#
+# Optional env vars (configure 1–2 lines to display):
+#   BART_LINE_1_DEST — Destination substring to match (e.g. "Daly City")
+#   BART_LINE_2_DEST — Second destination substring (optional)
+
+import os
+from typing import Any
+
+import requests
+
+import integrations.vestaboard as vestaboard
+
+_API_BASE = 'https://api.bart.gov/api'
+
+# Maps BART API color names to Vestaboard color tags.
+_LINE_COLOR_TAG: dict[str, str] = {
+  'RED': '[R]',
+  'ORANGE': '[O]',
+  'YELLOW': '[Y]',
+  'GREEN': '[G]',
+  'BLUE': '[B]',
+  'PURPLE': '[V]',
+  'WHITE': '[W]',
+  'BEIGE': '[W]',  # no beige on Vestaboard; white is closest
+}
+
+
+def _format_minutes(mins: str) -> str:
+  """Convert a BART API minutes string to a short display string."""
+  if mins in ('Leaving', '0'):
+    return 'Now'
+  try:
+    return str(int(mins))
+  except ValueError:
+    return mins
+
+
+def _build_line(color_tag: str, estimates: list[dict[str, Any]]) -> str:
+  """Build a departure line like '[G] 8 14 31' fitting within model.cols."""
+  base = color_tag + ' '
+  parts: list[str] = []
+  for est in estimates:
+    t = _format_minutes(est['minutes'])
+    if vestaboard._display_len(base + ' '.join(parts + [t])) > vestaboard.model.cols:  # noqa: SLF001
+      break
+    parts.append(t)
+  return base + (' '.join(parts) if parts else '--')
+
+
+def get_variables() -> dict[str, list[list[str]]]:
+  """Fetch BART departures and return a variables dict for template rendering.
+
+  Returns keys: 'station', 'line1', and optionally 'line2'. Each value is a
+  single-option list (no randomness — departure times are always current).
+  """
+  api_key = os.environ.get('BART_API_KEY', '').strip()
+  if not api_key:
+    raise RuntimeError('BART_API_KEY environment variable is not set')
+
+  station_raw = os.environ.get('BART_STATION', '').strip()
+  if not station_raw:
+    raise RuntimeError('BART_STATION environment variable is not set')
+  # Accept both raw codes (MLPT) and dropdown format (MLPT - Milpitas).
+  station = station_raw.split()[0]
+
+  dest_filters = [d for key in ('BART_LINE_1_DEST', 'BART_LINE_2_DEST') if (d := os.environ.get(key, '').strip())]
+  if not dest_filters:
+    raise RuntimeError('At least one of BART_LINE_1_DEST or BART_LINE_2_DEST must be set')
+
+  r = requests.get(
+    f'{_API_BASE}/etd.aspx',
+    params={'cmd': 'etd', 'orig': station, 'key': api_key, 'json': 'y'},
+    timeout=10,
+  )
+  r.raise_for_status()
+  data = r.json()
+
+  station_data = data['root']['station'][0]
+  station_name: str = station_data['name']
+  etds: list[dict[str, Any]] = station_data.get('etd', [])
+
+  variables: dict[str, list[list[str]]] = {
+    'station': [[station_name]],
+  }
+
+  for i, dest_filter in enumerate(dest_filters, 1):
+    line_value = '--'
+    for etd in etds:
+      if dest_filter.lower() in etd['destination'].lower():
+        estimates = etd.get('estimate', [])
+        if estimates:
+          color_tag = _LINE_COLOR_TAG.get(estimates[0].get('color', ''), '[ ]')
+          line_value = _build_line(color_tag, estimates)
+        break
+    variables[f'line{i}'] = [[line_value]]
+
+  return variables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "E-NOTE-ION"
-version = "0.2.0"
+version = "0.3.0"
 description = "Automation for Vestaboard displays — with emotion!"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/unraid/e-note-ion.xml
+++ b/unraid/e-note-ion.xml
@@ -46,6 +46,50 @@
     Mask="false"/>
 
   <Config
+    Name="BART API Key"
+    Target="BART_API_KEY"
+    Default=""
+    Mode=""
+    Description="Required if using the BART integration (CONTENT_ENABLED=bart). Free API key at https://api.bart.gov/api/register.aspx"
+    Type="Variable"
+    Display="always"
+    Required="false"
+    Mask="true"/>
+
+  <Config
+    Name="BART station"
+    Target="BART_STATION"
+    Default="12TH - 12th St. Oakland City Center|16TH - 16th St. Mission|19TH - 19th St. Oakland|24TH - 24th St. Mission|ANTC - Antioch|ASHB - Ashby|BALB - Balboa Park|BAYF - Bay Fair|BERY - Berryessa/North San Jose|CAST - Castro Valley|CIVC - Civic Center|COLS - Coliseum|COLM - Colma|CONC - Concord|DALY - Daly City|DBRK - Downtown Berkeley|DUBL - Dublin/Pleasanton|DELN - El Cerrito del Norte|PLZA - El Cerrito Plaza|EMBR - Embarcadero|FRMT - Fremont|FTVL - Fruitvale|GLEN - Glen Park|HAYW - Hayward|LAFY - Lafayette|LAKE - Lake Merritt|MCAR - MacArthur|MLBR - Millbrae|MLPT - Milpitas|MONT - Montgomery St.|NBRK - North Berkeley|NCON - North Concord/Martinez|OAKL - Oakland Intl Airport|ORIN - Orinda|PITT - Pittsburg/Bay Point|PCTR - Pittsburg Center|PHIL - Pleasant Hill|POWL - Powell St.|RICH - Richmond|ROCK - Rockridge|SBRN - San Bruno|SFIA - San Francisco Intl Airport|SANL - San Leandro|SHAY - South Hayward|SSAN - South San Francisco|UCTY - Union City|WARM - Warm Springs/South Fremont|WCRK - Walnut Creek|WDUB - West Dublin|WOAK - West Oakland"
+    Mode=""
+    Description="Required if using the BART integration. Your originating BART station."
+    Type="Variable"
+    Display="always"
+    Required="false"
+    Mask="false"/>
+
+  <Config
+    Name="BART line 1 destination"
+    Target="BART_LINE_1_DEST"
+    Default="Antioch|Berryessa/North San Jose|Daly City|Dublin/Pleasanton|Millbrae|Pittsburg/Bay Point|Richmond|San Francisco Intl Airport"
+    Mode=""
+    Description="Required if using the BART integration. Destination for the first departure line shown."
+    Type="Variable"
+    Display="always"
+    Required="false"
+    Mask="false"/>
+
+  <Config
+    Name="BART line 2 destination"
+    Target="BART_LINE_2_DEST"
+    Default="|Antioch|Berryessa/North San Jose|Daly City|Dublin/Pleasanton|Millbrae|Pittsburg/Bay Point|Richmond|San Francisco Intl Airport"
+    Mode=""
+    Description="Optional second BART departure line. Leave blank to show only one line."
+    Type="Variable"
+    Display="always"
+    Required="false"
+    Mask="false"/>
+
+  <Config
     Name="Flagship mode"
     Target="FLAGSHIP"
     Default="false|true"

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.2.0"
+version = "0.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- Adds `integrations/bart.py` fetching live departures from the BART Legacy API, with line colors auto-detected and rendered as Vestaboard color squares
- Adds `content/contrib/bart.json` contrib template (weekday mornings, 5-min interval, priority 8)
- Extends `integrations/vestaboard.py` to support color tags (`[R]`, `[G]`, etc.) in format strings
- Adds dynamic integration support to the scheduler: templates with `"integration": "<name>"` call `get_variables()` at job-fire time instead of using static variables
- Adds Unraid template dropdowns for all 50 BART stations and terminal destinations
- Documents BART data sources and update process in `content/README.md`

Closes #19.

## Test plan

- [ ] Set `BART_API_KEY`, `BART_STATION`, `BART_LINE_1_DEST` and run with `--content-enabled bart`; confirm departure board displays with correct color squares
- [ ] Set `BART_LINE_2_DEST` and confirm second line appears
- [ ] Omit `BART_LINE_2_DEST`; confirm single-line display works
- [ ] Confirm Unraid template dropdowns render correctly for station and destination fields
- [ ] Confirm color tag parsing works for all 8 tags in a format string

🤖 Generated with [Claude Code](https://claude.com/claude-code)