### PR TITLE
fix: grant build job permissions for reusable workflow call in auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -55,6 +55,13 @@ jobs:
     name: Build and push Docker image
     needs: release
     if: needs.release.outputs.tag != ''
+
+    permissions:
+      contents: read       # checkout
+      packages: write      # push to GHCR
+      attestations: write  # build provenance
+      id-token: write      # sign attestation
+
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release.outputs.tag }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,8 +222,10 @@ PR labels (apply one or more):
 At natural breakpoints (before a minor/major release, after a sprint of feature
 work), do a lightweight review of: test coverage gaps, code pattern consistency
 across integrations, dependency health (`pip-audit`), security posture (timeouts,
-key handling, `# nosec` justifications), documentation drift, and stale
-TODO/FIXME comments. Open issues for any gaps found; fix trivial things inline.
+key handling, `# nosec` justifications), documentation drift, stale TODO/FIXME
+comments, and **CI/CD workflow hygiene** (job permissions scoped to minimum
+required, CI steps match the documented check suite, no stale or misleading step
+names). Open issues for any gaps found; fix trivial things inline.
 See #65 for the full checklist.
 
 ### Planning before implementation
@@ -258,7 +260,9 @@ step may be skipped — use judgement.
 7. `gh pr create --label <label> --assignee JasonPuglisi`
 8. Enable auto-merge: `gh pr merge --squash --delete-branch --auto`
 9. Wait for merge: `gh pr checks <number> --watch`; once all pass and the PR merges, proceed
-10. After merge: `git checkout main && git pull && git branch -d feat/description`
+10. After merge: `git checkout main && git pull && git branch -d feat/description`; then
+    check post-merge workflows on main with `gh run list --branch main --limit 5` and
+    verify no `startup_failure` or failed runs from the merge commit
 11. Keep `README.md` and `CLAUDE.md` up to date as part of the same PR —
     new env vars, CLI flags, content format fields, project structure changes,
     and workflow changes should all be reflected before merge


### PR DESCRIPTION
— *Claude Code*

Fixes the `startup_failure` on the auto-release workflow after #84.

## Root cause

Setting `permissions: {}` at the workflow level in `auto-release.yml` denied all permissions to every job, including the `build` job that calls `release.yml` as a reusable workflow. GitHub bounds the called workflow's permissions by the caller's, so `release.yml` couldn't push to GHCR or mint attestations — it requested `packages: write, attestations: write, id-token: write` but was only allowed `none`.

## Fix

Add an explicit `permissions` block to the `build` job matching what `release.yml` requires:

```yaml
permissions:
  contents: read       # checkout
  packages: write      # push to GHCR
  attestations: write  # build provenance
  id-token: write      # sign attestation
```

The `release` job correctly keeps only `contents: write`. The workflow-level `permissions: {}` default is preserved — every job now declares exactly what it needs.

Also updates `CLAUDE.md` execution steps to check post-merge workflows on `main` after every PR so failures like this are caught before the session ends.

## Test plan

- [ ] Confirm CI passes on this PR
- [ ] Confirm the auto-release run on `main` after merge does not `startup_failure`
- [ ] Confirm the Docker image build and push succeeds if a version bump is present (or verify the `build` job is correctly skipped when no bump)