### PR TITLE
fix: correct startup log column alignment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.10.3"
+version = "0.10.4"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Fixes #150.

Three related bugs in the startup log table:

**Bug 1 — cron padding inside quotes**
```
· breakfast  cron="0 8 * * * "    ← before: space before closing quote
· breakfast  cron="0 8 * * *"     ← after: quotes wrap value only, space outside
```
Fix: pad the whole `cron="..."` token as a unit.

**Bug 2 — `s` suffix after padding**
```
· watching  hold=180 s  timeout=120s    ← before
· watching  hold=180s   timeout=120s    ← after
```
Fix: include `s` in the value string before padding.

**Bug 3 — widths from pre-override values**
When a cron override was shorter than the JSON value, column widths were still computed from the original, inflating padding. Fix: collect effective (post-override) values in a first pass, then compute widths, then schedule and print.

**Changes:**
- `scheduler.py`: two-pass approach; pad full `cron="..."` / `hold=Xs` / `timeout=Xs` tokens
- `tests/core/test_scheduler.py`: three targeted tests, one per bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)
