### PR TITLE
fix: update trakt air_time to 24-hour format

### DIFF
--- a/integrations/trakt.py
+++ b/integrations/trakt.py
@@ -213,7 +213,7 @@ def get_variables_calendar() -> dict[str, list[list[str]]]:
   """Fetch the next upcoming episode from the user's Trakt calendar.
 
   Returns variables: show_name, episode_ref (e.g. S01E02), air_day (e.g. MON),
-  air_time (e.g. 8PM), episode_title. All values are uppercased.
+  air_time (e.g. 20:00), episode_title. All values are uppercased.
 
   Raises IntegrationDataUnavailableError if the calendar window is empty.
   """
@@ -256,15 +256,7 @@ def get_variables_calendar() -> dict[str, list[list[str]]]:
   aired_dt = datetime.fromisoformat(entry['first_aired'].replace('Z', '+00:00'))
   local_dt = aired_dt.astimezone(_config_mod.get_timezone())
   air_day = local_dt.strftime('%a').upper()[:3]
-  hour = local_dt.hour
-  if hour == 0:
-    air_time = '12AM'
-  elif hour < 12:
-    air_time = f'{hour}AM'
-  elif hour == 12:
-    air_time = '12PM'
-  else:
-    air_time = f'{hour - 12}PM'
+  air_time = f'{local_dt.hour}:{local_dt.minute:02d}'
 
   return {
     'show_name': [[show_name]],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.10.2"
+version = "0.10.3"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_trakt.py
+++ b/tests/core/test_trakt.py
@@ -1,5 +1,6 @@
 """Unit tests for integrations/trakt.py (mocked — no real API calls)."""
 
+import re
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -343,7 +344,7 @@ def test_get_variables_calendar_returns_expected_vars(
   assert result['episode_ref'] == [['S2E5']]
   assert result['episode_title'] == [['ONE WITH THE TEST']]
   assert 'air_day' in result
-  assert 'air_time' in result
+  assert re.match(r'^\d+:\d{2}$', result['air_time'][0][0])
 
 
 def test_get_variables_calendar_empty_raises_unavailable(

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.10.2"
+version = "0.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Fixes #142.

Replaces the 12-hour AM/PM `air_time` formatting (`8PM`, `12AM`) with 24-hour `H:MM` format (`20:00`, `0:00`) per the display design system in `content/DESIGN.md`.

**Changes:**
- `integrations/trakt.py`: replace 8-line 12-hour logic with `f'{local_dt.hour}:{local_dt.minute:02d}'`; update docstring
- `tests/core/test_trakt.py`: tighten `air_time` assertion to verify `\d+:\d{2}` pattern rather than just key presence

🤖 Generated with [Claude Code](https://claude.com/claude-code)
