### PR TITLE
feat: integration test infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,31 @@ jobs:
         with:
           context: .
           push: false
+
+  # Advisory only — not required by the branch ruleset. Failures surface in
+  # the PR checks list but do not block merge.
+  integration:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run integration tests
+        run: uv run pytest -m integration -v
+        env:
+          BART_API_KEY: ${{ secrets.BART_API_KEY }}
+          BART_STATION: MLPT
+          BART_LINE_1_DEST: DALY
+          VESTABOARD_VIRTUAL_API_KEY: ${{ secrets.VESTABOARD_VIRTUAL_API_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,22 @@ PR labels (apply one or more):
 - When working on existing code that lacks tests, add retroactive coverage as
   part of the same PR where feasible
 
+#### Integration tests
+
+Integration tests live in `tests/integrations/` and are excluded from the
+default `uv run pytest` run. To run them locally, set the required env vars
+then: `uv run pytest -m integration -v`. A setup table prints at session start
+showing which env vars are set or missing.
+
+- Mark tests with `@pytest.mark.integration` and `@pytest.mark.require_env('VAR', ...)`
+- Tests skip automatically when required env vars are absent (no failures)
+- Required env vars per integration:
+  - BART: `BART_API_KEY`, `BART_STATION`, `BART_LINE_1_DEST`
+  - Vestaboard: `VESTABOARD_VIRTUAL_API_KEY` (use a virtual board, not physical)
+- CI runs the `integration` job on `main` pushes only; it is advisory
+  (`continue-on-error: true`) and not required by the branch ruleset
+- GitHub secrets needed: `BART_API_KEY`, `VESTABOARD_VIRTUAL_API_KEY`
+
 ### Periodic health review
 
 At natural breakpoints (before a minor/major release, after a sprint of feature
@@ -201,6 +217,10 @@ accurately describe what they do, post-merge workflows on `main` passing clean),
 `gh api repos/JasonPuglisi/e-note-ion/rulesets/13082160 --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'`
 that required status check names match actual CI job names in `ci.yml`, ruleset
 enforcement is `active`, and allowed merge methods are correct),
+**integration test hygiene** (advisory CI job passing on `main`; GitHub secrets
+`BART_API_KEY` and `VESTABOARD_VIRTUAL_API_KEY` present; new integrations have
+corresponding `test_<name>_integration.py` and their env vars listed in
+`tests/integrations/conftest.py`),
 and **issue/milestone hygiene**:
 - Every open issue has an appropriate milestone (no orphans)
 - Milestone scope is right-sized — merge single-issue milestones into a broader

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,11 @@ select = ["E", "F", "I"]  # pycodestyle errors, pyflakes, isort
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]
+addopts = "-m 'not integration'"
+markers = [
+  "integration: marks tests that call real external APIs (deselected by default)",
+  "require_env: list env var names required for the test to run",
+]
 
 [tool.bandit]
 exclude_dirs = [".venv", "tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 from typing import Generator
 
 import pytest
@@ -11,3 +12,14 @@ def reset_vestaboard_model() -> Generator[None, None, None]:
   original = vestaboard.model
   yield
   vestaboard.model = original
+
+
+@pytest.fixture
+def require_env(request: pytest.FixtureRequest) -> None:
+  """Skip the test if any env vars listed in @pytest.mark.require_env are unset."""
+  marker = request.node.get_closest_marker('require_env')
+  if marker is None:
+    return
+  for var in marker.args:
+    if not os.environ.get(var, '').strip():
+      pytest.skip(f'{var!r} not set')

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -1,0 +1,21 @@
+import os
+
+import pytest
+
+_INTEGRATION_VARS: list[tuple[str, str]] = [
+  ('BART_API_KEY', 'BART integration'),
+  ('BART_STATION', 'BART integration'),
+  ('BART_LINE_1_DEST', 'BART integration'),
+  ('VESTABOARD_VIRTUAL_API_KEY', 'Vestaboard integration'),
+]
+
+
+@pytest.fixture(scope='session', autouse=True)
+def _integration_env_summary() -> None:
+  """Print a setup table at session start showing which integration env vars are set."""
+  rows = [(var, desc, '✓ set' if os.environ.get(var, '').strip() else '✗ missing') for var, desc in _INTEGRATION_VARS]
+  col = max(len(v) for v, *_ in rows)
+  print('\nIntegration test env vars:')
+  for var, desc, status in rows:
+    print(f'  {var.ljust(col)}  {status}  ({desc})')
+  print()

--- a/tests/integrations/test_bart_integration.py
+++ b/tests/integrations/test_bart_integration.py
@@ -1,0 +1,41 @@
+"""Integration tests for integrations/bart.py — call the real BART API.
+
+Run with: uv run pytest -m integration
+
+Required env vars:
+  BART_API_KEY      — free BART API key
+  BART_STATION      — originating station code (e.g. MLPT)
+  BART_LINE_1_DEST  — destination abbreviation (e.g. DALY)
+"""
+
+import pytest
+
+import integrations.bart as bart
+import integrations.vestaboard as vb
+
+
+@pytest.mark.integration
+@pytest.mark.require_env('BART_API_KEY', 'BART_STATION', 'BART_LINE_1_DEST')
+def test_get_variables_real_api(require_env: None) -> None:
+  """get_variables() returns a valid variables dict from the live BART API."""
+  # Reset the color cache so each run fetches fresh data.
+  bart._dest_color_cache = None
+
+  result = bart.get_variables()
+
+  assert 'station' in result, 'missing station key'
+  assert 'line1' in result, 'missing line1 key'
+
+  # station: single-option list containing a non-empty string.
+  assert len(result['station']) == 1
+  assert len(result['station'][0]) == 1
+  assert result['station'][0][0], 'station name is empty'
+
+  # line1: single-option list; rendered text fits within display width.
+  assert len(result['line1']) == 1
+  assert len(result['line1'][0]) == 1
+  line = result['line1'][0][0]
+  assert isinstance(line, str)
+  assert vb.display_len(line) <= vb.model.cols, (
+    f'line1 exceeds model cols ({vb.display_len(line)} > {vb.model.cols}): {line!r}'
+  )

--- a/tests/integrations/test_vestaboard_integration.py
+++ b/tests/integrations/test_vestaboard_integration.py
@@ -1,0 +1,41 @@
+"""Integration tests for integrations/vestaboard.py — call the real Vestaboard API.
+
+Run with: uv run pytest -m integration
+
+Required env vars:
+  VESTABOARD_VIRTUAL_API_KEY — Read/Write key for a virtual Vestaboard
+                               (use a virtual board, not a physical one)
+"""
+
+import os
+
+import pytest
+
+import integrations.vestaboard as vb
+
+
+@pytest.mark.integration
+@pytest.mark.require_env('VESTABOARD_VIRTUAL_API_KEY')
+def test_get_state_real_api(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+  """get_state() returns a valid VestaboardState from the live API."""
+  monkeypatch.setenv('VESTABOARD_API_KEY', os.environ['VESTABOARD_VIRTUAL_API_KEY'])
+
+  state = vb.get_state()
+
+  assert isinstance(state.id, str) and state.id, 'state.id is empty'
+  assert isinstance(state.appeared, str) and state.appeared, 'state.appeared is empty'
+  assert isinstance(state.layout, list)
+  assert len(state.layout) == vb.model.rows, f'layout has {len(state.layout)} rows, expected {vb.model.rows}'
+  for row in state.layout:
+    assert len(row) == vb.model.cols, f'row has {len(row)} cols, expected {vb.model.cols}'
+    assert all(isinstance(code, int) for code in row), 'non-int code in row'
+
+
+@pytest.mark.integration
+@pytest.mark.require_env('VESTABOARD_VIRTUAL_API_KEY')
+def test_set_state_real_api(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+  """set_state() successfully writes a message to the live virtual board."""
+  monkeypatch.setenv('VESTABOARD_API_KEY', os.environ['VESTABOARD_VIRTUAL_API_KEY'])
+
+  # Writes a fixed test message; no exception means success.
+  vb.set_state([{'format': ['INTEGRATION TEST']}], {})


### PR DESCRIPTION
— *Claude Code*

Closes #94.

## Summary

- `pyproject.toml`: register `integration` and `require_env` markers; `addopts` deselects integration tests by default (`-m 'not integration'`)
- `tests/conftest.py`: `require_env` fixture — skips the test if listed env vars are absent
- `tests/integrations/conftest.py`: session-scoped `_integration_env_summary` fixture — prints a setup table when integration tests are collected
- `tests/integrations/test_bart_integration.py`: real BART API — validates variables dict shape and `display_len` bounds
- `tests/integrations/test_vestaboard_integration.py`: real Vestaboard API read + write against a virtual board
- `ci.yml`: advisory `integration` job (main-push only, `continue-on-error: true`) — not in branch ruleset
- `CLAUDE.md`: integration test docs + health review checklist item

## Test plan

- [ ] `uv run pytest` — 131 pass, 3 deselected (integration tests excluded)
- [ ] `uv run pytest -m integration -v` locally with real env vars set — setup table prints, tests pass
- [ ] `uv run pytest -m integration -v` with env vars unset — tests skip (no failures)
- [ ] CI `check` and `docker` jobs pass on PR
- [ ] After merge: advisory `integration` CI job runs on main push (needs `BART_API_KEY` and `VESTABOARD_VIRTUAL_API_KEY` secrets added to repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)