### PR TITLE
chore: bump version to 0.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.12.2"
+version = "0.13.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [


### PR DESCRIPTION
— *Claude Code*

Minor release for priority-based hold interruption (#151/#186). Should have been in the feature PR — version bumps will be included inline going forward.