### PR TITLE
chore: bump version to 0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.9.0"
+version = "0.10.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [


### PR DESCRIPTION
— *Claude Code*

Bumps version to 0.10.0 to release changes since v0.9.0:

- feat: global timezone config option for date/time display (#137)
- feat: compact episode refs and strip leading articles from titles (#136)
- fix: use [V] violet tag in trakt.json headers, not [P] (#134)
