### PR TITLE
chore: bump version to 0.12.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.12.0"
+version = "0.12.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [


### PR DESCRIPTION
— *Claude Code*

Patch release for the trakt calendar past-episode fix (#180/#181). Version bump was missed in the fix PR.

Fixes the missing release from #181.