### PR TITLE
feat: add priority to schedule overrides; move content format docs to content/README.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ on this project collaboratively with the user.
 
 ```
 scheduler.py                # Entry point — scheduler, queue, worker
-config.py                   # TOML config loader (load_config, get, get_optional, get_schedule_override)
+config.py                   # TOML config loader (load_config, get, get_optional, get_schedule_override — returns overrides for cron, hold, timeout, priority)
 config.toml                 # Runtime config with API keys (git-ignored; copy from config.example.toml)
 config.example.toml         # Config template committed to the repo
 integrations/vestaboard.py  # Vestaboard API client (get_state, set_state)

--- a/README.md
+++ b/README.md
@@ -129,95 +129,12 @@ Content is defined as JSON files in two directories:
 
 - **`content/contrib/`** — bundled community-contributed content, disabled by
   default. Enable files by stem using `--content-enabled` / `CONTENT_ENABLED`.
-  See [`content/README.md`](content/README.md) for available integrations.
 - **`content/user/`** — personal content, always loaded. Git-ignored; mount
   your own directory here or symlink to a private repo for versioning.
 
-Each file can contain multiple named templates, each with its own schedule and
-display settings.
-
-```json
-{
-  "templates": {
-    "my_message": {
-      "schedule": {
-        "cron": "0 8 * * *",
-        "hold": 600,
-        "timeout": 600
-      },
-      "priority": 5,
-      "public": true,
-      "truncation": "word",
-      "templates": [
-        { "format": ["GOOD MORNING", "{quip}"] }
-      ]
-    }
-  },
-  "variables": {
-    "quip": [
-      ["HAVE A", "GREAT DAY"],
-      ["YOU GOT", "THIS"]
-    ]
-  }
-}
-```
-
-| Field | Description |
-|---|---|
-| `cron` | Standard 5-field cron expression |
-| `hold` | Seconds the message stays on display before the next update |
-| `timeout` | Seconds the message can wait in the queue before being discarded |
-| `priority` | Integer 0–10; higher number runs first when multiple messages are queued |
-| `public` | If `false`, excluded when running with `--public` |
-| `truncation` | `hard` cuts mid-word (default); `word` stops at a word boundary; `ellipsis` adds `...` |
-
-### Variables
-
-`{variable}` placeholders are replaced with a randomly chosen option from the
-corresponding `variables` entry. A format entry that is exactly `{variable}`
-expands into all lines of the chosen option; an inline `{variable}` within
-other text is replaced by the first line of the option.
-
-When a template has multiple `{ "format": [...] }` entries, one is chosen at
-random each time the template fires.
-
-### Color squares
-
-Color squares can be embedded in format strings using short tags: `[R]` `[O]`
-`[Y]` `[G]` `[B]` `[V]` `[W]` `[K]` (red, orange, yellow, green, blue,
-violet, white, black). Each tag renders as a single colored square on the
-display.
-
-### Wrapping and truncation
-
-After variable expansion, lines are automatically word-wrapped to fit the
-board width. If the result has more rows than the board height, the excess is
-silently dropped. Content from dynamic sources (e.g. API responses) doesn't
-need to be pre-fitted to the board dimensions.
-
-### Integration templates
-
-Templates can pull live data from an integration by adding
-`"integration": "<name>"`. The worker calls the integration at job time to
-fetch current variable values:
-
-```json
-{
-  "templates": {
-    "my_integration_template": {
-      "schedule": { "cron": "*/5 * * * *", "hold": 60, "timeout": 60 },
-      "priority": 8,
-      "integration": "my_integration",
-      "templates": [
-        { "format": ["{line_1}", "{line_2}"] }
-      ]
-    }
-  }
-}
-```
-
-See [`content/README.md`](content/README.md) for available integrations and
-their configuration.
+See [`content/README.md`](content/README.md) for the full content format
+reference, including template fields, variables, color squares, priority
+guidelines, schedule overrides, and available integrations.
 
 ## Philosophy
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -21,10 +21,12 @@ line1_dest = "DALY"
 # line2_dest = "BERY"
 
 # ── Schedule overrides (optional) ─────────────────────────────────────────────
-# Override cron, hold, or timeout for a named template without editing JSON.
-# All three fields are optional; unspecified fields use the template default.
+# Override cron, hold, timeout, or priority for a named template without
+# editing JSON. All fields are optional; unspecified fields use the template
+# default.
 
 # [bart.schedules.departures]
 # cron = "*/5 7-9 * * 1-5"
 # hold = 290
 # timeout = 60
+# priority = 8

--- a/integrations/bart.py
+++ b/integrations/bart.py
@@ -7,13 +7,13 @@
 # dynamically from the BART routes API on first call and cached for the
 # process lifetime.
 #
-# Required env vars:
-#   BART_API_KEY    — API key (free at https://api.bart.gov/api/register.aspx)
-#   BART_STATION    — Originating station code (e.g. MLPT for Milpitas)
+# Required config.toml keys ([bart]):
+#   api_key    — API key (free at https://api.bart.gov/api/register.aspx)
+#   station    — Originating station code (e.g. MLPT for Milpitas)
+#   line1_dest — Destination abbreviation code for line 1 (e.g. DALY for Daly City)
 #
-# Optional env vars (configure 1–2 lines to display):
-#   BART_LINE_1_DEST — Destination abbreviation code (e.g. DALY for Daly City)
-#   BART_LINE_2_DEST — Second destination code (optional)
+# Optional config.toml keys:
+#   line2_dest — Second destination abbreviation code (optional)
 
 from typing import Any
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -275,6 +275,12 @@ def _load_file(
         effective[field] = val
       elif field in ('hold', 'timeout') and isinstance(val, int) and val >= 0:
         effective[field] = val
+    if 'priority' in override:
+      val = override['priority']
+      if isinstance(val, int) and 0 <= val <= 10:
+        priority = val
+      else:
+        print(f'Warning: ignoring invalid priority override for {job_id}: {val!r}')
     scheduler.add_job(
       enqueue,
       trigger='cron',


### PR DESCRIPTION
— *Claude Code*

Closes #119

## Summary

- **`scheduler.py`**: extends the config.toml schedule override loop to support `priority` (integer 0–10); logs a warning and preserves the JSON default if the override value is invalid
- **`config.example.toml`**: adds commented `priority` field to the override example block
- **`integrations/bart.py`**: fixes stale env var references in the header comment (config has lived in `config.toml` since the TOML migration)
- **`content/README.md`**: takes full ownership of the content format reference — JSON structure, field table, variables, color squares, wrapping, integration templates, priority guidelines (new), schedule overrides (new), and the contrib integration index
- **`README.md`**: replaces format sections with a pointer to `content/README.md`; the main README now focuses on setup, deployment, and running
- **`CLAUDE.md`**: notes all four overridable fields in the `get_schedule_override` doc
- **Tests**: three new cases for priority override — valid override applied, non-integer ignored with warning, out-of-range ignored with warning

## BART config assessment

The existing BART defaults (`priority: 8`, `hold: 290`, `timeout: 60`) are well-aligned with the priority guidelines being documented — no changes needed.

## Test plan

- [x] `uv run pytest` — all 51 tests pass
- [x] Full check suite passes (ruff, pyright, bandit, pip-audit, pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)