### PR TITLE
fix: trigger Docker image build on released event type

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [published]
+    types: [published, released]
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary

`gh release create` (used in `auto-release.yml`) fires the `released` GitHub event type, not `published`. The release workflow was only listening for `published`, so auto-created releases never triggered a Docker image build.

Adding `released` to the trigger types fixes this going forward. The existing tagged releases (v0.2.0–v0.4.0) will need to be manually re-triggered or the images built manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)