### PR TITLE
chore: clarify .env bare-value format and add integration test docs to README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Copy to .env and fill in your values.
 # .env is git-ignored — never commit it.
+# Use bare values (no surrounding quotes) — e.g. KEY=value, not KEY="value".
 #
 # Required for Vestaboard integration tests:
 VESTABOARD_VIRTUAL_API_KEY=your-virtual-board-read-write-key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ PR labels (apply one or more):
 Integration tests live in `tests/integrations/` and are excluded from the
 default `uv run pytest` run. To run them locally:
 
-1. Copy `.env.example` to `.env` and fill in your API keys
+1. Copy `.env.example` to `.env` and fill in your API keys (bare values, no quotes)
 2. Run `uv run pytest -m integration -v`
 
 A setup table prints at session start showing which env vars are set or missing.

--- a/README.md
+++ b/README.md
@@ -252,3 +252,23 @@ uv run pre-commit run pretty-format-json --all-files
 ```
 
 All checks are also enforced as pre-commit hooks.
+
+### Integration tests
+
+Integration tests hit the real APIs and are excluded from the default `pytest`
+run. To run them locally:
+
+```bash
+cp .env.example .env
+# fill in your API keys — bare values, no surrounding quotes
+uv run pytest -m integration -v
+```
+
+Required keys:
+
+| Key | Where to get it |
+|---|---|
+| `VESTABOARD_VIRTUAL_API_KEY` | [web.vestaboard.com](https://web.vestaboard.com) → Developer → Virtual Boards |
+| `BART_API_KEY` | [api.bart.gov/api/register.aspx](https://api.bart.gov/api/register.aspx) |
+
+`.env` is git-ignored — never commit it.


### PR DESCRIPTION
— *Claude Code*

Follow-up to #117.

## Summary

- `.env.example`: adds a comment that bare values (no quotes) are preferred
- `CLAUDE.md`: updates the integration test setup step to say "bare values, no quotes"
- `README.md`: adds an **Integration tests** subsection under Development with copy-paste instructions and a table of required keys and where to get them

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)