### PR TITLE
feat: global timezone config option for date/time display

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -2,6 +2,12 @@
 # Copy this file to config.toml and fill in your values.
 # config.toml is git-ignored — never commit it.
 
+[scheduler]
+# Optional: IANA timezone name for date/time display in all integrations.
+# Defaults to the system local timezone (TZ env var). Set this if you want
+# to display times in a specific timezone regardless of the host's TZ setting.
+# timezone = "America/Los_Angeles"
+
 [vestaboard]
 # Read/Write API key from https://store.vestaboard.com/pages/read-write-api
 api_key = "your-vestaboard-read-write-api-key"

--- a/integrations/trakt.py
+++ b/integrations/trakt.py
@@ -252,9 +252,10 @@ def get_variables_calendar() -> dict[str, list[list[str]]]:
   episode_ref = _format_episode_ref(ep['season'], ep['number'])
   episode_title = _strip_leading_article((ep.get('title') or '').upper())
 
-  # Convert UTC first_aired → local time for display
+  # Convert UTC first_aired → display timezone (config [scheduler].timezone,
+  # or system local if unset).
   aired_dt = datetime.fromisoformat(entry['first_aired'].replace('Z', '+00:00'))
-  local_dt = aired_dt.astimezone()
+  local_dt = aired_dt.astimezone(_config_mod.get_timezone())
   air_day = local_dt.strftime('%a').upper()[:3]
   hour = local_dt.hour
   if hour == 0:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 import tomllib
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -99,3 +100,23 @@ def test_get_schedule_override_absent(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_get_schedule_override_malformed_template_id(monkeypatch: pytest.MonkeyPatch) -> None:
   monkeypatch.setattr(_mod, '_config', {})
   assert _mod.get_schedule_override('no_dot_here') == {}
+
+
+# --- get_timezone ---
+
+
+def test_get_timezone_absent_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setattr(_mod, '_config', {})
+  assert _mod.get_timezone() is None
+
+
+def test_get_timezone_valid_returns_zone_info(monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setattr(_mod, '_config', {'scheduler': {'timezone': 'America/Los_Angeles'}})
+  result = _mod.get_timezone()
+  assert result == ZoneInfo('America/Los_Angeles')
+
+
+def test_get_timezone_invalid_raises_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setattr(_mod, '_config', {'scheduler': {'timezone': 'Not/ATimezone'}})
+  with pytest.raises(ValueError, match='Not/ATimezone'):
+    _mod.get_timezone()


### PR DESCRIPTION
— *Claude Code*

Closes #132.

## Summary

- `config.get_timezone()` — returns `ZoneInfo` from `[scheduler].timezone` if configured, `None` (system local) otherwise. Invalid timezone names raise `ValueError` with a clear message.
- `integrations/trakt.py` — `astimezone(config.get_timezone())` replaces bare `astimezone()`; `None` is identical to no-arg behaviour so existing installs with `TZ` set are unaffected
- `config.example.toml` — new `[scheduler]` section with commented-out `timezone` key
- 3 new tests in `test_config.py`

## Test plan

- [x] 204 unit tests passing
- [x] Full check suite clean (ruff, pyright, bandit, pip-audit, pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
