### PR TITLE
feat(scheduler): priority-based hold interruption with global min_hold

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -19,6 +19,12 @@
 # stems: ["bart", "trakt"]. Omit or leave empty to disable all contrib content.
 # content_enabled = ["*"]
 
+# Global minimum hold (seconds). Every message is guaranteed to display for at
+# least this long before a queued high-priority message (priority >= 8) can
+# interrupt it. Set to 0 to disable the floor (not recommended for physical
+# displays — flaps need time to settle). Default: 60.
+# min_hold = 60
+
 [vestaboard]
 # Read/Write API key from https://store.vestaboard.com/pages/read-write-api
 api_key = "your-vestaboard-read-write-api-key"

--- a/content/README.md
+++ b/content/README.md
@@ -116,8 +116,8 @@ runs — only which queued message the display shows first.
 |---|---|---|
 | Background | 0–2 | Ambient/decorative content. Pair with a short `timeout` so stale messages drop silently rather than showing late. |
 | Default | 3–5 | Normal scheduled content — daily quotes, weather, calendar items. Most templates should live here. |
-| Elevated | 6–7 | Time-sensitive but not urgent — transit departures, reminders. |
-| High | 8–9 | Alerts and time-critical events where the user should see it promptly — countdowns, imminent departures, notifications. |
+| Elevated | 6–7 | Time-sensitive but not urgent — transit departures, reminders. Gets priority position in the queue but does not interrupt an active hold. |
+| High | 8–9 | Alerts and time-critical events where the user should see it promptly — countdowns, imminent departures, notifications. **After the global `min_hold` floor, a High message waiting in the queue will interrupt the current display if it has a lower-priority hold in progress.** |
 | Maximum | 10 | Reserved for a single "always wins" template. Avoid using broadly — once multiple templates share the same level, tie-breaking falls back to scheduling order. |
 
 Rules of thumb:

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.12.1"
+version = "0.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- After a configurable global minimum hold (`[scheduler].min_hold`, default 60s), a queued **High-priority** message (priority ≥ 8) will interrupt an active hold on a lower-priority message
- High-priority messages always run their full hold and are never themselves interrupted
- Webhook `interrupt=True` continues to fire immediately regardless of `min_hold`

## Design

`_do_hold()` replaces the two-line hold in `worker()`. It polls at 1-second intervals and, after `min_hold` has elapsed, peeks the queue head (`with _queue.mutex: _queue.queue[0]`) — exiting early if the waiting item meets the threshold. The peek uses CPython's internal heap lock, which is the canonical thread-safe approach.

`_INTERRUPT_PRIORITY_THRESHOLD = 8` aligns with `content/README.md`'s "High" tier (8–9), matching the stated intent there — Elevated (6–7) items get queue priority but don't cut holds short.

## Files changed

- `scheduler.py` — `_do_hold()`, `_get_min_hold()`, constants; `worker()` delegates to `_do_hold()`
- `config.example.toml` — `min_hold` documented under `[scheduler]`
- `content/README.md` — High tier description updated to describe interrupt behaviour

## Test plan

- [x] 6 new tests in `test_scheduler.py`: full-duration hold, webhook interrupt, priority-based early exit, min_hold floor, high-priority-current-no-interrupt, below-threshold-no-interrupt
- [x] `uv run pytest tests/` — 263 passed
- [x] Full check suite clean

Closes #151
