### PR TITLE
chore: add post-merge check reminder to slipped-through examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,8 @@ prevention to the checklist or workflow — not just a one-off fix. Examples:
   health review; added inline comments in `ci.yml` linking to ruleset
 - Post-merge runs not waited on → tightened step 10 to require watching
   in-progress runs to completion before declaring done
+- Post-merge check skipped after `git pull` → step 10 is non-negotiable;
+  run the SHA lookup and `gh run list` even when the PR checks looked clean
 
 ### Planning before implementation
 


### PR DESCRIPTION
— *Claude Code*

I skipped the step 10 post-merge SHA lookup after merging PR #113, jumped straight to cleanup. The "why wasn't it caught" section exists for exactly this — adding a reminder that step 10 applies even when PR checks looked clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)