### PR TITLE
fix: revert Config to self-closing tags to prevent whitespace value injection

### DIFF
--- a/unraid/e-note-ion.xml
+++ b/unraid/e-note-ion.xml
@@ -21,8 +21,7 @@
     Type="Path"
     Display="always"
     Required="true"
-    Mask="false">
-  </Config>
+    Mask="false"/>
 
   <Config
     Name="Enabled contrib content"
@@ -33,8 +32,7 @@
     Type="Variable"
     Display="always"
     Required="false"
-    Mask="false">
-  </Config>
+    Mask="false"/>
 
   <Config
     Name="User content directory"
@@ -45,8 +43,7 @@
     Type="Path"
     Display="always"
     Required="false"
-    Mask="false">
-  </Config>
+    Mask="false"/>
 
   <Config
     Name="Flagship mode"
@@ -57,8 +54,7 @@
     Type="Variable"
     Display="always"
     Required="false"
-    Mask="false">
-  </Config>
+    Mask="false"/>
 
   <Config
     Name="Public mode"
@@ -69,6 +65,5 @@
     Type="Variable"
     Display="always"
     Required="false"
-    Mask="false">
-  </Config>
+    Mask="false"/>
 </Container>


### PR DESCRIPTION
## Summary

Reverts the `<Config>` elements back to self-closing tags. Explicit open/close tags with indented content caused Unraid to read the whitespace text node (newline + indentation spaces) as the field value, prepending spaces to configured paths and breaking container startup.

The actual fix for config-loss on edit/update is the sensible `Default` attribute values added in #127 — the tag style change was unnecessary and caused a regression.

Fixes the regression introduced by #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
