### PR TITLE
chore: tighten AGENTS.md and extract contrib template

### DIFF
--- a/content/contrib/TEMPLATE.md
+++ b/content/contrib/TEMPLATE.md
@@ -1,0 +1,25 @@
+# <name>.json
+
+One-sentence description. Schedule summary.
+
+## Configuration
+
+Add the following to your `config.toml`:
+
+```toml
+[<name>]
+key_name = "value"
+```
+
+| Key | Required | Description |
+|---|---|---|
+| `key_name` | Yes/No | What it does |
+
+## Keeping data current
+
+### <Data type>
+
+Authoritative source: <URL>
+
+Instructions for verifying and updating any hardcoded lists (station codes,
+destination names, API endpoint changes, etc.).


### PR DESCRIPTION
— *Claude Code*

## Summary

- **Health review** (lines 240–264): rewrote 44-line prose block as a 10-item numbered checklist — same checks, scannable at a glance
- **Planning approval gate** (step 3): marked as ⛔ HARD STOP so it reads as a blocker, not a suggestion
- **Execution step 10**: trimmed nested sub-bullets to inline notes
- **Contrib template**: extracted 30-line inline markdown block to `content/contrib/TEMPLATE.md`; replaced with a one-liner link

441 → 386 lines.

Closes #162

## Test plan

- [ ] All CI checks pass (docs-only change)
- [ ] Verify `content/contrib/TEMPLATE.md` contains the full template previously inline in AGENTS.md
- [ ] Verify all 10 health review items are preserved in the new checklist
