### PR TITLE
feat: add configurable truncation strategies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ for a physical split-flap device whose flaps need time to settle.
       },
       "priority": 5,           // integer 0–10; higher number = higher priority
       "public": true,          // if false, skipped when running with --public
+      "truncation": "word",    // optional: "hard" (default), "word", "ellipsis"
       "templates": [
         { "format": ["LINE ONE", "LINE {variable}"] }
       ]

--- a/content/contrib/bart.json
+++ b/content/contrib/bart.json
@@ -8,6 +8,7 @@
       },
       "priority": 8,
       "public": true,
+      "truncation": "ellipsis",
       "integration": "bart",
       "templates": [
         {


### PR DESCRIPTION
## Summary

- Adds `TruncationStrategy = Literal['hard', 'word', 'ellipsis']` to `vestaboard.py`
- `_truncate()` now handles all three strategies; `_wrap_lines()` and `set_state()` accept and thread it through
- Optional `"truncation"` key in content JSON (per named template); defaults to `"hard"` for backwards compatibility; invalid values raise `ValueError` at load time
- `bart.json` → `"ellipsis"` (signals when a long station name is cut)
- `aria.json` (user) → `"word"` (clean cut at word boundary)
- Documents `truncation` key in `CLAUDE.md` content JSON format section

Closes #37.

## Test plan

- [ ] Confirm existing content loads and renders without change (hard truncation default)
- [ ] Confirm a long line with `word` strategy cuts at a word boundary
- [ ] Confirm a long line with `ellipsis` strategy appends `...` after the last full word
- [ ] Confirm an invalid `truncation` value raises `ValueError` at load time

🤖 Generated with [Claude Code](https://claude.com/claude-code)