### PR TITLE
feat: TOML config system (#36)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Copy to .env and fill in your values.
+# .env is git-ignored — never commit it.
+#
+# Required for Vestaboard integration tests:
+VESTABOARD_VIRTUAL_API_KEY=your-virtual-board-read-write-key
+#
+# Required for BART integration tests:
+BART_API_KEY=your-bart-api-key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,4 @@ jobs:
         run: uv run pytest -m integration -v
         env:
           BART_API_KEY: ${{ secrets.BART_API_KEY }}
-          BART_STATION: MLPT
-          BART_LINE_1_DEST: DALY
           VESTABOARD_VIRTUAL_API_KEY: ${{ secrets.VESTABOARD_VIRTUAL_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ wheels/
 # macOS
 .DS_Store
 
+# Runtime config (contains secrets — never commit)
+config.toml
+
+# Local integration test secrets (never commit)
+.env
+
 # User content (personal, not committed to the project repo)
 content/user/*
 !content/user/.gitkeep

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ ENV UV_COMPILE_BYTECODE=1 \
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev
 
-# Copy source and bundled contrib content.
-COPY scheduler.py entrypoint.sh ./
+# Copy source, config example, and bundled contrib content.
+COPY scheduler.py entrypoint.sh config.py config.example.toml ./
 COPY integrations/ ./integrations/
 COPY content/contrib/ ./content/contrib/
 

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ The Vestaboard community has built a lot of great tooling:
 Pre-built multi-arch images (`linux/amd64`, `linux/arm64`) are published to
 the GitHub Container Registry on each release.
 
-The image ships with bundled contrib content (disabled by default). Enable
-it by name, or mount your own content directory:
+First copy `config.example.toml` to `config.toml` and fill in your API keys
+and settings (see [Configuration](#configuration) below). Then run:
 
 ```bash
 docker run -d \
   --name e-note-ion \
   --restart unless-stopped \
-  -e VESTABOARD_API_KEY=your_api_key_here \
+  -v /path/to/config.toml:/app/config.toml:ro \
   -e CONTENT_ENABLED=bart \
   ghcr.io/jasonpuglisi/e-note-ion:latest
 ```
@@ -92,13 +92,24 @@ An Unraid Docker template is included at `unraid/e-note-ion.xml`. To install:
 The template exposes all environment variables as UI fields and an optional
 path for personal content.
 
+## Configuration
+
+Copy `config.example.toml` to `config.toml` and fill in your values:
+
+```bash
+cp config.example.toml config.toml
+# edit config.toml — add your Vestaboard API key and any integration settings
+```
+
+`config.toml` is git-ignored and contains secrets — never commit it.
+
 ## Running directly
 
 **Requirements:** Python 3.14+, [uv](https://github.com/astral-sh/uv)
 
 ```bash
 uv sync
-export VESTABOARD_API_KEY=your_api_key_here
+cp config.example.toml config.toml  # fill in your API key
 python scheduler.py
 ```
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,30 @@
+# e-note-ion configuration
+# Copy this file to config.toml and fill in your values.
+# config.toml is git-ignored — never commit it.
+
+[vestaboard]
+# Read/Write API key from https://store.vestaboard.com/pages/read-write-api
+api_key = "your-vestaboard-read-write-api-key"
+
+[bart]
+# Free API key — register at https://api.bart.gov/api/register.aspx
+api_key = "your-bart-api-key"
+
+# Originating station abbreviation code.
+# See full list: https://api.bart.gov/docs/overview/abbrev.aspx
+station = "MLPT"
+
+# Destination abbreviation code for the first departure line (required).
+line1_dest = "DALY"
+
+# Second departure line (optional — remove or leave blank for one line).
+# line2_dest = "BERY"
+
+# ── Schedule overrides (optional) ─────────────────────────────────────────────
+# Override cron, hold, or timeout for a named template without editing JSON.
+# All three fields are optional; unspecified fields use the template default.
+
+# [bart.schedules.departures]
+# cron = "*/5 7-9 * * 1-5"
+# hold = 290
+# timeout = 60

--- a/config.py
+++ b/config.py
@@ -1,0 +1,69 @@
+# config.py
+#
+# TOML configuration loader.
+#
+# Call load_config() once at startup (e.g. from main()). All other functions
+# read from the module-level cache and may be called from any thread.
+#
+# Integration modules import config inside their functions so they can be
+# imported in tests without a real config file present.
+
+import sys
+import tomllib
+from pathlib import Path
+
+_CONFIG_PATH = Path('config.toml')
+_EXAMPLE_PATH = Path('config.example.toml')
+
+_config: dict = {}
+
+
+def load_config() -> None:
+  """Load config.toml from the current working directory.
+
+  Exits with a clear message if the file is missing. Lets
+  tomllib.TOMLDecodeError propagate on parse errors.
+  """
+  global _config
+  if not _CONFIG_PATH.exists():
+    print(
+      f'Error: config.toml not found. Copy {_EXAMPLE_PATH} to config.toml and fill in your values.',
+      file=sys.stderr,
+    )
+    raise SystemExit(1)
+  with open(_CONFIG_PATH, 'rb') as f:
+    _config = tomllib.load(f)
+
+
+def get(section: str, key: str) -> str:
+  """Return a required string config value.
+
+  Raises ValueError with a descriptive message if the section or key is
+  missing, or if the value is an empty string.
+  """
+  value = _config.get(section, {}).get(key)
+  if not value:
+    raise ValueError(f'Missing required config key [{section}].{key} in config.toml')
+  return str(value)
+
+
+def get_optional(section: str, key: str, default: str = '') -> str:
+  """Return an optional string config value, or default if absent."""
+  value = _config.get(section, {}).get(key)
+  if value is None:
+    return default
+  return str(value)
+
+
+def get_schedule_override(template_id: str) -> dict:
+  """Return schedule overrides for a named template, or {} if not configured.
+
+  template_id is '<file_stem>.<template_name>' (e.g. 'bart.departures').
+  Reads from [<file_stem>.schedules.<template_name>] in config.toml.
+  """
+  parts = template_id.split('.', 1)
+  if len(parts) != 2:
+    return {}
+  section, template_name = parts
+  overrides = _config.get(section, {}).get('schedules', {}).get(template_name, {})
+  return dict(overrides) if isinstance(overrides, dict) else {}

--- a/content/README.md
+++ b/content/README.md
@@ -1,8 +1,7 @@
 # Content
 
 This directory contains the JSON files that define what gets displayed on the
-board. Files are watched at runtime — add, edit, or remove a file and it takes
-effect within ~5 seconds without restarting.
+board. Restart the scheduler to pick up changes.
 
 See the root [README](../README.md) for the full content file format.
 

--- a/content/contrib/bart.md
+++ b/content/contrib/bart.md
@@ -8,16 +8,26 @@ weekday mornings (07:00–09:00).
 
 ## Configuration
 
-| Variable | Required | Description |
+Add the following to your `config.toml`:
+
+```toml
+[bart]
+api_key = "your-bart-api-key"
+station = "MLPT"
+line1_dest = "DALY"
+# line2_dest = "BERY"  # optional second departure line
+```
+
+| Key | Required | Description |
 |---|---|---|
-| `BART_API_KEY` | Yes | Free API key — register at https://api.bart.gov/api/register.aspx |
-| `BART_STATION` | Yes | Originating station abbreviation code (e.g. `MLPT` for Milpitas) |
-| `BART_LINE_1_DEST` | Yes | Destination station abbreviation code for the first departure line (e.g. `DALY` for Daly City) |
-| `BART_LINE_2_DEST` | No | Destination abbreviation code for an optional second line |
+| `api_key` | Yes | Free API key — register at https://api.bart.gov/api/register.aspx |
+| `station` | Yes | Originating station abbreviation code (e.g. `MLPT` for Milpitas) |
+| `line1_dest` | Yes | Destination station abbreviation code for the first departure line (e.g. `DALY` for Daly City) |
+| `line2_dest` | No | Destination abbreviation code for an optional second line |
 
 All station values use abbreviation codes only (e.g. `MLPT`, `DALY`, `BERY`).
-`BART_LINE_x_DEST` is matched case-insensitively against the `abbreviation`
-field in the BART ETD API response.
+`line1_dest` / `line2_dest` are matched case-insensitively against the
+`abbreviation` field in the BART ETD API response.
 
 ## Keeping data current
 
@@ -25,15 +35,14 @@ field in the BART ETD API response.
 
 Authoritative source: https://api.bart.gov/docs/overview/abbrev.aspx
 
-The `BART_STATION` dropdown in `unraid/e-note-ion.xml` uses
-`CODE - Display Name` format. When BART opens new stations, add entries to
-the pipe-separated `Default=` list in that file.
+Station abbreviation codes in `config.toml` must match the codes used by the
+BART API. When BART opens new stations, update accordingly.
 
 ### Terminal destinations
 
-`BART_LINE_x_DEST` values must match the `abbreviation` field in BART ETD API
-responses. To see current abbreviations for departures from a station, call
-the API directly (requires an API key):
+`line1_dest` / `line2_dest` values must match the `abbreviation` field in BART
+ETD API responses. To see current abbreviations for departures from a station,
+call the API directly (requires an API key):
 
 ```
 https://api.bart.gov/api/etd.aspx?cmd=etd&orig=MLPT&key=<key>&json=y
@@ -42,7 +51,6 @@ https://api.bart.gov/api/etd.aspx?cmd=etd&orig=MLPT&key=<key>&json=y
 For current lines and termini without an API key, check the schedule PDFs:
 https://www.bart.gov/schedules/pdfs
 
-When BART changes line termini, update the destination dropdown in
-`unraid/e-note-ion.xml` to reflect the new abbreviation codes. No code
-changes are needed — line colors are derived dynamically from the routes API
-and will update automatically when the integration restarts.
+When BART changes line termini, update the destination codes in `config.toml`.
+No code changes are needed — line colors are derived dynamically from the routes
+API and will update automatically when the integration restarts.

--- a/integrations/bart.py
+++ b/integrations/bart.py
@@ -15,7 +15,6 @@
 #   BART_LINE_1_DEST — Destination abbreviation code (e.g. DALY for Daly City)
 #   BART_LINE_2_DEST — Second destination code (optional)
 
-import os
 from typing import Any
 
 import requests
@@ -136,18 +135,13 @@ def get_variables() -> dict[str, list[list[str]]]:
   """
   global _dest_color_cache
 
-  api_key = os.environ.get('BART_API_KEY', '').strip()
-  if not api_key:
-    raise RuntimeError('BART_API_KEY environment variable is not set')
+  import config as _config_mod
 
-  station_raw = os.environ.get('BART_STATION', '').strip()
-  if not station_raw:
-    raise RuntimeError('BART_STATION environment variable is not set')
-  station = station_raw
-
-  dest_filters = [d for key in ('BART_LINE_1_DEST', 'BART_LINE_2_DEST') if (d := os.environ.get(key, '').strip())]
-  if not dest_filters:
-    raise RuntimeError('At least one of BART_LINE_1_DEST or BART_LINE_2_DEST must be set')
+  api_key = _config_mod.get('bart', 'api_key')
+  station = _config_mod.get('bart', 'station')
+  dest1 = _config_mod.get('bart', 'line1_dest')
+  dest2 = _config_mod.get_optional('bart', 'line2_dest')
+  dest_filters = [d for d in (dest1, dest2) if d]
 
   if _dest_color_cache is None:
     try:

--- a/integrations/vestaboard.py
+++ b/integrations/vestaboard.py
@@ -12,7 +12,6 @@
 # is a raw JSON array-of-arrays of integer character codes with no wrapper key.
 
 import json
-import os
 import random
 import re
 from enum import Enum
@@ -28,13 +27,12 @@ _HOST = 'https://rw.vestaboard.com'
 def _get_headers() -> dict[str, str]:
   """Return the auth headers for the Vestaboard API.
 
-  Reads VESTABOARD_API_KEY from the environment on each call so that the
-  module can be imported without the key being present (e.g. in tests that
-  don't exercise the API).
+  Imports config inside the function so the module can be imported without a
+  config file present (e.g. in tests that don't exercise the API).
   """
-  api_key = os.environ.get('VESTABOARD_API_KEY', '')
-  if not api_key:
-    raise RuntimeError('VESTABOARD_API_KEY environment variable is not set')
+  import config as _config_mod
+
+  api_key = _config_mod.get('vestaboard', 'api_key')
   return {
     'X-Vestaboard-Read-Write-Key': api_key,
     'Content-Type': 'application/json',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "E-NOTE-ION"
-version = "0.7.0"
+version = "0.8.0"
 description = "Automation for Vestaboard displays — with emotion!"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_bart.py
+++ b/tests/core/test_bart.py
@@ -1,0 +1,120 @@
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+import integrations.bart as bart
+import integrations.vestaboard as vb
+
+
+@pytest.fixture(autouse=True)
+def reset_color_cache() -> Generator[None, None, None]:
+  """Reset the module-level route color cache before each test."""
+  bart._dest_color_cache = None
+  yield
+  bart._dest_color_cache = None  # type: ignore[assignment]
+
+
+@pytest.fixture()
+def bart_config(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Patch config to provide BART settings without a real config file."""
+  import config as _cfg
+
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {'bart': {'api_key': 'test-bart-key', 'station': 'MLPT', 'line1_dest': 'DALY'}},
+  )
+
+
+def _mock_routes_empty() -> MagicMock:
+  """Routes API returning no routes (simplifies etd-only tests)."""
+  mock = MagicMock()
+  mock.raise_for_status.return_value = None
+  mock.json.return_value = {'root': {'routes': {'route': []}}}
+  return mock
+
+
+def _mock_etd(dest: str = 'DALY', minutes: str = '5', color: str = 'GREEN') -> MagicMock:
+  mock = MagicMock()
+  mock.raise_for_status.return_value = None
+  mock.json.return_value = {
+    'root': {
+      'station': [
+        {
+          'name': 'Milpitas',
+          'etd': [{'abbreviation': dest, 'estimate': [{'minutes': minutes, 'color': color}]}],
+        }
+      ]
+    }
+  }
+  return mock
+
+
+# --- get_variables ---
+
+
+def test_get_variables_missing_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  def _raise(section: str, key: str) -> str:
+    if section == 'bart' and key == 'api_key':
+      raise ValueError('Missing required config key [bart].api_key in config.toml')
+    return 'value'
+
+  monkeypatch.setattr(_cfg, 'get', _raise)
+  with pytest.raises(ValueError, match='api_key'):
+    bart.get_variables()
+
+
+def test_get_variables_missing_station(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  def _raise(section: str, key: str) -> str:
+    if section == 'bart' and key == 'station':
+      raise ValueError('Missing required config key [bart].station in config.toml')
+    return 'value'
+
+  monkeypatch.setattr(_cfg, 'get', _raise)
+  with pytest.raises(ValueError, match='station'):
+    bart.get_variables()
+
+
+def test_get_variables_returns_station_and_line1(bart_config: None) -> None:
+  with patch('integrations.bart.requests.get', side_effect=[_mock_routes_empty(), _mock_etd()]):
+    result = bart.get_variables()
+  assert 'station' in result
+  assert 'line1' in result
+  assert result['station'][0][0] == 'Milpitas'
+
+
+def test_get_variables_no_service_when_dest_not_in_etd(bart_config: None) -> None:
+  mock_etd = MagicMock()
+  mock_etd.raise_for_status.return_value = None
+  mock_etd.json.return_value = {'root': {'station': [{'name': 'Milpitas', 'etd': []}]}}
+  with patch('integrations.bart.requests.get', side_effect=[_mock_routes_empty(), mock_etd]):
+    result = bart.get_variables()
+  assert 'NO SERVICE' in result['line1'][0][0]
+
+
+def test_get_variables_line1_fits_display(bart_config: None) -> None:
+  with patch('integrations.bart.requests.get', side_effect=[_mock_routes_empty(), _mock_etd()]):
+    result = bart.get_variables()
+  line = result['line1'][0][0]
+  assert vb.display_len(line) <= vb.model.cols
+
+
+def test_get_variables_http_error_does_not_leak_key(bart_config: None) -> None:
+  """HTTPError re-raise must not include the API key in the error message."""
+  err_resp = MagicMock()
+  err_resp.status_code = 503
+  err_resp.reason = 'Service Unavailable'
+  mock_routes = _mock_routes_empty()
+  mock_etd = MagicMock()
+  mock_etd.raise_for_status.side_effect = requests.HTTPError(response=err_resp)
+
+  with patch('integrations.bart.requests.get', side_effect=[mock_routes, mock_etd]):
+    with pytest.raises(requests.HTTPError) as exc_info:
+      bart.get_variables()
+  assert 'test-bart-key' not in str(exc_info.value)

--- a/tests/core/test_vestaboard.py
+++ b/tests/core/test_vestaboard.py
@@ -294,24 +294,30 @@ def test_expand_format_escaped_brace_whole_line_not_expanded() -> None:
 # --- _get_headers ---
 
 
-def test_get_headers_raises_without_key(monkeypatch: pytest.MonkeyPatch) -> None:
-  monkeypatch.delenv('VESTABOARD_API_KEY', raising=False)
-  with pytest.raises(RuntimeError, match='VESTABOARD_API_KEY'):
-    vb._get_headers()  # noqa: SLF001
+def test_get_headers_uses_config_key(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
 
-
-def test_get_headers_returns_correct_headers(monkeypatch: pytest.MonkeyPatch) -> None:
-  monkeypatch.setenv('VESTABOARD_API_KEY', 'my-test-key')
+  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'my-test-key'}})
   headers = vb._get_headers()  # noqa: SLF001
   assert headers['X-Vestaboard-Read-Write-Key'] == 'my-test-key'
   assert headers['Content-Type'] == 'application/json'
+
+
+def test_get_headers_missing_key_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {})
+  with pytest.raises(ValueError, match='vestaboard'):
+    vb._get_headers()  # noqa: SLF001
 
 
 # --- get_state ---
 
 
 def test_get_state_returns_state(monkeypatch: pytest.MonkeyPatch) -> None:
-  monkeypatch.setenv('VESTABOARD_API_KEY', 'test-key')
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
   layout = [[0] * vb.model.cols for _ in range(vb.model.rows)]
   mock_resp = MagicMock()
   mock_resp.json.return_value = {
@@ -330,7 +336,9 @@ def test_get_state_returns_state(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_get_state_passes_auth_header(monkeypatch: pytest.MonkeyPatch) -> None:
-  monkeypatch.setenv('VESTABOARD_API_KEY', 'sentinel-key')
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'sentinel-key'}})
   layout = [[0] * vb.model.cols for _ in range(vb.model.rows)]
   mock_resp = MagicMock()
   mock_resp.json.return_value = {'currentMessage': {'id': 'x', 'appeared': 'y', 'layout': json.dumps(layout)}}
@@ -345,7 +353,9 @@ def test_get_state_passes_auth_header(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_set_state_posts_grid_to_api(monkeypatch: pytest.MonkeyPatch) -> None:
-  monkeypatch.setenv('VESTABOARD_API_KEY', 'test-key')
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
   mock_resp = MagicMock()
   mock_resp.status_code = 200
   mock_resp.raise_for_status.return_value = None
@@ -359,7 +369,9 @@ def test_set_state_posts_grid_to_api(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_set_state_raises_board_locked_on_423(monkeypatch: pytest.MonkeyPatch) -> None:
-  monkeypatch.setenv('VESTABOARD_API_KEY', 'test-key')
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
   mock_resp = MagicMock()
   mock_resp.status_code = 423
   with patch('integrations.vestaboard.requests.post', return_value=mock_resp):
@@ -368,7 +380,9 @@ def test_set_state_raises_board_locked_on_423(monkeypatch: pytest.MonkeyPatch) -
 
 
 def test_set_state_propagates_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
-  monkeypatch.setenv('VESTABOARD_API_KEY', 'test-key')
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
   mock_resp = MagicMock()
   mock_resp.status_code = 500
   mock_resp.raise_for_status.side_effect = requests.HTTPError('server error')
@@ -378,7 +392,9 @@ def test_set_state_propagates_http_error(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 def test_set_state_raises_duplicate_on_409(monkeypatch: pytest.MonkeyPatch) -> None:
-  monkeypatch.setenv('VESTABOARD_API_KEY', 'test-key')
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
   mock_resp = MagicMock()
   mock_resp.status_code = 409
   with patch('integrations.vestaboard.requests.post', return_value=mock_resp):
@@ -387,7 +403,9 @@ def test_set_state_raises_duplicate_on_409(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_get_state_raises_empty_board_on_404(monkeypatch: pytest.MonkeyPatch) -> None:
-  monkeypatch.setenv('VESTABOARD_API_KEY', 'test-key')
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
   mock_resp = MagicMock()
   mock_resp.status_code = 404
   with patch('integrations.vestaboard.requests.get', return_value=mock_resp):
@@ -396,7 +414,9 @@ def test_get_state_raises_empty_board_on_404(monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_set_state_passes_auth_header(monkeypatch: pytest.MonkeyPatch) -> None:
-  monkeypatch.setenv('VESTABOARD_API_KEY', 'sentinel-key')
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'sentinel-key'}})
   mock_resp = MagicMock()
   mock_resp.status_code = 200
   mock_resp.raise_for_status.return_value = None

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -1,15 +1,38 @@
 import os
+from pathlib import Path
 
 import pytest
 
 _INTEGRATION_VARS: list[tuple[str, str]] = [
   ('BART_API_KEY', 'BART integration'),
-  ('BART_STATION', 'BART integration'),
-  ('BART_LINE_1_DEST', 'BART integration'),
   ('VESTABOARD_VIRTUAL_API_KEY', 'Vestaboard integration'),
 ]
 
 _skipped = 0
+
+
+def _load_dotenv() -> None:
+  """Load .env from the project root into os.environ if the file exists.
+
+  Only sets variables that are not already present in the environment, so
+  CI secrets (set as real env vars) always take precedence over .env values.
+  Simple key=value parser — no external dependency needed.
+  """
+  env_path = Path(__file__).parent.parent.parent / '.env'
+  if not env_path.exists():
+    return
+  for line in env_path.read_text().splitlines():
+    line = line.strip()
+    if not line or line.startswith('#') or '=' not in line:
+      continue
+    key, _, value = line.partition('=')
+    key = key.strip()
+    value = value.strip()
+    if key and key not in os.environ:
+      os.environ[key] = value
+
+
+_load_dotenv()
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/integrations/test_bart_integration.py
+++ b/tests/integrations/test_bart_integration.py
@@ -3,21 +3,33 @@
 Run with: uv run pytest -m integration
 
 Required env vars:
-  BART_API_KEY      — free BART API key
-  BART_STATION      — originating station code (e.g. MLPT)
-  BART_LINE_1_DEST  — destination abbreviation (e.g. DALY)
+  BART_API_KEY  — free BART API key
 """
+
+import os
 
 import pytest
 
+import config as _cfg
 import integrations.bart as bart
 import integrations.vestaboard as vb
 
 
 @pytest.mark.integration
-@pytest.mark.require_env('BART_API_KEY', 'BART_STATION', 'BART_LINE_1_DEST')
-def test_get_variables_real_api(require_env: None) -> None:
+@pytest.mark.require_env('BART_API_KEY')
+def test_get_variables_real_api(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
   """get_variables() returns a valid variables dict from the live BART API."""
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {
+      'bart': {
+        'api_key': os.environ['BART_API_KEY'],
+        'station': 'MLPT',
+        'line1_dest': 'DALY',
+      }
+    },
+  )
   # Reset the color cache so each run fetches fresh data.
   bart._dest_color_cache = None
 

--- a/tests/integrations/test_vestaboard_integration.py
+++ b/tests/integrations/test_vestaboard_integration.py
@@ -12,6 +12,7 @@ import time
 
 import pytest
 
+import config as _cfg
 import integrations.vestaboard as vb
 
 
@@ -19,7 +20,7 @@ import integrations.vestaboard as vb
 @pytest.mark.require_env('VESTABOARD_VIRTUAL_API_KEY')
 def test_set_state_real_api(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
   """set_state() successfully writes a message to the live virtual board."""
-  monkeypatch.setenv('VESTABOARD_API_KEY', os.environ['VESTABOARD_VIRTUAL_API_KEY'])
+  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': os.environ['VESTABOARD_VIRTUAL_API_KEY']}})
 
   # Use the last 4 digits of the epoch to make each run unique — the virtual
   # board returns 409 if you POST the same content as the current message.
@@ -34,7 +35,7 @@ def test_get_state_real_api(require_env: None, monkeypatch: pytest.MonkeyPatch) 
 
   Relies on test_set_state_real_api having run first so the board has state.
   """
-  monkeypatch.setenv('VESTABOARD_API_KEY', os.environ['VESTABOARD_VIRTUAL_API_KEY'])
+  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': os.environ['VESTABOARD_VIRTUAL_API_KEY']}})
 
   state = vb.get_state()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,101 @@
+import tomllib
+from pathlib import Path
+
+import pytest
+
+import config as _mod
+
+
+def _write_config(tmp_path: Path, content: str) -> None:
+  (tmp_path / 'config.toml').write_text(content)
+
+
+# --- load_config ---
+
+
+def test_load_config_missing_file_exits(
+  tmp_path: Path,
+  monkeypatch: pytest.MonkeyPatch,
+  capsys: pytest.CaptureFixture[str],
+) -> None:
+  monkeypatch.chdir(tmp_path)
+  with pytest.raises(SystemExit) as exc_info:
+    _mod.load_config()
+  assert exc_info.value.code == 1
+  assert 'config.example.toml' in capsys.readouterr().err
+
+
+def test_load_config_valid_file_populates_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.chdir(tmp_path)
+  _write_config(tmp_path, '[vestaboard]\napi_key = "test-key"\n')
+  _mod.load_config()
+  assert _mod._config.get('vestaboard', {}).get('api_key') == 'test-key'
+
+
+def test_load_config_invalid_toml_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.chdir(tmp_path)
+  (tmp_path / 'config.toml').write_text('not valid toml ={[}')
+  with pytest.raises(tomllib.TOMLDecodeError):
+    _mod.load_config()
+
+
+# --- get ---
+
+
+def test_get_required_present(monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setattr(_mod, '_config', {'sec': {'key': 'value'}})
+  assert _mod.get('sec', 'key') == 'value'
+
+
+def test_get_required_missing_section_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setattr(_mod, '_config', {})
+  with pytest.raises(ValueError, match='missing_sec'):
+    _mod.get('missing_sec', 'key')
+
+
+def test_get_required_missing_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setattr(_mod, '_config', {'sec': {}})
+  with pytest.raises(ValueError, match='missing_key'):
+    _mod.get('sec', 'missing_key')
+
+
+def test_get_required_empty_string_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setattr(_mod, '_config', {'sec': {'key': ''}})
+  with pytest.raises(ValueError):
+    _mod.get('sec', 'key')
+
+
+# --- get_optional ---
+
+
+def test_get_optional_present(monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setattr(_mod, '_config', {'sec': {'key': 'val'}})
+  assert _mod.get_optional('sec', 'key') == 'val'
+
+
+def test_get_optional_absent_returns_default(monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setattr(_mod, '_config', {})
+  assert _mod.get_optional('sec', 'key') == ''
+
+
+# --- get_schedule_override ---
+
+
+def test_get_schedule_override_present(monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setattr(
+    _mod,
+    '_config',
+    {'bart': {'schedules': {'departures': {'cron': '*/5 7-9 * * 1-5', 'hold': 120}}}},
+  )
+  result = _mod.get_schedule_override('bart.departures')
+  assert result == {'cron': '*/5 7-9 * * 1-5', 'hold': 120}
+
+
+def test_get_schedule_override_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setattr(_mod, '_config', {})
+  assert _mod.get_schedule_override('bart.departures') == {}
+
+
+def test_get_schedule_override_malformed_template_id(monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setattr(_mod, '_config', {})
+  assert _mod.get_schedule_override('no_dot_here') == {}

--- a/unraid/e-note-ion.xml
+++ b/unraid/e-note-ion.xml
@@ -13,15 +13,15 @@
   <Icon>https://raw.githubusercontent.com/JasonPuglisi/e-note-ion/main/assets/icon.png</Icon>
 
   <Config
-    Name="Vestaboard API Key"
-    Target="VESTABOARD_API_KEY"
+    Name="Config file"
+    Target="/app/config.toml"
     Default=""
-    Mode=""
-    Description="Your Vestaboard Read/Write API key. Found in the Vestaboard app under Settings."
-    Type="Variable"
+    Mode="rw"
+    Description="Required. Path to your config.toml on the host. Copy config.example.toml from the repo, fill in your API keys and settings, and point this path at the result."
+    Type="Path"
     Display="always"
     Required="true"
-    Mask="true"/>
+    Mask="false"/>
 
   <Config
     Name="Enabled contrib content"
@@ -41,50 +41,6 @@
     Mode="rw"
     Description="Optional. Path to a directory of personal content JSON files on the host. Files placed here are always loaded automatically. Leave blank if you only want to use bundled contrib content."
     Type="Path"
-    Display="always"
-    Required="false"
-    Mask="false"/>
-
-  <Config
-    Name="BART API Key"
-    Target="BART_API_KEY"
-    Default=""
-    Mode=""
-    Description="Required if using the BART integration (CONTENT_ENABLED=bart). Free API key at https://api.bart.gov/api/register.aspx"
-    Type="Variable"
-    Display="always"
-    Required="false"
-    Mask="true"/>
-
-  <Config
-    Name="BART station"
-    Target="BART_STATION"
-    Default="12TH - 12th St. Oakland City Center|16TH - 16th St. Mission|19TH - 19th St. Oakland|24TH - 24th St. Mission|ANTC - Antioch|ASHB - Ashby|BALB - Balboa Park|BAYF - Bay Fair|BERY - Berryessa/North San Jose|CAST - Castro Valley|CIVC - Civic Center|COLS - Coliseum|COLM - Colma|CONC - Concord|DALY - Daly City|DBRK - Downtown Berkeley|DUBL - Dublin/Pleasanton|DELN - El Cerrito del Norte|PLZA - El Cerrito Plaza|EMBR - Embarcadero|FRMT - Fremont|FTVL - Fruitvale|GLEN - Glen Park|HAYW - Hayward|LAFY - Lafayette|LAKE - Lake Merritt|MCAR - MacArthur|MLBR - Millbrae|MLPT - Milpitas|MONT - Montgomery St.|NBRK - North Berkeley|NCON - North Concord/Martinez|OAKL - Oakland Intl Airport|ORIN - Orinda|PITT - Pittsburg/Bay Point|PCTR - Pittsburg Center|PHIL - Pleasant Hill|POWL - Powell St.|RICH - Richmond|ROCK - Rockridge|SBRN - San Bruno|SFIA - San Francisco Intl Airport|SANL - San Leandro|SHAY - South Hayward|SSAN - South San Francisco|UCTY - Union City|WARM - Warm Springs/South Fremont|WCRK - Walnut Creek|WDUB - West Dublin|WOAK - West Oakland"
-    Mode=""
-    Description="Required if using the BART integration. Your originating BART station."
-    Type="Variable"
-    Display="always"
-    Required="false"
-    Mask="false"/>
-
-  <Config
-    Name="BART line 1 destination"
-    Target="BART_LINE_1_DEST"
-    Default="ANTC|BERY|DALY|DUBL|MLBR|PITT|PCTR|RICH|SFIA"
-    Mode=""
-    Description="Required if using the BART integration. Destination station abbreviation code for the first departure line shown. See https://api.bart.gov/docs/overview/abbrev.aspx"
-    Type="Variable"
-    Display="always"
-    Required="false"
-    Mask="false"/>
-
-  <Config
-    Name="BART line 2 destination"
-    Target="BART_LINE_2_DEST"
-    Default="|ANTC|BERY|DALY|DUBL|MLBR|PITT|PCTR|RICH|SFIA"
-    Mode=""
-    Description="Optional second BART departure line. Station abbreviation code. Leave blank to show only one line."
-    Type="Variable"
     Display="always"
     Required="false"
     Mask="false"/>

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.7.0"
+version = "0.8.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

Closes #36.

## Summary

- Introduces `config.toml` (copied from `config.example.toml`) as the single source of truth for all integration settings, replacing the patchwork of env vars
- New `config.py` module: `load_config()`, `get()`, `get_optional()`, `get_schedule_override()` — clear errors, no silent failures
- Integrations use a lazy import pattern so they remain importable in tests without a config file present
- `scheduler.py` reads config at startup and applies optional per-template schedule overrides from TOML (`[bart.schedules.departures]`, etc.)
- Removed `watch_content()` hot-reload — no longer needed now that config drives everything
- Docker/Unraid updated: bind-mount `config.toml` at `/app/config.toml`; Unraid template no longer exposes individual secret fields
- Tests updated throughout: `monkeypatch.setattr(config, '_config', {...})` replaces `monkeypatch.setenv`; 17 new tests added (`test_config.py`, `test_bart.py`)
- `.env.example` added for local integration test secrets; `conftest.py` loads `.env` automatically

## Test plan

- [ ] `uv run pytest` — 151 tests pass
- [ ] `uv run ruff check . && uv run ruff format --check .` — clean
- [ ] `uv run pyright` — 0 errors
- [ ] `uv run bandit -c pyproject.toml -r .` — no issues
- [ ] `uv run pip-audit` — no vulnerabilities
- [ ] Copy `config.example.toml` → `config.toml`, fill in keys, run `python scheduler.py` locally
- [ ] CI passes (check + docker + CodeQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)