### PR TITLE
chore: update CI check job name to include tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   check:
-    name: Lint, type-check, and security scan
+    name: Lint, type-check, security scan, and tests
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
— *Claude Code*

The CI `check` job has been named "Lint, type-check, and security scan" since before tests were added. It now also runs `pytest` and `pretty-format-json`, so the name should reflect the full scope.

Updated to: **Lint, type-check, security scan, and tests**