### PR TITLE
chore: rename VESTABOARD_KEY to VESTABOARD_API_KEY

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ on this project collaboratively with the user.
   background threads must be caught and logged, never silently swallowed
 
 **Security:**
-- Treat `VESTABOARD_KEY` and all future API credentials as secrets — never
+- Treat `VESTABOARD_API_KEY` and all future API credentials as secrets — never
   log, echo, or expose them in output, errors, or intermediary state
 - Validate and sanitize all data fetched from external APIs before rendering
   to the display (bounds-check lengths, strip unexpected characters)
@@ -151,7 +151,7 @@ Flags can be combined.
 
 ## Environment
 
-- `VESTABOARD_KEY` — Vestaboard Read/Write API key (required)
+- `VESTABOARD_API_KEY` — Vestaboard Read/Write API key (required)
 - Integration-specific env vars are documented in each integration's sidecar
   doc under `content/contrib/<name>.md`
 - Python version managed via `.python-version` (uv)
@@ -170,7 +170,7 @@ The image is built on `ghcr.io/astral-sh/uv:python3.14-bookworm-slim` and
 published to `ghcr.io/jasonpuglisi/e-note-ion` via GitHub Actions on each
 release. Multi-arch: `linux/amd64` and `linux/arm64`.
 
-Runtime env vars (via `entrypoint.sh`): `VESTABOARD_KEY` (required),
+Runtime env vars (via `entrypoint.sh`): `VESTABOARD_API_KEY` (required),
 `FLAGSHIP=true` (Flagship 6×22), `PUBLIC=true` (public templates only),
 `CONTENT_ENABLED` (comma-separated contrib stems, or `*` for all).
 
@@ -319,7 +319,7 @@ After adding a new integration doc, add a row to the table in
 Open issues are tracked on GitHub: https://github.com/JasonPuglisi/e-note-ion/issues
 
 Milestones:
-- **v1.0 — Public Release**: CA submission (#10), PyPI publish (#16), unit tests (#58), rename VESTABOARD_KEY (#52), refine Unraid icon (#53), verbose logging (#54)
+- **v1.0 — Public Release**: CA submission (#10), PyPI publish (#16), unit tests (#58), rename VESTABOARD_API_KEY (#52), refine Unraid icon (#53), verbose logging (#54)
 - **Content & Integrations**: default content and API integrations (#13), dynamic dependency loading (#35), structured config (#36), escape sequences (#38), BART env var consistency (#57)
 - **Notion Integration**: Notion database as content source (#30)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ it by name, or mount your own content directory:
 docker run -d \
   --name e-note-ion \
   --restart unless-stopped \
-  -e VESTABOARD_KEY=your_api_key_here \
+  -e VESTABOARD_API_KEY=your_api_key_here \
   -e CONTENT_ENABLED=bart \
   ghcr.io/jasonpuglisi/e-note-ion:latest
 ```
@@ -67,7 +67,7 @@ path for personal content.
 
 ```bash
 uv sync
-export VESTABOARD_KEY=your_api_key_here
+export VESTABOARD_API_KEY=your_api_key_here
 python e-note-ion.py
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,8 +10,8 @@ steps to reproduce, and any potential impact.
 
 ## API Key Handling
 
-This project requires a Vestaboard Read/Write API key via the `VESTABOARD_KEY`
+This project requires a Vestaboard Read/Write API key via the `VESTABOARD_API_KEY`
 environment variable. Keep this key out of version control and never include it
 in content JSON files or Docker image builds. When running with Docker, pass it
-at runtime via `-e VESTABOARD_KEY=...` or an env file, not in the `Dockerfile`
+at runtime via `-e VESTABOARD_API_KEY=...` or an env file, not in the `Dockerfile`
 or image layers.

--- a/integrations/vestaboard.py
+++ b/integrations/vestaboard.py
@@ -24,9 +24,9 @@ import requests
 # --- API configuration ---
 
 try:
-  _API_KEY = os.environ['VESTABOARD_KEY']
+  _API_KEY = os.environ['VESTABOARD_API_KEY']
 except KeyError:
-  print('Vestaboard API key missing in environment variable `VESTABOARD_KEY`')
+  print('Vestaboard API key missing in environment variable `VESTABOARD_API_KEY`')
   sys.exit(1)
 
 _HOST = 'https://rw.vestaboard.com'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "E-NOTE-ION"
-version = "0.4.2"
+version = "0.5.0"
 description = "Automation for Vestaboard displays — with emotion!"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,8 @@ import os
 from typing import Generator
 
 # Must be set before vestaboard is imported anywhere, since it reads
-# VESTABOARD_KEY at module level and exits if absent.
-os.environ.setdefault('VESTABOARD_KEY', 'test-key')
+# VESTABOARD_API_KEY at module level and exits if absent.
+os.environ.setdefault('VESTABOARD_API_KEY', 'test-key')
 
 import pytest
 

--- a/unraid/e-note-ion.xml
+++ b/unraid/e-note-ion.xml
@@ -14,7 +14,7 @@
 
   <Config
     Name="Vestaboard API Key"
-    Target="VESTABOARD_KEY"
+    Target="VESTABOARD_API_KEY"
     Default=""
     Mode=""
     Description="Your Vestaboard Read/Write API key. Found in the Vestaboard app under Settings."

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.4.2"
+version = "0.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- Renames `VESTABOARD_KEY` → `VESTABOARD_API_KEY` throughout the codebase for consistency with `BART_API_KEY`
- Updates `integrations/vestaboard.py`, `unraid/e-note-ion.xml`, `README.md`, `CLAUDE.md`, `SECURITY.md`, and `tests/conftest.py`
- Bumps version to `0.5.0` (minor — breaking change to Docker env var interface)

Closes #52.

## Test plan

- [x] All 77 tests pass — renamed sentinel in `tests/conftest.py` confirms the module imports correctly under the new name
- [x] Full check suite clean (ruff, pyright, bandit, pip-audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)