### PR TITLE
chore: add JSON formatter to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # v6.0.0
+    hooks:
+      - id: pretty-format-json
+        args: [--autofix, --indent=2, --no-sort-keys]
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.2
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,8 @@ Flags can be combined.
 - Dev tools: `ruff` (lint + format), `pyright` (type checking), `bandit`
   (security linting), `pip-audit` (dependency CVE scanning), `pre-commit`
 - Run checks: `uv run ruff check .`, `uv run ruff format --check .`,
-  `uv run pyright`, `uv run bandit -c pyproject.toml -r .`, `uv run pip-audit`
+  `uv run pyright`, `uv run bandit -c pyproject.toml -r .`, `uv run pip-audit`,
+  `uv run pre-commit run pretty-format-json --all-files`
 - Install hooks (once after cloning): `uv run pre-commit install`
 
 ## Docker

--- a/content/contrib/bart.json
+++ b/content/contrib/bart.json
@@ -10,7 +10,13 @@
       "public": true,
       "integration": "bart",
       "templates": [
-        { "format": ["BART {station}", "{line1}", "{line2}"] }
+        {
+          "format": [
+            "BART {station}",
+            "{line1}",
+            "{line2}"
+          ]
+        }
       ]
     }
   }


### PR DESCRIPTION
## Summary

- Adds `pretty-format-json` from `pre-commit-hooks` v6.0.0 to `.pre-commit-config.yaml`
- Configured with `--autofix`, 2-space indent, and `--no-sort-keys` to preserve authoring order
- Formats `content/contrib/bart.json` in place (the only file that needed changes)
- Documents the JSON format check in `CLAUDE.md`

Closes #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)