### PR TITLE
fix: trigger Docker image build from auto-release via workflow_call

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,11 +6,17 @@ on:
 
 permissions:
   contents: write
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   release:
     name: Create release on version bump
     runs-on: ubuntu-latest
+
+    outputs:
+      tag: ${{ steps.create.outputs.tag }}
 
     steps:
       - name: Checkout
@@ -32,6 +38,7 @@ jobs:
           fi
 
       - name: Create release
+        id: create
         if: steps.version.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -39,6 +46,17 @@ jobs:
           tag="v${{ steps.version.outputs.current }}"
           if gh release view "$tag" &>/dev/null; then
             echo "Release $tag already exists, skipping."
+            echo "tag=" >> "$GITHUB_OUTPUT"
           else
             gh release create "$tag" --generate-notes --title "$tag"
+            echo "tag=$tag" >> "$GITHUB_OUTPUT"
           fi
+
+  build:
+    name: Build and push Docker image
+    needs: release
+    if: needs.release.outputs.tag != ''
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.release.outputs.tag }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   release:
     types: [published, released]
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. v0.4.2)'
+        required: true
+        type: string
   workflow_dispatch:
 
 env:
@@ -23,6 +29,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -37,9 +45,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{version}},value=${{ inputs.tag || github.ref_name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag || github.ref_name }}
+            type=semver,pattern={{major}},value=${{ inputs.tag || github.ref_name }}
           flavor: |
             latest=true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "E-NOTE-ION"
-version = "0.4.1"
+version = "0.4.2"
 description = "Automation for Vestaboard displays — with emotion!"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [


### PR DESCRIPTION
## Summary
- Fixes #50: Docker image was never built for releases created by `auto-release.yml` because GitHub prevents `GITHUB_TOKEN`-created events from triggering other workflows
- `release.yml` now exposes a `workflow_call` trigger accepting a `tag` input
- `auto-release.yml` calls `release.yml` directly after creating a release, bypassing the GITHUB_TOKEN restriction
- Also bumps version to 0.4.2 to exercise the new flow end-to-end

## Test plan
- [ ] PR merges and auto-release creates v0.4.2
- [ ] `release.yml` is invoked by `auto-release.yml` and builds/pushes the Docker image
- [ ] `ghcr.io/jasonpuglisi/e-note-ion:latest` and `:0.4.2` tags appear in the registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)