### PR TITLE
fix: strip surrounding quotes from .env values in _load_dotenv()

### DIFF
--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -27,7 +27,7 @@ def _load_dotenv() -> None:
       continue
     key, _, value = line.partition('=')
     key = key.strip()
-    value = value.strip()
+    value = value.strip().strip('"').strip("'")
     if key and key not in os.environ:
       os.environ[key] = value
 


### PR DESCRIPTION
— *Claude Code*

The `_load_dotenv()` parser in `tests/integrations/conftest.py` did not strip surrounding quotes from values, so a line like `KEY="value"` would set `os.environ['KEY']` to `"value"` (with the quotes). This caused integration tests to fail with 403s when `.env` was written with quoted values.

One-line fix: add `.strip('"').strip("'")` after the existing `.strip()`.

## Test plan

- [ ] `uv run pytest -m integration -v` — all 3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)