### PR TITLE
feat(webhook): accept secret as ?secret= query param for Plex/headerless senders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,7 +204,9 @@ The webhook listener is activated by adding a `[webhook]` section to
 `config.toml` (see `config.example.toml`). It binds to `127.0.0.1:8080` by
 default. A shared secret is auto-generated on first startup if not configured;
 check the startup log to copy it into your webhook sender. Endpoint:
-`POST /webhook/<integration>` with `X-Webhook-Secret: <secret>` header.
+`POST /webhook/<integration>` — secret accepted as `X-Webhook-Secret: <secret>`
+header (preferred) or `?secret=<secret>` query parameter (for senders like Plex
+that cannot set custom headers).
 
 When adding a new webhook-capable integration, also add its name to
 `_KNOWN_INTEGRATIONS` in `scheduler.py`.

--- a/config.example.toml
+++ b/config.example.toml
@@ -67,9 +67,11 @@ line1_dest = "DALY"
 #
 # port = 8080
 # secret is auto-generated on first startup if omitted — check logs for the
-# value and copy it into your webhook sender.
+# value and copy it into your webhook sender (as ?secret= in the URL, or via
+# X-Webhook-Secret header if your sender supports custom headers).
 # secret = "..."
-# Bind to 0.0.0.0 to accept connections from outside localhost (e.g. Docker).
+# Bind to 0.0.0.0 to accept connections from outside localhost (e.g. Docker/Unraid).
+# Unraid: the template maps container port 8080 → host port 32800 by default.
 # Requires a TLS-terminating reverse proxy for external webhook sources.
 # bind = "0.0.0.0"
 

--- a/unraid/e-note-ion.xml
+++ b/unraid/e-note-ion.xml
@@ -44,4 +44,15 @@
     Display="always"
     Required="false"
     Mask="false"/>
+
+  <Config
+    Name="Webhook port"
+    Target="8080"
+    Default="32800"
+    Mode="tcp"
+    Description="Optional. Host port for the HTTP webhook listener (used by Plex and other push integrations). Only takes effect if [webhook] is enabled in config.toml with bind = &quot;0.0.0.0&quot;. The container always listens on 8080 internally; this maps it to a host port. 32800 is the recommended default to avoid conflicts with other common services on 8080."
+    Type="Port"
+    Display="advanced"
+    Required="false"
+    Mask="false"/>
 </Container>


### PR DESCRIPTION
— *Claude Code*

Closes #196.

## Summary

- Webhook handler now accepts the shared secret as a `?secret=` query parameter in addition to the `X-Webhook-Secret` header. This lets Plex (and any other sender that can't set custom headers) post directly to the scheduler without a proxy.
- `X-Webhook-Secret` header still works and takes precedence when both are provided.
- Unraid template gains a webhook port mapping (container `8080` → host `32800`) so the listener is accessible from Plex out of the box.
- `plex.md` webhook setup section rewritten with Unraid-native instructions.
- `config.example.toml` updated with query-param and Unraid port notes.

## Test plan

- [x] `test_query_param_secret_accepted` — secret in `?secret=` accepted
- [x] `test_query_param_wrong_secret_returns_401` — wrong query param rejected
- [x] `test_header_takes_precedence_over_query_param` — correct header + wrong query param → 200
- [x] Existing secret tests unchanged and passing
- [x] 308 tests pass; full check suite clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
