### PR TITLE
fix(trakt): skip already-aired episodes in calendar next-airing logic

### DIFF
--- a/integrations/trakt.py
+++ b/integrations/trakt.py
@@ -22,7 +22,7 @@
 
 import threading
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 import requests
 
@@ -243,8 +243,15 @@ def get_variables_calendar() -> dict[str, list[list[str]]]:
   if not entries:
     raise IntegrationDataUnavailableError('No upcoming episodes in calendar window')
 
-  entries.sort(key=lambda e: e['first_aired'])
-  entry = entries[0]
+  now = datetime.now(timezone.utc)
+  future_entries = [
+    e for e in entries if e.get('first_aired') and datetime.fromisoformat(e['first_aired'].replace('Z', '+00:00')) > now
+  ]
+  if not future_entries:
+    raise IntegrationDataUnavailableError('No upcoming episodes in calendar window')
+
+  future_entries.sort(key=lambda e: e['first_aired'])
+  entry = future_entries[0]
 
   show_name = entry['show']['title'].upper()
   ep = entry['episode']


### PR DESCRIPTION
— *Claude Code*

## Summary

- `get_variables_calendar()` was picking the episode with the earliest `first_aired` after sorting, but not filtering out episodes that had already aired
- The Trakt calendar API returns entries by **calendar date** (today onward), not by whether `first_aired` is in the future — so a show that aired at 2am UTC is still returned when the integration runs at 10pm UTC
- This caused the display to show "NEXT AIRING: SHRINKING S3E5 TUE 18:00" (already aired) instead of the genuinely next upcoming show (Jujutsu Kaisen on Thursday)

## Fix

Filter `entries` to `first_aired > now(UTC)` before sorting and selecting. If all entries in the window have already aired, raise `IntegrationDataUnavailableError` as usual.

Added two new tests:
- `test_get_variables_calendar_all_past_raises_unavailable` — all entries past → unavailable
- `test_get_variables_calendar_skips_past_entries` — mixed past+future → returns first future entry

Fixes #180

## Test plan

- [x] `uv run pytest tests/core/test_trakt.py` — 34 passed
- [x] `uv run pytest tests/` — 257 passed
- [x] `uv run ruff check .` and `ruff format --check .` — clean
- [x] `uv run pyright` and `uv run bandit` — clean
- [x] Live API call confirmed: returns Jujutsu Kaisen (next future episode) instead of Shrinking S3E5 (already aired)
