### PR TITLE
docs: add positioning, See also, and Philosophy sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,40 @@
 
 [![CI](https://github.com/JasonPuglisi/e-note-ion/actions/workflows/ci.yml/badge.svg)](https://github.com/JasonPuglisi/e-note-ion/actions/workflows/ci.yml)
 
-A cron-based content scheduler for Vestaboard split-flap displays. Supports
-both the [Note](https://shop.vestaboard.com/products/note) (3×15) and the
-Flagship (6×22). Schedules and sends templated messages on a per-template cron
-schedule, with support for priority queuing, hold durations, and public/private
-content modes.
+A self-hosted, code-first content scheduler for Vestaboard split-flap
+displays. Define your board content as version-controlled JSON — cron
+schedules, templated messages, live data integrations, and a priority queue —
+with no web UI or cloud dependency required. Supports both the
+[Note](https://shop.vestaboard.com/products/note) (3×15) and the Flagship
+(6×22).
 
 > This project is primarily agent-developed using [Claude](https://claude.ai),
-> with human design, decision-making, guidance, and review.
+> with human design, decision-making, guidance, and review. See
+> [Philosophy](#philosophy) for more on the approach.
+
+## Who this is for
+
+E•NOTE•ION is built for developers and power users who want to treat their
+board like infrastructure: content in files, schedules in cron, secrets in env
+vars, deploys in Docker.
+
+If you'd prefer a friendlier experience — a web UI, drag-and-drop scheduling,
+and a polished setup flow — check out
+[FiestaBoard](https://github.com/Fiestaboard/FiestaBoard), which nails that
+use case beautifully.
+
+## See also
+
+The Vestaboard community has built a lot of great tooling:
+
+| Project | What it does well |
+|---|---|
+| [FiestaBoard](https://github.com/Fiestaboard/FiestaBoard) | Full-featured self-hosted app with a web UI and a rich scheduling experience |
+| [Vestaboard+](https://www.vestaboard.com/vestaboard-plus) | Official cloud subscription with Zapier/IFTTT integration and a curated app marketplace |
+| [jparise/vesta](https://github.com/jparise/vesta) | Clean Python library for the Vestaboard API — great if you want to build your own tooling |
+| [natekspencer/hacs-vestaboard](https://github.com/natekspencer/hacs-vestaboard) | Home Assistant integration for triggering board updates from automations |
+| [Zapier](https://zapier.com) / [IFTTT](https://ifttt.com) | No-code workflow triggers via Vestaboard+ — lowest barrier to entry |
+| MCP servers | Emerging tools for LLM-driven board updates from Claude and other agents |
 
 ## Running with Docker (recommended)
 
@@ -176,6 +202,20 @@ fetch current variable values:
 
 See [`content/README.md`](content/README.md) for available integrations and
 their configuration.
+
+## Philosophy
+
+**Content as code.** Board messages live in JSON files alongside your other
+dotfiles and configs. They're version-controlled, diff-able, and deployable
+the same way as everything else. There's no database to back up, no UI state
+to sync, and no vendor lock-in — just files, cron, and a single Python
+process.
+
+**An AI development experiment.** E•NOTE•ION is also an ongoing exploration of
+agentic software development. Most of the implementation is written by Claude,
+with a human setting direction, reviewing plans, and making architectural
+calls. The goal isn't to remove the human — it's to see how far thoughtful
+human–AI collaboration can go on a real project with real constraints.
 
 ## Development
 


### PR DESCRIPTION
— *Claude Code*

Closes #70.

## Summary

- Rewrites the intro tagline to lead with the code-first, self-hosted value proposition
- Adds a **Who this is for** section that sets honest expectations and warmly directs readers who want a web UI to FiestaBoard
- Adds a **See also** table celebrating the broader Vestaboard ecosystem (FiestaBoard, Vestaboard+, vesta, HACS integration, Zapier/IFTTT, MCP servers) — no comparisons, just genuine positive callouts
- Adds a **Philosophy** section near the bottom covering the "content as code" ethos and the AI development experiment angle
- Updates the agent-developed note to link to the new Philosophy section
- All existing usage, Docker, content format, and development sections are unchanged
- No version bump — docs only

## Test plan

- [ ] Verify README renders correctly on GitHub (section headers, table links, blockquote)
- [ ] Confirm all external links in See also table resolve correctly
- [ ] Confirm Philosophy anchor link (`#philosophy`) in the intro note resolves

🤖 Generated with [Claude Code](https://claude.ai/claude-code)