### PR TITLE
fix: advisory failure when integration tests skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     continue-on-error: true
+    environment: integration  # secrets scoped to this env; restrict env to main in repo settings
 
     steps:
       - name: Checkout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,12 @@ showing which env vars are set or missing.
   - Vestaboard: `VESTABOARD_VIRTUAL_API_KEY` (use a virtual board, not physical)
 - CI runs the `integration` job on `main` pushes only; it is advisory
   (`continue-on-error: true`) and not required by the branch ruleset
-- GitHub secrets needed: `BART_API_KEY`, `VESTABOARD_VIRTUAL_API_KEY`
+- GitHub secrets needed: `BART_API_KEY`, `VESTABOARD_VIRTUAL_API_KEY` — store as
+  **environment secrets** on the `integration` environment (Settings → Environments),
+  restricted to the `main` branch; this scopes them tighter than repo secrets and
+  prevents any PR branch from accessing them even if a workflow runs there
+- If any integration test is skipped, the pytest session exits with code 5
+  (NO_TESTS_COLLECTED), making the advisory job visibly fail rather than silently pass
 
 ### Periodic health review
 


### PR DESCRIPTION
— *Claude Code*

Follow-up to #94 / PR #109.

## Problem

With `continue-on-error: true` and all tests skipping due to missing secrets, the integration job showed green — giving false confidence that everything was validated when nothing actually ran.

## Fix

- `tests/integrations/conftest.py`: `pytest_sessionfinish` hook exits with code 5 (`NO_TESTS_COLLECTED`) if **any** integration test was skipped. Even one missing env var now surfaces as an advisory failure.
- `ci.yml`: added `environment: integration` — secrets are scoped to that environment rather than the whole repo. Restrict the environment to `main` in **Settings → Environments** to prevent any PR branch from accessing them.
- `CLAUDE.md`: documented both behaviors; recommend environment secrets over repo secrets.

## Test plan

- [ ] `uv run pytest` — 131 pass, 3 deselected (unchanged)
- [ ] `uv run pytest -m integration -v` with all env vars set — passes with exit 0
- [ ] `uv run pytest -m integration -v` with any env var unset — exits 5 with warning message
- [ ] CI `check` and `docker` jobs pass on PR (integration job skips on PR — only runs on main push)

## Setup required after merge

1. Go to **Settings → Environments → New environment**, name it `integration`
2. Under **Deployment branches**, restrict to `main` only
3. Add secrets `BART_API_KEY` and `VESTABOARD_VIRTUAL_API_KEY` to the environment (not as repo secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)