### PR TITLE
fix(trakt): zero-pad air_time hour; add content/README.md to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,9 +410,13 @@ doc, add a row to the table in `content/README.md`.
 ## Content Design
 
 When writing or reviewing content JSON, integration format strings, or
-template output, consult and follow `content/DESIGN.md`. This covers
-layout, color use, tone, character set, time formatting, and the
-pre-ship checklist.
+template output, consult and follow both content docs:
+
+- `content/README.md` — content author reference: JSON format, priority
+  guidelines (0–10 scale with tier definitions), `timeout` pairing rules,
+  schedule overrides, and the contrib integrations table
+- `content/DESIGN.md` — visual/design conventions: layout, color use,
+  tone, character set, time formatting, and the pre-ship checklist
 
 ## Code Conventions
 

--- a/integrations/trakt.py
+++ b/integrations/trakt.py
@@ -263,7 +263,7 @@ def get_variables_calendar() -> dict[str, list[list[str]]]:
   aired_dt = datetime.fromisoformat(entry['first_aired'].replace('Z', '+00:00'))
   local_dt = aired_dt.astimezone(_config_mod.get_timezone())
   air_day = local_dt.strftime('%a').upper()[:3]
-  air_time = f'{local_dt.hour}:{local_dt.minute:02d}'
+  air_time = f'{local_dt.hour:02d}:{local_dt.minute:02d}'
 
   return {
     'show_name': [[show_name]],

--- a/tests/core/test_trakt.py
+++ b/tests/core/test_trakt.py
@@ -356,7 +356,7 @@ def test_get_variables_calendar_returns_expected_vars(
   assert result['episode_ref'] == [['S2E5']]
   assert result['episode_title'] == [['ONE WITH THE TEST']]
   assert 'air_day' in result
-  assert re.match(r'^\d+:\d{2}$', result['air_time'][0][0])
+  assert re.match(r'^\d{2}:\d{2}$', result['air_time'][0][0])
 
 
 def test_get_variables_calendar_empty_raises_unavailable(

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Changes

**Bug fix — trakt air_time zero-padding (#183)**
- `air_time` was formatted as `H:MM` (e.g. `7:26`) instead of `HH:MM` (`07:26`), violating the DESIGN.md 24-hour zero-padded time requirement
- Fixed: `f'{local_dt.hour:02d}:{local_dt.minute:02d}'`
- Test regex tightened from `\d+:\d{2}` to `\d{2}:\d{2}` to catch regressions

**Docs — content/README.md pointer in AGENTS.md (#183)**
- Added `content/README.md` alongside `content/DESIGN.md` in the Content Design section, with a one-line summary of what each doc covers (format/priority guidelines vs. visual/design conventions)

## Test plan

- [x] `uv run pytest tests/core/test_trakt.py` — 34 passed
- [x] `uv run pytest tests/` — full suite clean
- [x] `uv run ruff check/format`, `pyright`, `bandit` — all clean