### PR TITLE
fix: sanitize BART API errors to prevent key leakage

### DIFF
--- a/content/contrib/bart.json
+++ b/content/contrib/bart.json
@@ -2,7 +2,7 @@
   "templates": {
     "departures": {
       "schedule": {
-        "cron": "*/5 6-10 * * 1-5",
+        "cron": "*/5 7-9 * * 1-5",
         "hold": 290,
         "timeout": 60
       },

--- a/integrations/bart.py
+++ b/integrations/bart.py
@@ -83,7 +83,11 @@ def get_variables() -> dict[str, list[list[str]]]:
     params={'cmd': 'etd', 'orig': station, 'key': api_key, 'json': 'y'},
     timeout=10,
   )
-  r.raise_for_status()
+  try:
+    r.raise_for_status()
+  except requests.HTTPError as e:
+    # Re-raise without the URL to avoid leaking the API key in logs.
+    raise requests.HTTPError(f'BART API error: {e.response.status_code} {e.response.reason}') from None
   data = r.json()
 
   station_data = data['root']['station'][0]


### PR DESCRIPTION
## Summary

- `requests.HTTPError` includes the full request URL in its message, which exposes `BART_API_KEY` as a query parameter in logs. Catch and re-raise with a sanitized message (HTTP status + reason only) before the error reaches the logger.
- Narrows the BART departure cron window from 06:00–10:00 to 07:00–09:00.

## Test plan

- [ ] Confirm that a bad API key produces `BART API error: 400 Bad Request` in logs with no URL or key visible
- [ ] Confirm departures display correctly with a valid key

🤖 Generated with [Claude Code](https://claude.com/claude-code)