### PR TITLE
fix: add exceptions.py to Dockerfile COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev
 
 # Copy source, config example, and bundled contrib content.
-COPY scheduler.py entrypoint.sh config.py config.example.toml ./
+COPY scheduler.py entrypoint.sh config.py exceptions.py config.example.toml ./
 COPY integrations/ ./integrations/
 COPY content/contrib/ ./content/contrib/
 


### PR DESCRIPTION
Fixes container startup crash introduced in #146. The Dockerfile explicitly names each source file; `exceptions.py` was missing from the `COPY` line, causing `ModuleNotFoundError: No module named 'exceptions'` at startup.

No logic changes — one-line Dockerfile fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)