### PR TITLE
chore: remove stale lgtm suppression comment

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -339,7 +339,7 @@ def _start_webhook_server() -> None:
   if not secret:
     secret = secrets.token_urlsafe(32)
     _config_mod.write_section_values('webhook', {'secret': secret})
-    print(  # lgtm[py/clear-text-logging-sensitive-data]
+    print(
       f'Webhook secret generated and saved to config.toml:\n'
       f'  {secret}\n'
       f'Copy this into your webhook sender (Plex, Shortcuts, etc.).'


### PR DESCRIPTION
## Summary

- Removes the stale `# lgtm[py/clear-text-logging-sensitive-data]` comment from `scheduler.py:343`
- The LGTM suppression syntax has no effect in CodeQL; the alert has been dismissed directly via the GitHub API with a won't-fix justification (intentional disclosure on first startup so the user can copy the generated secret into their webhook sender)

## Test plan

- [x] No logic changes; checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
