### PR TITLE
fix: suppress CodeQL clear-text-logging finding for intentional secret disclosure

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -341,7 +341,7 @@ def _start_webhook_server() -> None:
   if not secret:
     secret = secrets.token_urlsafe(32)
     _config_mod.write_section_values('webhook', {'secret': secret})
-    print(
+    print(  # lgtm[py/clear-text-logging-sensitive-data]
       f'Webhook secret generated and saved to config.toml:\n'
       f'  {secret}\n'
       f'Copy this into your webhook sender (Plex, Shortcuts, etc.).'


### PR DESCRIPTION
## Summary

- Suppresses the CodeQL `py/clear-text-logging-sensitive-data` (high) alert introduced in #176
- Adds `CodeQL` as a required status check in the branch ruleset so future high-severity findings block merge

## Rationale for the suppression

The webhook secret is intentionally printed once to stdout on first startup so the user can copy it into their webhook sender. This is a deliberate first-run UX decision — without it, the user has no way to learn their auto-generated secret without opening `config.toml`. The pattern is standard practice (Grafana, HashiCorp Vault, and others all print generated credentials on first run).

This is not an accidental leak: the secret is freshly generated, printed exactly once, and persisted to `config.toml`. The `# lgtm` annotation documents this rationale inline.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest -q` — 241 passed
- [x] CodeQL alert should resolve on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
