### PR TITLE
security: strip request details from Vestaboard HTTPError

### DIFF
--- a/integrations/vestaboard.py
+++ b/integrations/vestaboard.py
@@ -261,7 +261,10 @@ def get_state(color: VestaboardColor = VestaboardColor.BLACK) -> VestaboardState
   r = requests.get(_HOST, headers=_get_headers(), timeout=10)
   if r.status_code == 404:
     raise EmptyBoardError('board has no current message')
-  r.raise_for_status()
+  try:
+    r.raise_for_status()
+  except requests.HTTPError as e:
+    raise requests.HTTPError(f'Vestaboard API error: {e.response.status_code} {e.response.reason}') from None
   return VestaboardState(r.json(), color)
 
 
@@ -489,4 +492,7 @@ def set_state(
     raise DuplicateContentError('board already shows this content')
   if r.status_code == 423:
     raise BoardLockedError('board is locked (rate-limited or quiet hours)')
-  r.raise_for_status()
+  try:
+    r.raise_for_status()
+  except requests.HTTPError as e:
+    raise requests.HTTPError(f'Vestaboard API error: {e.response.status_code} {e.response.reason}') from None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.10.2"
+version = "0.10.3"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.10.2"
+version = "0.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Fixes #153.

Wraps `r.raise_for_status()` in both `get_state()` and `set_state()` with a try/except that re-raises a clean `requests.HTTPError` containing only the status code and reason phrase — matching the pattern already used in `bart.py` and `trakt.py`.

**Why:** The Vestaboard API key is sent in the `X-Vestaboard-Read-Write-Key` header. While the URL itself doesn't contain the key, allowing the raw `requests.HTTPError` to propagate creates inconsistency and risk if request details are ever logged upstream.

**Changes:**
- `integrations/vestaboard.py`: wrap both `raise_for_status()` calls; re-raise with `'Vestaboard API error: {status} {reason}'`
- `tests/core/test_vestaboard.py`: update existing 500-error test to use proper `response=` kwarg; add `test_set_state_http_error_does_not_leak_api_key` and `test_get_state_http_error_does_not_leak_api_key`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
