### PR TITLE
feat: compact episode refs (S9E8) and strip leading articles from titles

### DIFF
--- a/integrations/trakt.py
+++ b/integrations/trakt.py
@@ -193,6 +193,22 @@ def _ensure_authenticated() -> None:
 # --- Integration functions ---
 
 
+_LEADING_ARTICLES = ('THE ', 'AN ', 'A ')
+
+
+def _format_episode_ref(season: int, number: int) -> str:
+  """Return a compact episode ref, e.g. S9E8 (no zero-padding)."""
+  return f'S{season}E{number}'
+
+
+def _strip_leading_article(title: str) -> str:
+  """Remove a leading article (A, An, The) from an uppercased title."""
+  for article in _LEADING_ARTICLES:
+    if title.startswith(article):
+      return title[len(article) :]
+  return title
+
+
 def get_variables_calendar() -> dict[str, list[list[str]]]:
   """Fetch the next upcoming episode from the user's Trakt calendar.
 
@@ -233,8 +249,8 @@ def get_variables_calendar() -> dict[str, list[list[str]]]:
 
   show_name = entry['show']['title'].upper()
   ep = entry['episode']
-  episode_ref = f'S{ep["season"]:02d}E{ep["number"]:02d}'
-  episode_title = (ep.get('title') or '').upper()
+  episode_ref = _format_episode_ref(ep['season'], ep['number'])
+  episode_title = _strip_leading_article((ep.get('title') or '').upper())
 
   # Convert UTC first_aired → local time for display
   aired_dt = datetime.fromisoformat(entry['first_aired'].replace('Z', '+00:00'))
@@ -294,8 +310,8 @@ def get_variables_watching() -> dict[str, list[list[str]]]:
   if media_type == 'episode':
     show_name = data['show']['title'].upper()
     ep = data['episode']
-    episode_ref = f'S{ep["season"]:02d}E{ep["number"]:02d}'
-    episode_title = (ep.get('title') or '').upper()
+    episode_ref = _format_episode_ref(ep['season'], ep['number'])
+    episode_title = _strip_leading_article((ep.get('title') or '').upper())
   elif media_type == 'movie':
     show_name = data['movie']['title'].upper()
     episode_ref = 'MOVIE'

--- a/tests/core/test_trakt.py
+++ b/tests/core/test_trakt.py
@@ -265,6 +265,54 @@ def test_auth_thread_logs_error_on_denied(config_without_tokens: Path, capsys: p
   assert 'denied' in out.lower()
 
 
+# --- _format_episode_ref ---
+
+
+def test_format_episode_ref_no_padding() -> None:
+  assert trakt._format_episode_ref(9, 8) == 'S9E8'  # noqa: SLF001
+
+
+def test_format_episode_ref_double_digit() -> None:
+  assert trakt._format_episode_ref(12, 24) == 'S12E24'  # noqa: SLF001
+
+
+def test_format_episode_ref_single_digit_each() -> None:
+  assert trakt._format_episode_ref(1, 1) == 'S1E1'  # noqa: SLF001
+
+
+# --- _strip_leading_article ---
+
+
+def test_strip_leading_article_the() -> None:
+  assert trakt._strip_leading_article('THE FINAL SHOWDOWN') == 'FINAL SHOWDOWN'  # noqa: SLF001
+
+
+def test_strip_leading_article_a() -> None:
+  assert trakt._strip_leading_article('A QUIET MAN') == 'QUIET MAN'  # noqa: SLF001
+
+
+def test_strip_leading_article_an() -> None:
+  assert trakt._strip_leading_article('AN UNEXPECTED JOURNEY') == 'UNEXPECTED JOURNEY'  # noqa: SLF001
+
+
+def test_strip_leading_article_no_article() -> None:
+  assert trakt._strip_leading_article('PILOT') == 'PILOT'  # noqa: SLF001
+
+
+def test_strip_leading_article_word_starting_with_the() -> None:
+  # "THEORY" should not be stripped — must match full word boundary
+  assert trakt._strip_leading_article('THEORY OF EVERYTHING') == 'THEORY OF EVERYTHING'  # noqa: SLF001
+
+
+def test_strip_leading_article_word_starting_with_a() -> None:
+  # "AFTERMATH" should not be stripped
+  assert trakt._strip_leading_article('AFTERMATH') == 'AFTERMATH'  # noqa: SLF001
+
+
+def test_strip_leading_article_empty() -> None:
+  assert trakt._strip_leading_article('') == ''  # noqa: SLF001
+
+
 # --- get_variables_calendar ---
 
 
@@ -292,8 +340,8 @@ def test_get_variables_calendar_returns_expected_vars(
     result = trakt.get_variables_calendar()
 
   assert result['show_name'] == [['GREAT SHOW']]
-  assert result['episode_ref'] == [['S02E05']]
-  assert result['episode_title'] == [['THE ONE WITH THE TEST']]
+  assert result['episode_ref'] == [['S2E5']]
+  assert result['episode_title'] == [['ONE WITH THE TEST']]
   assert 'air_day' in result
   assert 'air_time' in result
 
@@ -357,7 +405,7 @@ def test_get_variables_watching_episode_returns_vars(
     result = trakt.get_variables_watching()
 
   assert result['show_name'] == [['MY SHOW']]
-  assert result['episode_ref'] == [['S01E03']]
+  assert result['episode_ref'] == [['S1E3']]
   assert result['episode_title'] == [['PILOT']]
 
 


### PR DESCRIPTION
— *Claude Code*

Closes #135.

## Summary

- Episode refs are now compact: `S9E8` instead of `S09E08` (saves 2 chars on the 15-col Note layout)
- Leading articles (`A`, `An`, `The`) are stripped from episode titles before display — e.g. `THE FINAL SHOWDOWN` → `FINAL SHOWDOWN` (recovers up to 4 chars)
- Both changes apply to `get_variables_calendar` and `get_variables_watching`

## Test plan

- [x] 201 unit tests passing (10 new: `_format_episode_ref` × 3, `_strip_leading_article` × 7)
- [x] Full check suite clean (ruff, pyright, bandit, pip-audit, pre-commit)
- [x] Word-boundary safety tested: `THEORY...` and `AFTERMATH` correctly not stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
