### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "E-NOTE-ION"
-version = "0.4.0"
+version = "0.4.1"
 description = "Automation for Vestaboard displays — with emotion!"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [


### PR DESCRIPTION
## Summary
- Bumps version to 0.4.1 to trigger the first Docker image build now that the `release.yml` trigger is fixed (#47)
- Releases v0.2.0–v0.4.0 were created before the fix and never got Docker images built

🤖 Generated with [Claude Code](https://claude.com/claude-code)