### PR TITLE
chore: tighten auto-release permissions and add JSON format check to CI

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,16 +4,15 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  packages: write
-  attestations: write
-  id-token: write
+permissions: {}
 
 jobs:
   release:
     name: Create release on version bump
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # create GitHub release
 
     outputs:
       tag: ${{ steps.create.outputs.tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: pip-audit
         run: uv run pip-audit
 
+      - name: Pretty-format JSON
+        run: uv run pre-commit run pretty-format-json --all-files
+
       - name: Run tests
         run: uv run pytest
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,13 @@ on this project collaboratively with the user.
 - Apply principle of least privilege — integrations should request only the
   OAuth scopes and API permissions they strictly need
 
+**Pre-v1.0 stance:**
+- No backwards compatibility concerns before v1.0 — breaking changes to the
+  content JSON format, CLI flags, Docker env vars, and internal APIs are all
+  fair game
+- Refactor early and often when it sets up a better foundation; don't hold
+  back to preserve existing behaviour
+
 **Decision-making:**
 - Raise security concerns proactively, even when not explicitly asked
 - Prefer reversible, auditable changes; flag anything destructive before acting


### PR DESCRIPTION
— *Claude Code*

Closes #82. Closes #83.

## Summary

- **`auto-release.yml`** — scopes permissions to `contents: write` on the `release` job only (down from four permissions at the workflow level). The `build` job calls `release.yml` as a reusable workflow, which already declares its own job-level permissions; no extras needed at the caller.
- **`ci.yml`** — adds a `Pretty-format JSON` step to the `check` job so JSON format is enforced in CI, matching what `CLAUDE.md` already documents as a required check.
- **`CLAUDE.md`** — adds the pre-v1.0 refactoring stance that was agreed on this session (no backwards compat concerns before v1.0).

## Test plan

- [ ] Confirm all CI checks pass on this PR
- [ ] Confirm `auto-release.yml` `release` job only has `contents: write` in the permissions block
- [ ] Confirm `pretty-format-json` step appears and passes in the CI run

🤖 Generated with [Claude Code](https://claude.ai/claude-code)