### PR TITLE
fix: handle 409 DuplicateContentError and 404 EmptyBoardError in Vestaboard API

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -152,6 +152,9 @@ def worker() -> None:
         variables,
         message.data.get('truncation', 'hard'),
       )
+    except vestaboard.DuplicateContentError:
+      print('Duplicate content, skipping.')
+      continue
     except vestaboard.BoardLockedError as e:
       print(f'Board locked: {e}. Retrying in {_LOCK_RETRY_DELAY}s.')
       time.sleep(_LOCK_RETRY_DELAY)
@@ -396,7 +399,10 @@ def main() -> None:
   print(f'Starting e-note-ion — {board_desc}, {", ".join(extras)}')
 
   print('Current message:')
-  print(vestaboard.get_state())
+  try:
+    print(vestaboard.get_state())
+  except vestaboard.EmptyBoardError:
+    print('(no current message)')
   scheduler = BackgroundScheduler(misfire_grace_time=300)
   load_content(scheduler, public_mode=args.public, content_enabled=content_enabled)
   scheduler.start()

--- a/tests/core/test_vestaboard.py
+++ b/tests/core/test_vestaboard.py
@@ -377,6 +377,24 @@ def test_set_state_propagates_http_error(monkeypatch: pytest.MonkeyPatch) -> Non
       vb.set_state([{'format': ['HELLO']}], {})
 
 
+def test_set_state_raises_duplicate_on_409(monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setenv('VESTABOARD_API_KEY', 'test-key')
+  mock_resp = MagicMock()
+  mock_resp.status_code = 409
+  with patch('integrations.vestaboard.requests.post', return_value=mock_resp):
+    with pytest.raises(vb.DuplicateContentError):
+      vb.set_state([{'format': ['HELLO']}], {})
+
+
+def test_get_state_raises_empty_board_on_404(monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setenv('VESTABOARD_API_KEY', 'test-key')
+  mock_resp = MagicMock()
+  mock_resp.status_code = 404
+  with patch('integrations.vestaboard.requests.get', return_value=mock_resp):
+    with pytest.raises(vb.EmptyBoardError):
+      vb.get_state()
+
+
 def test_set_state_passes_auth_header(monkeypatch: pytest.MonkeyPatch) -> None:
   monkeypatch.setenv('VESTABOARD_API_KEY', 'sentinel-key')
   mock_resp = MagicMock()


### PR DESCRIPTION
Closes #112

## Summary

- `set_state()` now raises `DuplicateContentError` on HTTP 409 (same content already on board)
- `get_state()` now raises `EmptyBoardError` on HTTP 404 (no message on a fresh board)
- Scheduler worker catches `DuplicateContentError` and discards the message (content is already displayed — no retry needed)
- Scheduler startup catches `EmptyBoardError` from the initial `get_state()` call and prints `(no current message)` instead of crashing — fixes a crash on first run against a fresh virtual board
- 4 new unit tests covering all new error paths

## Test plan

- [x] `test_set_state_raises_duplicate_on_409`
- [x] `test_get_state_raises_empty_board_on_404`
- [x] `test_main_empty_board_on_startup`
- [x] `test_worker_skips_on_duplicate_content`
- [x] Existing `test_set_state_propagates_http_error` confirms non-mapped codes (e.g. 500) still raise `HTTPError`
- [x] 135 tests passing, all checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)