### PR TITLE
fix: use [V] violet tag in trakt.json headers, not [P]

### DIFF
--- a/content/contrib/trakt.json
+++ b/content/contrib/trakt.json
@@ -14,7 +14,7 @@
       "templates": [
         {
           "format": [
-            "[P] NEXT AIRING",
+            "[V] NEXT AIRING",
             "{show_name}",
             "{episode_ref} {air_day} {air_time}"
           ]
@@ -35,7 +35,7 @@
       "templates": [
         {
           "format": [
-            "[P] NOW PLAYING",
+            "[V] NOW PLAYING",
             "{show_name}",
             "{episode_ref} {episode_title}"
           ]


### PR DESCRIPTION
— *Claude Code*

`[P]` is not a valid Vestaboard color tag — it passes through as the literal characters `[`, `P`, `]`, which the board renders as just `P`. Violet is `[V]`.

Fixes the Trakt `[P] NOW PLAYING` / `[P] NEXT AIRING` headers so they display a violet square as intended.

Opens #133 to add load-time validation so this class of mistake is caught automatically in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
