### PR TITLE
chore: add CONTRIBUTING.md and triage bullet to health review (#97)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,6 +261,7 @@ prevention here — not just a one-off fix. See #65 for extended notes.
     - Blocking relationships explicit ("Blocked by #X" in body)
     - Tracking issues have sub-issues linked (`gh api repos/JasonPuglisi/e-note-ion/issues/<n>/sub_issues`)
     - Issues in wrong milestone reassigned; stale/superseded issues closed with a note
+    - Untriaged issues (missing label, milestone, or assignee) caught and resolved
 
 ### Planning before implementation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to e-note-ion
+
+Thanks for your interest. This is a personal project with a small scope, so
+contributions are welcome but selective.
+
+## Filing issues
+
+Before opening an issue, check for duplicates in the [issue tracker][issues].
+
+Include:
+- What you expected vs. what happened (for bugs)
+- Your board model (Note or Flagship), Python version, and deployment method
+- Relevant config (redact any API keys)
+
+Out-of-scope requests (e.g. support for other display hardware) will be closed
+with an explanation.
+
+## Pull requests
+
+Before writing code, open an issue so we can discuss whether the change fits
+the project. PRs without a linked issue may be closed.
+
+Requirements for all PRs:
+- Tests for any new logic (`uv run pytest` must pass)
+- `uv run ruff check .` and `uv run ruff format --check .` clean
+- `uv run pyright` clean
+- No new secrets logged or exposed; all HTTP calls include `timeout=`
+
+See [AGENTS.md](AGENTS.md) for code conventions (indentation, type hints,
+security practices, integration patterns).
+
+[issues]: https://github.com/JasonPuglisi/e-note-ion/issues


### PR DESCRIPTION
— *Claude Code*

Closes #97.

## Summary

- Adds a minimal `CONTRIBUTING.md` covering how to file issues, PR requirements (tests, style checks, security basics), and a pointer to `AGENTS.md` for code conventions
- Adds one sub-bullet to the periodic health review checklist: catch untriaged issues missing a label, milestone, or assignee

## What's not included

Per issue discussion: no triage section in AGENTS.md, no session-start routine change, no SLA guidance — all premature without real external traffic.
