### PR TITLE
chore: remove command substitution from post-merge check step

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,9 +259,10 @@ step may be skipped — use judgement.
 8. Enable auto-merge: `gh pr merge --squash --delete-branch --auto`
 9. Wait for merge: `gh pr checks <number> --watch`; once all pass and the PR merges, proceed
 10. After merge: `git checkout main && git pull && git branch -d feat/description`; then
-    check post-merge workflows on main with `gh run list --branch main --commit $(git rev-parse HEAD)`,
-    watch any in-progress runs to completion (`gh run watch <id>`), and verify all
-    runs from the merge commit succeeded with no `startup_failure` or failures
+    run `git rev-parse HEAD` to get the merge commit SHA and check post-merge workflows
+    with `gh run list --branch main --commit <sha>`, watch any in-progress runs to
+    completion (`gh run watch <id>`), and verify all runs from the merge commit
+    succeeded with no `startup_failure` or failures
 11. Keep `README.md` and `CLAUDE.md` up to date as part of the same PR —
     new env vars, CLI flags, content format fields, project structure changes,
     and workflow changes should all be reflected before merge


### PR DESCRIPTION
— *Claude Code*

Replaces `$(git rev-parse HEAD)` in step 10 with a two-step approach: run `git rev-parse HEAD` to get the SHA, then pass it explicitly to `gh run list --commit <sha>`. Avoids command substitution, which triggers permission prompts in Claude Code.

Also adopts this pattern going forward for commit messages (using `git commit -F`) and PR bodies (using `--body-file`) instead of heredoc command substitution.
