### PR TITLE
chore: clarify advisory integration job in workflow docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,8 @@ showing which env vars are set or missing.
   prevents any PR branch from accessing them even if a workflow runs there
 - If any integration test is skipped, the pytest session exits with code 5
   (NO_TESTS_COLLECTED), making the advisory job visibly fail rather than silently pass
+- When adding a new integration, also add `tests/integrations/test_<name>_integration.py`
+  and add its env vars to the `_INTEGRATION_VARS` list in `tests/integrations/conftest.py`
 
 ### Periodic health review
 
@@ -288,6 +290,9 @@ step may be skipped — use judgement.
     with `gh run list --branch main --commit <sha>`, watch any in-progress runs to
     completion (`gh run watch <id>`), and verify all runs from the merge commit
     succeeded with no `startup_failure` or failures
+    - **Required jobs** (check, docker, CodeQL) must pass — any failure here is a blocker
+    - **Advisory integration job** may fail — note the result; a failure means tests
+      skipped (missing secrets) or an API issue, not a merge blocker
 11. Keep `README.md` and `CLAUDE.md` up to date as part of the same PR —
     new env vars, CLI flags, content format fields, project structure changes,
     and workflow changes should all be reflected before merge


### PR DESCRIPTION
— *Claude Code*

Two documentation gaps found during integration test process review.

**Step 10 ambiguity**: "verify all runs succeeded" doesn't distinguish required jobs from the advisory integration job, which is *expected* to fail when secrets are missing or an API call fails. Updated to explicitly call out that only check/docker/CodeQL are blockers.

**New integration checklist omission**: instructions for adding a new integration didn't mention updating `_INTEGRATION_VARS` in `tests/integrations/conftest.py`. That's only in the health review. Added it to the integration tests section where it's actionable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)