### PR TITLE
chore: bump version to 0.12.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.12.1"
+version = "0.12.2"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [


### PR DESCRIPTION
— *Claude Code*

Patch release for the trakt air_time zero-padding fix (#183/#184). Version bump was missed in the fix PR.