### PR TITLE
chore: tabular log alignment and Unraid docs accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,18 @@ Contrib integrations require their own API keys and configuration — see
 
 ### Unraid
 
-An [Unraid Community Applications](https://unraid.net/community/apps) template
-is included at `unraid/e-note-ion.xml`. Add it manually via the CA template
-URL:
+> **Note:** e-note-ion is not yet listed in the Community Applications store
+> (tracked at [#10](https://github.com/JasonPuglisi/e-note-ion/issues/10)).
 
-```
-https://raw.githubusercontent.com/JasonPuglisi/e-note-ion/main/unraid/e-note-ion.xml
-```
+An Unraid Docker template is included at `unraid/e-note-ion.xml`. To install:
+
+1. In the Unraid web UI, go to **Docker** → **Add Container**
+2. In the **Template** dropdown, choose a previously saved template — or paste
+   the template URL directly into the URL field:
+   ```
+   https://raw.githubusercontent.com/JasonPuglisi/e-note-ion/main/unraid/e-note-ion.xml
+   ```
+3. Fill in the required fields (Vestaboard API Key, etc.) and click **Apply**
 
 The template exposes all environment variables as UI fields and an optional
 path for personal content.

--- a/scheduler.py
+++ b/scheduler.py
@@ -252,6 +252,10 @@ def _load_file(
       job.remove()
 
   max_name = max((len(job_id[len(stem) + 1 :]) for job_id, *_ in new_jobs), default=0)
+  max_cron = max((len(schedule['cron']) for _, _, _, schedule in new_jobs), default=0)
+  max_priority = max((len(str(priority)) for _, priority, _, _ in new_jobs), default=0)
+  max_hold = max((len(str(schedule['hold'])) for _, _, _, schedule in new_jobs), default=0)
+  max_timeout = max((len(str(schedule['timeout'])) for _, _, _, schedule in new_jobs), default=0)
   if new_jobs:
     print(f'Loaded {content_file.parent.name}/{content_file.name}:')
   for job_id, priority, data, schedule in new_jobs:
@@ -265,10 +269,10 @@ def _load_file(
     template_name = job_id[len(stem) + 1 :]
     print(
       f'  · {template_name.ljust(max_name)}'
-      f'  cron="{schedule["cron"]}"'
-      f'  priority={priority}'
-      f'  hold={schedule["hold"]}s'
-      f'  timeout={schedule["timeout"]}s'
+      f'  cron="{schedule["cron"].ljust(max_cron)}"'
+      f'  priority={str(priority).ljust(max_priority)}'
+      f'  hold={str(schedule["hold"]).ljust(max_hold)}s'
+      f'  timeout={str(schedule["timeout"]).ljust(max_timeout)}s'
     )
 
 

--- a/unraid/e-note-ion.xml
+++ b/unraid/e-note-ion.xml
@@ -5,7 +5,7 @@
   <Registry>https://github.com/JasonPuglisi/e-note-ion/pkgs/container/e-note-ion</Registry>
   <Network>bridge</Network>
   <Privileged>false</Privileged>
-  <Support><!-- TODO: replace with Unraid forum thread URL before CA submission --></Support>
+  <Support>https://github.com/JasonPuglisi/e-note-ion/issues</Support>
   <Project>https://github.com/JasonPuglisi/e-note-ion</Project>
   <Overview>E•NOTE•ION is a cron-based content scheduler for Vestaboard split-flap displays. Supports both the Note (3×15) and Flagship (6×22). Content is defined in JSON files and displayed on a schedule with priority queueing. Ships with bundled contrib content (opt-in via CONTENT_ENABLED) and supports personal content via a host-mounted directory.</Overview>
   <Category>HomeAutomation</Category>


### PR DESCRIPTION
Closes #104.
Closes #75.

**#104 — fully tabular log alignment**

Extends the name-column `ljust()` from #103 to all remaining fields. Now computes `max_cron`, `max_priority`, `max_hold`, and `max_timeout` across all jobs in the file, so every column lines up:

```
Loaded user/my_content.json:
  · short_name    cron="0 8 * * *      "  priority=5   hold=600s  timeout=600s
  · a_longer_name  cron="*/15 * * * *"  priority=10  hold=60s   timeout=120s
```

**#75 — Unraid docs accuracy**

- README: clarifies e-note-ion is not yet in the CA store (links to #10), replaces the ambiguous "CA template URL" paragraph with a concrete Docker → Add Container import flow
- `unraid/e-note-ion.xml`: replaces the stale `TODO` comment in `<Support>` with the GitHub issues URL so it's usable today