### PR TITLE
fix(bart): right-align minute values to 2 chars for column alignment

### DIFF
--- a/integrations/bart.py
+++ b/integrations/bart.py
@@ -103,11 +103,16 @@ def _no_service_line(dest_abbr: str, color_map: dict[str, list[str]]) -> str:
 
 
 def _format_minutes(mins: str) -> str:
-  """Convert a BART API minutes string to a short display string."""
+  """Convert a BART API minutes string to a short display string.
+
+  Numeric minutes are right-aligned in a 2-character field so departure
+  times align in column when two lines are shown side by side on the board.
+  E.g. ' 5' and '12' rather than '5' and '12'.
+  """
   if mins in ('Leaving', '0'):
     return 'Now'
   try:
-    return str(int(mins))
+    return f'{int(mins):>2}'
   except ValueError:
     return mins
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.16.0"
+version = "0.16.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_bart.py
+++ b/tests/core/test_bart.py
@@ -52,6 +52,29 @@ def _mock_etd(dest: str = 'DALY', minutes: str = '5', color: str = 'GREEN') -> M
   return mock
 
 
+# --- _format_minutes ---
+
+
+def test_format_minutes_single_digit_right_aligned() -> None:
+  assert bart._format_minutes('5') == ' 5'
+
+
+def test_format_minutes_double_digit_unchanged() -> None:
+  assert bart._format_minutes('12') == '12'
+
+
+def test_format_minutes_leaving_returns_now() -> None:
+  assert bart._format_minutes('Leaving') == 'Now'
+
+
+def test_format_minutes_zero_returns_now() -> None:
+  assert bart._format_minutes('0') == 'Now'
+
+
+def test_format_minutes_non_numeric_passthrough() -> None:
+  assert bart._format_minutes('unknown') == 'unknown'
+
+
 # --- get_variables ---
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.16.0"
+version = "0.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
When two departure lines are displayed, single-digit and double-digit minute values weren't column-aligned, making the board look uneven. For example:

```
[G] MILPITAS DEPARTS
[G]  8 14 31
[B]  5 10 25
```

…would previously render as:

```
[G]  8 14 31
[B] 5 10 25
```

## Change

`_format_minutes()` now right-aligns numeric minutes in a 2-character field (`f'{n:>2}'`), so `'5'` → `' 5'` and `'12'` stays `'12'`. The first time slot in each row now starts at the same column position regardless of digit count.

- Applies to both Note (15 cols) and Flagship (22 cols) — fix is in the shared formatting helper
- `'Now'` (Leaving/0) is unchanged at 3 chars (acceptable edge case)

## Tests

- `test_format_minutes_single_digit_right_aligned` — `'5'` → `' 5'`
- `test_format_minutes_double_digit_unchanged` — `'12'` → `'12'`
- `test_format_minutes_leaving_returns_now` and `test_format_minutes_zero_returns_now` — existing behaviour preserved
- `test_format_minutes_non_numeric_passthrough` — passthrough preserved

Closes #194

— *Claude Code*
