### PR TITLE
feat(scheduler): periodic content refresh during hold for integration templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,8 @@ for a physical split-flap device whose flaps need time to settle.
       "schedule": {
         "cron": "0 8 * * *",  // standard 5-field cron expression
         "hold": 600,  // seconds to show before pulling next
-        "timeout": 600  // seconds message can wait before discarding
+        "timeout": 600,  // seconds message can wait before discarding
+        "refresh_interval": 60  // optional: re-fetch integration data every N seconds during hold (min 30; integration templates only)
       },
       "priority": 5,           // integer 0–10; higher number = higher priority
       "public": true,          // if false, skipped when running with --public

--- a/config.example.toml
+++ b/config.example.toml
@@ -53,6 +53,7 @@ line1_dest = "DALY"
 # hold = 290
 # timeout = 60
 # priority = 8
+# refresh_interval = 60  # re-fetch departure times every 60s during the hold (min 30)
 
 [webhook]
 # Optional: enable the HTTP webhook listener so external systems (Plex,

--- a/content/contrib/bart.json
+++ b/content/contrib/bart.json
@@ -4,7 +4,8 @@
       "schedule": {
         "cron": "*/5 7-9 * * 1-5",
         "hold": 290,
-        "timeout": 60
+        "timeout": 60,
+        "refresh_interval": 60
       },
       "priority": 8,
       "public": true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.13.0"
+version = "0.14.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.12.2"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- Adds optional `refresh_interval` field to the `schedule` block of integration templates; the worker re-calls `get_variables()` every N seconds during a hold and re-sends to the display only when content changes
- Enforces a 30s minimum floor via `_validate_template()`; supports schedule overrides via `config.toml`
- Enables `refresh_interval: 60` on the BART departures template so departure times stay accurate across the 290s hold
- 27 new tests covering validation, `_do_hold` refresh behaviour, worker closure setup, and `_load_file` propagation/overrides
- Bumps version to 0.14.0

Closes #152

## Test plan

- [ ] All 277 unit tests pass (`uv run pytest`)
- [ ] Full check suite passes (ruff, pyright, bandit, pip-audit)
- [ ] `bart.json` parses and loads cleanly with new `refresh_interval` field
- [ ] CI check + docker jobs pass on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
