### PR TITLE
test: fill test coverage gaps for set_state, get_state, worker, enqueue, load_content, and BART two-line

### DIFF
--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -4,9 +4,12 @@ import time
 from pathlib import Path
 from queue import Empty
 from typing import Any, Generator
+from unittest.mock import patch
 
 import pytest
 from apscheduler.schedulers.background import BackgroundScheduler
+
+import integrations.vestaboard as vb
 
 # e-note-ion.py has a hyphen in its name so it can't be imported with a
 # standard import statement. Load it via importlib instead.
@@ -178,3 +181,129 @@ def test_load_file_public_mode_keeps_public(sched: BackgroundScheduler, tmp_path
   f.write_text(json.dumps(_make_content(public=True)))
   _mod._load_file(sched, f, public_mode=True)
   assert len(sched.get_jobs()) == 1
+
+
+# --- enqueue ---
+
+
+def test_enqueue_puts_message_on_queue() -> None:
+  _mod.enqueue(priority=5, data={'x': 1}, hold=30, timeout=60, name='test')
+  msg = _mod._queue.get_nowait()
+  assert msg.priority == 5
+  assert msg.name == 'test'
+  assert msg.hold == 30
+  assert msg.timeout == 60
+  assert msg.data == {'x': 1}
+
+
+def test_enqueue_seq_increments() -> None:
+  _mod.enqueue(priority=5, data={}, hold=10, timeout=10, name='first')
+  _mod.enqueue(priority=5, data={}, hold=10, timeout=10, name='second')
+  # Both have the same priority, so lower seq is popped first.
+  msg1 = _mod._queue.get_nowait()
+  msg2 = _mod._queue.get_nowait()
+  assert msg1.seq < msg2.seq
+
+
+# --- load_content ---
+
+
+def _make_file(directory: Path, name: str = 'test.json') -> Path:
+  f = directory / name
+  f.write_text(json.dumps(_make_content()))
+  return f
+
+
+def test_load_content_loads_user_files(
+  sched: BackgroundScheduler, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  user_dir = tmp_path / 'content' / 'user'
+  user_dir.mkdir(parents=True)
+  _make_file(user_dir)
+  monkeypatch.chdir(tmp_path)
+  _mod.load_content(sched)
+  assert len(sched.get_jobs()) == 1
+
+
+def test_load_content_contrib_disabled_by_default(
+  sched: BackgroundScheduler, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  contrib_dir = tmp_path / 'content' / 'contrib'
+  contrib_dir.mkdir(parents=True)
+  _make_file(contrib_dir)
+  monkeypatch.chdir(tmp_path)
+  _mod.load_content(sched)
+  assert len(sched.get_jobs()) == 0
+
+
+def test_load_content_contrib_enabled_by_stem(
+  sched: BackgroundScheduler, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  contrib_dir = tmp_path / 'content' / 'contrib'
+  contrib_dir.mkdir(parents=True)
+  _make_file(contrib_dir, 'bart.json')
+  monkeypatch.chdir(tmp_path)
+  _mod.load_content(sched, content_enabled={'bart'})
+  assert len(sched.get_jobs()) == 1
+
+
+def test_load_content_contrib_enabled_star(
+  sched: BackgroundScheduler, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  contrib_dir = tmp_path / 'content' / 'contrib'
+  contrib_dir.mkdir(parents=True)
+  _make_file(contrib_dir, 'anything.json')
+  monkeypatch.chdir(tmp_path)
+  _mod.load_content(sched, content_enabled={'*'})
+  assert len(sched.get_jobs()) == 1
+
+
+def test_load_content_missing_dirs_dont_raise(
+  sched: BackgroundScheduler, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  monkeypatch.chdir(tmp_path)
+  _mod.load_content(sched)  # no content/ dir — should not raise
+  assert len(sched.get_jobs()) == 0
+
+
+# --- worker ---
+
+
+def _make_worker_msg(*, scheduled_at: float, timeout: int) -> Any:
+  return _mod.QueuedMessage(
+    priority=5,
+    seq=0,
+    name='test',
+    scheduled_at=scheduled_at,
+    data={
+      'templates': [{'format': ['HELLO']}],
+      'variables': {},
+      'truncation': 'hard',
+    },
+    hold=60,
+    timeout=timeout,
+  )
+
+
+def test_worker_board_locked_requeues_within_timeout() -> None:
+  msg = _make_worker_msg(scheduled_at=time.monotonic(), timeout=3600)
+  with (
+    patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
+    patch('integrations.vestaboard.set_state', side_effect=vb.BoardLockedError('locked')),
+    patch('time.sleep'),
+  ):
+    with pytest.raises(KeyboardInterrupt):
+      _mod.worker()
+  assert not _mod._queue.empty()
+
+
+def test_worker_board_locked_discards_after_timeout() -> None:
+  msg = _make_worker_msg(scheduled_at=time.monotonic() - 1000, timeout=10)
+  with (
+    patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
+    patch('integrations.vestaboard.set_state', side_effect=vb.BoardLockedError('locked')),
+    patch('time.sleep'),
+  ):
+    with pytest.raises(KeyboardInterrupt):
+      _mod.worker()
+  assert _mod._queue.empty()


### PR DESCRIPTION
## Summary

- Adds `get_state` and `set_state` tests (happy path, 423 → `BoardLockedError`, HTTP error propagation)
- Adds `_expand_format` test for random option selection via mocked `random.choice`
- Adds `enqueue` tests (fields, seq increment)
- Adds `load_content` tests (user files, contrib disabled by default, enabled by stem, enabled with `*`, missing dirs)
- Adds `worker` tests for `BoardLockedError` retry: re-enqueues within timeout, discards after timeout
- Adds BART `get_variables` tests: `line2` absent when `BART_LINE_2_DEST` unset, `line2` present when set

Closes #61.

## Test plan

- [x] All 77 tests pass (`uv run pytest`)
- [x] Full check suite clean (ruff, pyright, bandit, pip-audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)