### PR TITLE
chore: bump version to 0.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.15.0"
+version = "0.16.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
PR #197 (feat/webhook-query-secret) modified `scheduler.py` — a release-worthy change per the versioning rules in AGENTS.md — but the version bump was missed. This catches up to 0.16.0 to trigger a Docker image release including the `?secret=` query param support.

— *Claude Code*