### PR TITLE
feat: raise RuntimeError with install hint on missing integration deps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,16 @@ short tags: `[R]` `[O]` `[Y]` `[G]` `[B]` `[V]` `[W]` `[K]` (red, orange,
 yellow, green, blue, violet, white, black). Each tag encodes to the
 corresponding Vestaboard color square code (63–70).
 
+### Integration dependencies
+
+Add any packages required by a new integration to `pyproject.toml`
+`dependencies` (the base list). All deps are installed unconditionally —
+this keeps the Docker image simple, and Docker is the primary deployment
+target. If an integration is loaded and its deps are missing (e.g. a
+source-install user skipped them), `_get_integration()` will catch the
+`ImportError` and raise a `RuntimeError` with an install hint; the worker
+logs it and skips that message rather than crashing.
+
 ## Environment
 
 - Configuration lives in `config.toml` at the project root (git-ignored). Copy

--- a/scheduler.py
+++ b/scheduler.py
@@ -43,7 +43,13 @@ def _get_integration(name: str) -> Any:
   if name not in _KNOWN_INTEGRATIONS:
     raise ValueError(f'Unknown integration: {name!r}')
   if name not in _integrations:
-    _integrations[name] = importlib.import_module(f'integrations.{name}')
+    try:
+      _integrations[name] = importlib.import_module(f'integrations.{name}')
+    except ImportError as e:
+      raise RuntimeError(
+        f'Integration {name!r} is missing dependencies. '
+        f'Install them with: pip install -r integrations/{name}.requirements.txt'
+      ) from e
   return _integrations[name]
 
 

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -660,6 +660,13 @@ def test_get_integration_known_loads_module() -> None:
   assert result is bart_mod
 
 
+def test_get_integration_missing_deps_raises_runtime_error() -> None:
+  _mod._integrations.pop('bart', None)
+  with patch('importlib.import_module', side_effect=ImportError('No module named requests')):
+    with pytest.raises(RuntimeError, match='missing dependencies'):
+      _mod._get_integration('bart')
+
+
 def test_get_integration_caches_module() -> None:
   import integrations.bart as bart_mod
 


### PR DESCRIPTION
Closes #35

## Summary

- Wraps `importlib.import_module` in `_get_integration()` with `try/except ImportError` — missing deps surface as a clear `RuntimeError` with an install hint rather than a cryptic traceback
- The existing worker exception handler catches and logs it; the message is skipped rather than crashing the worker
- Adds `test_get_integration_missing_deps_raises_runtime_error` to `tests/core/test_scheduler.py`
- Documents in `CLAUDE.md` that new integration deps go in `pyproject.toml` base `dependencies` (not optional extras), with rationale

No version bump — no runtime behaviour change for users who have deps installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)