### PR TITLE
feat: add brace and color tag escape sequences

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,11 @@ on this project collaboratively with the user.
 - Be opinionated — if a proposed approach has a better alternative, push back
   and explain why rather than just implementing what was asked
 
+**GitHub authorship:**
+- When writing GitHub issues, PR descriptions, or comments, make it clear that
+  Claude authored them (e.g. open issue/PR bodies with "— *Claude Code*" or
+  include a note at the top of comments)
+
 ## Project Structure
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "E-NOTE-ION"
-version = "0.5.1"
+version = "0.6.0"
 description = "Automation for Vestaboard displays — with emotion!"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.5.1"
+version = "0.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

Adds escape syntax so format strings can contain `{`, `}`, and `[X]` literally without triggering variable substitution or color encoding.

**Brace escaping (`_expand_format`):**
- `{{` → literal `{` (code 0/blank on board)
- `}}` → literal `}` (code 0/blank on board)
- Uses `\x00`/`\x01` sentinel bytes as placeholders during regex processing

**Color tag escaping (`_encode_line`, `_display_len`, `_truncate`):**
- `[[G]]` → literal `[`, `G`, `]` (3 display chars, not a color square)
- Works for all 8 color letters: `[[R]]`, `[[O]]`, `[[Y]]`, `[[G]]`, `[[B]]`, `[[V]]`, `[[W]]`, `[[K]]`

**Refactoring:**
- New `_next_token(text, i)` helper centralises token scanning; eliminates duplicated look-ahead logic across `_encode_line`, `_display_len`, and `_truncate`

Also adds GitHub authorship guidance to `CLAUDE.md`.

Bumps to `0.6.0` (minor — new escape syntax in the content JSON format).

Closes #38.

## Test plan

- [x] `test_next_token_*` — verifies token detection for all token types including incomplete sequences
- [x] `test_display_len_escaped_color_tag` — `[[G]]` counts as 3 display chars
- [x] `test_encode_line_escaped_color_tag_not_green` — `[[G]]` encodes as `[0, 7, 0, ...]`, not green
- [x] `test_truncate_does_not_split_escaped_color_tag` — atomic: if it doesn't fit, drop it entirely
- [x] `test_truncate_includes_escaped_color_tag_when_it_fits`
- [x] `test_expand_format_escaped_braces_not_substituted`
- [x] `test_expand_format_escaped_braces_in_inline`
- [x] `test_expand_format_escaped_brace_whole_line_not_expanded`
- [x] All 95 tests pass (`uv run pytest`)
- [x] Full check suite clean (ruff, pyright, bandit, pip-audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)