### PR TITLE
feat: verbose startup and registration logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,15 @@ PR labels (apply one or more):
 - When working on existing code that lacks tests, add retroactive coverage as
   part of the same PR where feasible
 
+### Periodic health review
+
+At natural breakpoints (before a minor/major release, after a sprint of feature
+work), do a lightweight review of: test coverage gaps, code pattern consistency
+across integrations, dependency health (`pip-audit`), security posture (timeouts,
+key handling, `# nosec` justifications), documentation drift, and stale
+TODO/FIXME comments. Open issues for any gaps found; fix trivial things inline.
+See #65 for the full checklist.
+
 ### Planning before implementation
 
 All non-trivial work follows a plan-then-execute cycle:


### PR DESCRIPTION
## Summary

- Adds startup banner: `Starting e-note-ion — Note (3×15), user content only` (reflects board model and active flags)
- Adds per-file and per-template registration output in `_load_file`:
  ```
  Loaded user/morning.json:
    · greeting  cron="0 8 * * *"  priority=5  hold=600s  timeout=600s
  ```
- Includes template name in worker send log: `[08:15:00] Sending user.morning.greeting | ...`
- Prints job count summary after scheduler starts: `Scheduler started — 3 job(s) registered`
- Also includes the periodic health review process in `CLAUDE.md` (see #65)

Closes #54.

## Test plan

- [x] `test_load_file_prints_registration` — verifies file header and template name/cron/priority in stdout
- [x] `test_worker_log_includes_template_name` — verifies `message.name` appears in worker send log
- [x] All 79 tests pass (`uv run pytest`)
- [x] Full check suite clean (ruff, pyright, bandit, pip-audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)