### PR TITLE
fix: add coalesce window to prevent lower-priority co-scheduled messages firing first

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.8.0"
+version = "0.8.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.8.0"
+version = "0.8.1"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Closes #124

## Summary

- `pop_valid_message()` now sleeps 100 ms (`_COALESCE_WINDOW`) after the first message arrives, drains the queue, and returns the highest-priority valid candidate — re-enqueueing the rest
- Fixes the case where a priority-0 message fired before a priority-9 one because both were cron-scheduled at the same time and APScheduler dispatched them within milliseconds
- Existing `pop_valid_message` tests updated to patch `time.sleep`; three new tests added for the co-scheduling scenario

## Test plan

- [ ] `test_pop_valid_message_prefers_higher_priority_coscheduled` — both messages pre-loaded; high-priority returned
- [ ] `test_pop_valid_message_requeues_lower_priority` — low-priority message back in queue after pop
- [ ] `test_pop_valid_message_discards_expired_in_batch` — expired message discarded even when it was higher-priority than the valid one

🤖 Generated with [Claude Code](https://claude.com/claude-code)