### PR TITLE
feat: derive BART no-service line colors from routes API

### DIFF
--- a/content/contrib/bart.md
+++ b/content/contrib/bart.md
@@ -2,7 +2,9 @@
 
 BART real-time departure board. Shows upcoming departures from a configured
 originating station across 1–2 lines, with line colors as Vestaboard color
-squares. Runs every 5 minutes on weekday mornings (07:00–09:00).
+squares. Line colors are derived dynamically from the BART routes API on
+first call and cached for the process lifetime. Runs every 5 minutes on
+weekday mornings (07:00–09:00).
 
 ## Configuration
 
@@ -41,5 +43,6 @@ For current lines and termini without an API key, check the schedule PDFs:
 https://www.bart.gov/schedules/pdfs
 
 When BART changes line termini, update the destination dropdown in
-`unraid/e-note-ion.xml` and the `_DEST_COLOR_FALLBACK` dict in
-`integrations/bart.py` to reflect the new abbreviation codes.
+`unraid/e-note-ion.xml` to reflect the new abbreviation codes. No code
+changes are needed — line colors are derived dynamically from the routes API
+and will update automatically when the integration restarts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "E-NOTE-ION"
-version = "0.6.0"
+version = "0.7.0"
 description = "Automation for Vestaboard displays — with emotion!"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/integrations/test_bart.py
+++ b/tests/integrations/test_bart.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -52,6 +53,98 @@ _FAKE_ETD: dict[str, Any] = {
   }
 }
 
+# Minimal routes and routeinfo API fixtures for cache tests.
+_FAKE_ROUTES_ONE: dict[str, Any] = {'root': {'routes': {'route': [{'number': '6', 'color': 'GREEN'}]}}}
+
+_FAKE_ROUTEINFO_6_DALY: dict[str, Any] = {
+  'root': {
+    'routes': {
+      'route': {
+        'number': '6',
+        'destination': 'DALY',
+        'config': {'station': ['MLPT', 'CIVC', 'DALY']},
+      }
+    }
+  }
+}
+
+_FAKE_ROUTES_TWO: dict[str, Any] = {
+  'root': {
+    'routes': {
+      'route': [
+        {'number': '1', 'color': 'YELLOW'},
+        {'number': '6', 'color': 'GREEN'},
+      ]
+    }
+  }
+}
+
+_FAKE_ROUTEINFO_1_NO_MLPT: dict[str, Any] = {
+  'root': {
+    'routes': {
+      'route': {
+        'number': '1',
+        'destination': 'ANTC',
+        'config': {'station': ['SFIA', 'MLBR', 'ANTC']},
+      }
+    }
+  }
+}
+
+_FAKE_ROUTES_MULTI_COLOR: dict[str, Any] = {
+  'root': {
+    'routes': {
+      'route': [
+        {'number': '4', 'color': 'ORANGE'},
+        {'number': '6', 'color': 'GREEN'},
+      ]
+    }
+  }
+}
+
+_FAKE_ROUTEINFO_4_BERY: dict[str, Any] = {
+  'root': {
+    'routes': {
+      'route': {
+        'number': '4',
+        'destination': 'BERY',
+        'config': {'station': ['MLPT', 'BERY']},
+      }
+    }
+  }
+}
+
+_FAKE_ROUTEINFO_6_BERY: dict[str, Any] = {
+  'root': {
+    'routes': {
+      'route': {
+        'number': '6',
+        'destination': 'BERY',
+        'config': {'station': ['MLPT', 'BERY']},
+      }
+    }
+  }
+}
+
+
+def _mock(json_data: dict[str, Any]) -> MagicMock:
+  """Return a mock response with the given JSON payload."""
+  m = MagicMock()
+  m.json.return_value = json_data
+  m.raise_for_status.return_value = None
+  return m
+
+
+# Reset the module-level color cache before every test so routes API calls
+# don't bleed between tests. Tests that specifically exercise cache population
+# set bart._dest_color_cache = None themselves after this fixture runs.
+@pytest.fixture(autouse=True)
+def reset_color_cache() -> Generator[None, None, None]:
+  original = bart._dest_color_cache  # noqa: SLF001
+  bart._dest_color_cache = {}  # noqa: SLF001
+  yield
+  bart._dest_color_cache = original  # noqa: SLF001
+
 
 # --- _format_minutes ---
 
@@ -99,14 +192,72 @@ def test_build_line_empty_estimates() -> None:
 
 
 def test_no_service_line_known_dest() -> None:
-  result = bart._no_service_line('DALY')  # noqa: SLF001
+  result = bart._no_service_line('DALY', {'DALY': ['[G]']})  # noqa: SLF001
   assert 'NO SERVICE' in result
   assert '[G]' in result
 
 
 def test_no_service_line_unknown_dest() -> None:
-  result = bart._no_service_line('ZZZZ')  # noqa: SLF001
+  result = bart._no_service_line('ZZZZ', {})  # noqa: SLF001
   assert result == 'NO SERVICE'
+
+
+def test_no_service_line_multi_color_uses_first() -> None:
+  # When multiple tags exist, the first (lowest route number) is used.
+  result = bart._no_service_line('BERY', {'BERY': ['[O]', '[G]']})  # noqa: SLF001
+  assert result == '[O] NO SERVICE'
+
+
+# --- _fetch_dest_colors ---
+
+
+def test_fetch_dest_colors_maps_terminal_to_color() -> None:
+  with patch(
+    'integrations.bart.requests.get',
+    side_effect=[_mock(_FAKE_ROUTES_ONE), _mock(_FAKE_ROUTEINFO_6_DALY)],
+  ):
+    result = bart._fetch_dest_colors('testkey', 'MLPT')  # noqa: SLF001
+  assert result['DALY'] == ['[G]']
+
+
+def test_fetch_dest_colors_excludes_routes_not_serving_origin() -> None:
+  # Route 1 (YELLOW) has no MLPT — only route 6 (GREEN, DALY) should appear.
+  with patch(
+    'integrations.bart.requests.get',
+    side_effect=[
+      _mock(_FAKE_ROUTES_TWO),
+      _mock(_FAKE_ROUTEINFO_1_NO_MLPT),
+      _mock(_FAKE_ROUTEINFO_6_DALY),
+    ],
+  ):
+    result = bart._fetch_dest_colors('testkey', 'MLPT')  # noqa: SLF001
+  assert 'ANTC' not in result
+  assert result.get('DALY') == ['[G]']
+
+
+def test_fetch_dest_colors_handles_multiple_colors_per_dest() -> None:
+  # Routes 4 (ORANGE) and 6 (GREEN) both serve BERY from MLPT.
+  # Route 4 has a lower number so ORANGE appears first.
+  with patch(
+    'integrations.bart.requests.get',
+    side_effect=[
+      _mock(_FAKE_ROUTES_MULTI_COLOR),
+      _mock(_FAKE_ROUTEINFO_4_BERY),
+      _mock(_FAKE_ROUTEINFO_6_BERY),
+    ],
+  ):
+    result = bart._fetch_dest_colors('testkey', 'MLPT')  # noqa: SLF001
+  assert '[O]' in result['BERY']
+  assert '[G]' in result['BERY']
+  assert result['BERY'][0] == '[O]'
+
+
+def test_fetch_dest_colors_raises_on_http_error() -> None:
+  mock_fail = MagicMock()
+  mock_fail.raise_for_status.side_effect = requests.HTTPError('network error')
+  with patch('integrations.bart.requests.get', return_value=mock_fail):
+    with pytest.raises(requests.HTTPError):
+      bart._fetch_dest_colors('testkey', 'MLPT')  # noqa: SLF001
 
 
 # --- get_variables ---
@@ -283,3 +434,49 @@ def test_get_variables_http_error_does_not_leak_key(monkeypatch: pytest.MonkeyPa
     with pytest.raises(requests.HTTPError) as exc_info:
       bart.get_variables()
   assert api_key not in str(exc_info.value)
+
+
+# --- get_variables — color cache ---
+
+
+def test_get_variables_populates_color_cache(bart_env: None) -> None:
+  # Override the autouse fixture: start with an unpopulated cache.
+  bart._dest_color_cache = None  # noqa: SLF001
+  with patch(
+    'integrations.bart.requests.get',
+    side_effect=[
+      _mock(_FAKE_ROUTES_ONE),  # routes call
+      _mock(_FAKE_ROUTEINFO_6_DALY),  # routeinfo route 6
+      _mock(_FAKE_ETD),  # ETD call
+    ],
+  ):
+    bart.get_variables()
+  assert bart._dest_color_cache is not None  # noqa: SLF001
+  assert '[G]' in (bart._dest_color_cache or {}).get('DALY', [])  # noqa: SLF001
+
+
+def test_get_variables_routes_api_failure_does_not_crash(bart_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+  # Routes API fails — get_variables should still return ETD data and degrade
+  # no-service lines to colorless 'NO SERVICE'.
+  bart._dest_color_cache = None  # noqa: SLF001
+  empty_etd = {'root': {'station': [{'name': 'Milpitas', 'abbr': 'MLPT', 'etd': []}]}}
+  mock_fail = MagicMock()
+  mock_fail.raise_for_status.side_effect = requests.HTTPError('network error')
+  with patch(
+    'integrations.bart.requests.get',
+    side_effect=[mock_fail, _mock(empty_etd)],
+  ):
+    result = bart.get_variables()
+  assert result['line1'][0][0] == 'NO SERVICE'
+  out = capsys.readouterr().out
+  assert 'Warning' in out
+
+
+def test_get_variables_uses_cached_colors_on_second_call(bart_env: None) -> None:
+  # Cache is already populated (autouse sets it to {}). The routes API must
+  # NOT be called — only the single ETD request should happen.
+  bart._dest_color_cache = {'DALY': ['[G]']}  # noqa: SLF001
+  with patch('integrations.bart.requests.get', return_value=_mock(_FAKE_ETD)) as mock_get:
+    bart.get_variables()
+  # Only one requests.get call (the ETD); no routes/routeinfo calls.
+  assert mock_get.call_count == 1

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.6.0"
+version = "0.7.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Replaces the static `_DEST_COLOR_FALLBACK` dict with a dynamically built `dest_abbr → [color_tags]` cache, populated lazily on first `get_variables()` call
- `_fetch_dest_colors(api_key, origin)` queries `/route.aspx?cmd=routes` + `/route.aspx?cmd=routeinfo` (~N+1 calls, cached for the process lifetime) to derive the correct color for each terminal destination reachable from the origin station
- Multi-color destinations (e.g. BERY served by both ORANGE and GREEN from MLPT) are supported; the lowest route-number tag is used for no-service lines
- If the routes API fails, cache degrades gracefully to `{}` and no-service lines fall back to colorless `NO SERVICE` — the ETD call still proceeds

Closes #46.

## Test plan

- [ ] `_fetch_dest_colors` maps terminals to correct color tags
- [ ] Routes not serving the origin station are excluded
- [ ] Multi-color destinations accumulate all tags in route-number order
- [ ] Routes API failure raises `HTTPError` (propagated to caller for degradation)
- [ ] `get_variables` populates cache on first call
- [ ] `get_variables` routes API failure degrades gracefully with warning printed
- [ ] Cache is not re-populated on subsequent calls (only one `requests.get` for ETD)
- [ ] Existing `_no_service_line` tests updated for new `(dest_abbr, color_map)` signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)