### PR TITLE
fix: match BART_LINE_x_DEST by abbreviation code

### DIFF
--- a/content/contrib/bart.md
+++ b/content/contrib/bart.md
@@ -9,14 +9,13 @@ squares. Runs every 5 minutes on weekday mornings (07:00–09:00).
 | Variable | Required | Description |
 |---|---|---|
 | `BART_API_KEY` | Yes | Free API key — register at https://api.bart.gov/api/register.aspx |
-| `BART_STATION` | Yes | Originating station code (e.g. `MLPT` for Milpitas) |
-| `BART_LINE_1_DEST` | Yes | Destination name to match for the first departure line |
-| `BART_LINE_2_DEST` | No | Destination name for an optional second line |
+| `BART_STATION` | Yes | Originating station abbreviation code (e.g. `MLPT` for Milpitas) |
+| `BART_LINE_1_DEST` | Yes | Destination station abbreviation code for the first departure line (e.g. `DALY` for Daly City) |
+| `BART_LINE_2_DEST` | No | Destination abbreviation code for an optional second line |
 
-`BART_STATION` accepts either a raw code (`MLPT`) or the Unraid dropdown
-format (`MLPT - Milpitas`) — only the code is used. `BART_LINE_x_DEST` values
-are matched as substrings against the destination names returned by the BART
-ETD API, so partial matches work (e.g. `Richmond` matches `Richmond`).
+All station values use abbreviation codes only (e.g. `MLPT`, `DALY`, `BERY`).
+`BART_LINE_x_DEST` is matched case-insensitively against the `abbreviation`
+field in the BART ETD API response.
 
 ## Keeping data current
 
@@ -30,9 +29,9 @@ the pipe-separated `Default=` list in that file.
 
 ### Terminal destinations
 
-`BART_LINE_x_DEST` values must match the `destination` field in BART ETD API
-responses, which uses the terminal station name. To see current destinations
-for a station, call the API directly (requires an API key):
+`BART_LINE_x_DEST` values must match the `abbreviation` field in BART ETD API
+responses. To see current abbreviations for departures from a station, call
+the API directly (requires an API key):
 
 ```
 https://api.bart.gov/api/etd.aspx?cmd=etd&orig=MLPT&key=<key>&json=y
@@ -42,4 +41,5 @@ For current lines and termini without an API key, check the schedule PDFs:
 https://www.bart.gov/schedules/pdfs
 
 When BART changes line termini, update the destination dropdown in
-`unraid/e-note-ion.xml` and verify the new names match what the API returns.
+`unraid/e-note-ion.xml` and the `_DEST_COLOR_FALLBACK` dict in
+`integrations/bart.py` to reflect the new abbreviation codes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "E-NOTE-ION"
-version = "0.5.0"
+version = "0.5.1"
 description = "Automation for Vestaboard displays — with emotion!"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/unraid/e-note-ion.xml
+++ b/unraid/e-note-ion.xml
@@ -70,9 +70,9 @@
   <Config
     Name="BART line 1 destination"
     Target="BART_LINE_1_DEST"
-    Default="Antioch|Berryessa/North San Jose|Daly City|Dublin/Pleasanton|Millbrae|Pittsburg/Bay Point|Richmond|San Francisco Intl Airport"
+    Default="ANTC|BERY|DALY|DUBL|MLBR|PITT|PCTR|RICH|SFIA"
     Mode=""
-    Description="Required if using the BART integration. Destination for the first departure line shown."
+    Description="Required if using the BART integration. Destination station abbreviation code for the first departure line shown. See https://api.bart.gov/docs/overview/abbrev.aspx"
     Type="Variable"
     Display="always"
     Required="false"
@@ -81,9 +81,9 @@
   <Config
     Name="BART line 2 destination"
     Target="BART_LINE_2_DEST"
-    Default="|Antioch|Berryessa/North San Jose|Daly City|Dublin/Pleasanton|Millbrae|Pittsburg/Bay Point|Richmond|San Francisco Intl Airport"
+    Default="|ANTC|BERY|DALY|DUBL|MLBR|PITT|PCTR|RICH|SFIA"
     Mode=""
-    Description="Optional second BART departure line. Leave blank to show only one line."
+    Description="Optional second BART departure line. Station abbreviation code. Leave blank to show only one line."
     Type="Variable"
     Display="always"
     Required="false"

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.5.0"
+version = "0.5.1"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

— *Claude Code*

- Changes `BART_LINE_x_DEST` to accept station abbreviation codes (`DALY`, `BERY`, etc.) instead of destination name substrings
- Matching now uses the ETD `abbreviation` field with a case-insensitive exact match (simpler and unambiguous)
- Removes the `BART_STATION` `split()[0]` convenience parsing — codes only now
- Updates `_DEST_COLOR_FALLBACK` keys from name substrings to abbreviation codes
- Updates `unraid/e-note-ion.xml` destination dropdowns to use codes
- Updates `content/contrib/bart.md` configuration docs and data currency instructions
- Bumps version to `0.5.1`

Closes #57. Aligns with #46 (dynamic color cache), which will use `abbreviation` codes directly.

## Test plan

- [x] Updated `bart_env` fixture to use `DALY` instead of `Daly City`
- [x] `test_get_variables_matches_by_abbreviation_code` — DALY matches ETD abbreviation
- [x] `test_get_variables_code_matching_is_case_insensitive` — lowercase `daly` still matches
- [x] `test_get_variables_unknown_code_shows_no_service` — unknown code → NO SERVICE
- [x] All 82 tests pass (`uv run pytest`)
- [x] Full check suite clean (ruff, pyright, bandit, pip-audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)