### PR TITLE
chore: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   release:
     types: [published, released]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to `release.yml` so Docker image builds can be manually triggered for any ref
- Primary use case: retrigger builds for releases created before the `released` event fix (v0.2.0–v0.4.0)
- Usage: `gh workflow run release.yml --ref vX.Y.Z`

## Test plan
- [ ] Merge PR
- [ ] Run `gh workflow run release.yml --ref v0.4.0` to trigger the missing build

🤖 Generated with [Claude Code](https://claude.com/claude-code)