### PR TITLE
fix(webhook): parse multipart/form-data body for Plex integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.16.2"
+version = "0.16.3"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.16.2"
+version = "0.16.3"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Plex sends webhooks as `multipart/form-data` with the JSON event inside a field named `payload`. The handler was calling `json.loads(body)` directly on the raw multipart body, which fails with `json.JSONDecodeError` → 400 "Invalid JSON". The Plex integration was completely non-functional as a result.

## Fix

Detect `Content-Type: multipart/form-data`, parse with `email.parser.BytesParser`, extract the `payload` part, then `json.loads` its content. All other integrations continue to receive raw JSON bodies unchanged.

## Tests

- `test_multipart_payload_field_is_parsed_as_json` — Plex-style multipart body is unwrapped and the parsed dict is passed to `handle_webhook`
- `test_multipart_missing_payload_field_returns_400` — multipart without a `payload` field returns 400
- `test_multipart_invalid_json_in_payload_returns_400` — multipart with malformed JSON in the payload field returns 400

Closes #203

— *Claude Code*
