### PR TITLE
security: validate integration names against allowlist before dynamic import

### DIFF
--- a/e-note-ion.py
+++ b/e-note-ion.py
@@ -30,11 +30,17 @@ from apscheduler.schedulers.background import BackgroundScheduler
 
 import integrations.vestaboard as vestaboard
 
+# Allowlist of valid integration names. Must be extended when a new integration
+# is added to integrations/.
+_KNOWN_INTEGRATIONS: frozenset[str] = frozenset({'bart'})
+
 # Cache of loaded integration modules, keyed by name.
 _integrations: dict[str, Any] = {}
 
 
 def _get_integration(name: str) -> Any:
+  if name not in _KNOWN_INTEGRATIONS:
+    raise ValueError(f'Unknown integration: {name!r}')
   if name not in _integrations:
     _integrations[name] = importlib.import_module(f'integrations.{name}')
   return _integrations[name]


### PR DESCRIPTION
Closes #79.

## Summary

- Adds `_KNOWN_INTEGRATIONS: frozenset[str]` allowlist in `e-note-ion.py`
- `_get_integration()` now raises `ValueError` for any name not in the allowlist before calling `importlib.import_module()`
- Prevents user-controlled content JSON from loading unintended modules (stdlib, third-party, etc.)
- 4 new tests: unknown name, path traversal attempt, successful known load, module caching

## Test plan

- [x] `test_get_integration_unknown_raises` — `'os'` raises `ValueError`
- [x] `test_get_integration_path_traversal_raises` — `'../something'` raises `ValueError`
- [x] `test_get_integration_known_loads_module` — `'bart'` loads and returns the module
- [x] `test_get_integration_caches_module` — second call doesn't re-import
- [x] Full check suite passes (116 tests, ruff, pyright, bandit, pip-audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)