### PR TITLE
chore: fix README run command and add worker integration test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,15 +110,15 @@ cp config.example.toml config.toml
 ```bash
 uv sync
 cp config.example.toml config.toml  # fill in your API key
-python scheduler.py
+uv run e-note-ion
 ```
 
 ```bash
-python scheduler.py                          # Note (3×15), user content only
-python scheduler.py --content-enabled bart   # also enable contrib/bart.json
-python scheduler.py --content-enabled '*'    # enable all contrib content
-python scheduler.py --flagship               # Flagship (6×22)
-python scheduler.py --public                 # public templates only
+uv run e-note-ion                          # Note (3×15), user content only
+uv run e-note-ion --content-enabled bart   # also enable contrib/bart.json
+uv run e-note-ion --content-enabled '*'    # enable all contrib content
+uv run e-note-ion --flagship               # Flagship (6×22)
+uv run e-note-ion --public                 # public templates only
 ```
 
 Flags can be combined.


### PR DESCRIPTION
Findings from a project health check.

## Summary

- **README**: replace `python scheduler.py` with `uv run e-note-ion` in the "Running directly" section — the bare command requires manual venv activation, which uv users don't do
- **Tests**: two worker coverage gaps filled:
  - `test_worker_calls_integration_get_variables` — verifies the worker calls `get_variables()` on the integration module and passes the result through to `set_state()`
  - `test_worker_logs_and_skips_on_missing_integration_deps` — verifies the `except Exception` handler catches `RuntimeError` from a missing-dep integration, skips `set_state()`, and continues rather than crashing

No version bump — docs and test-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)