### PR TITLE
feat: show line color and no-service indicator for inactive BART routes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "E-NOTE-ION"
-version = "0.3.0"
+version = "0.4.0"
 description = "Automation for Vestaboard displays — with emotion!"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.3.0"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- When the BART ETD API returns no departures for a configured destination, shows `[COLOR] NO SERVICE` instead of `--`
- Color is determined via a static `destination → color` fallback map; falls back to `NO SERVICE` (no color) if the destination isn't in the map
- Tested locally: Daly City (not running) shows `[G] NO SERVICE`, Richmond (running) shows `[O] 8 28`
- Bumps to v0.4.0 (combines truncation strategies #37 and this change)

Closes #44.

## Test plan

- [x] Daly City (no service) → `[G] NO SERVICE` ✓
- [x] Richmond (active) → `[O] 8 28` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)