### PR TITLE
chore: lazy API key, public display_len, expanded vestaboard tests

### DIFF
--- a/integrations/bart.py
+++ b/integrations/bart.py
@@ -119,7 +119,7 @@ def _build_line(color_tag: str, estimates: list[dict[str, Any]]) -> str:
   parts: list[str] = []
   for est in estimates:
     t = _format_minutes(est['minutes'])
-    if vestaboard._display_len(base + ' '.join(parts + [t])) > vestaboard.model.cols:  # noqa: SLF001
+    if vestaboard.display_len(base + ' '.join(parts + [t])) > vestaboard.model.cols:
       break
     parts.append(t)
   return base + (' '.join(parts) if parts else '--')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,4 @@
-import os
 from typing import Generator
-
-# Must be set before vestaboard is imported anywhere, since it reads
-# VESTABOARD_API_KEY at module level and exits if absent.
-os.environ.setdefault('VESTABOARD_API_KEY', 'test-key')
 
 import pytest
 

--- a/tests/integrations/test_bart.py
+++ b/tests/integrations/test_bart.py
@@ -173,14 +173,14 @@ def test_build_line_basic() -> None:
   result = bart._build_line('[G]', estimates)  # noqa: SLF001
   assert result.startswith('[G]')
   assert '5' in result
-  assert vb._display_len(result) <= vb.model.cols  # noqa: SLF001
+  assert vb.display_len(result) <= vb.model.cols
 
 
 def test_build_line_stops_at_col_limit() -> None:
   # Enough estimates to potentially overflow the board width
   estimates = [{'minutes': str(i)} for i in range(1, 30)]
   result = bart._build_line('[G]', estimates)  # noqa: SLF001
-  assert vb._display_len(result) <= vb.model.cols  # noqa: SLF001
+  assert vb.display_len(result) <= vb.model.cols
 
 
 def test_build_line_empty_estimates() -> None:


### PR DESCRIPTION
Resolves #77, #80, #78.

**#77 — Lazy API key read**
- Moved `VESTABOARD_API_KEY` read from module level into `_get_headers()`. Importing `vestaboard` no longer fails if the key is absent (removes the need for the conftest timing workaround).
- Raises `RuntimeError` instead of `sys.exit(1)` so callers can handle the error.
- Removed `import sys`.

**#80 — `_display_len` → `display_len` (public)**
- Renamed to signal stable public API. Updated `bart.py` (removes `# noqa: SLF001`) and all test files.

**#78 — Expanded vestaboard tests**
- `test_get_headers_raises_without_key`: confirms `RuntimeError` when key is missing.
- `test_get_headers_returns_correct_headers`: confirms returned dict has correct key/value.
- `test_get_state_passes_auth_header`: verifies the API key reaches the HTTP call.
- `test_set_state_passes_auth_header`: same for `set_state`.

120 tests passing (up from 116).
