### PR TITLE
chore: bump version to 0.10.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.10.1"
+version = "0.10.2"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [


### PR DESCRIPTION
Triggers release and Docker image rebuild following the Dockerfile fix in #147 (`exceptions.py` missing from `COPY`, causing container startup crash after #146).

🤖 Generated with [Claude Code](https://claude.com/claude-code)