### PR TITLE
fix(plex): include S/E reference in episode display

### DIFF
--- a/content/contrib/plex.json
+++ b/content/contrib/plex.json
@@ -15,7 +15,7 @@
           "format": [
             "[O] NOW PLAYING",
             "{show_name}",
-            "{episode_detail}"
+            "{episode_line}"
           ]
         }
       ]
@@ -35,7 +35,7 @@
           "format": [
             "[O] PAUSED",
             "{show_name}",
-            "{episode_detail}"
+            "{episode_line}"
           ]
         }
       ]

--- a/content/contrib/plex.md
+++ b/content/contrib/plex.md
@@ -125,13 +125,13 @@ Only video media is displayed — music and photo events return no message.
 ```
 [O] NOW PLAYING
 SHOW NAME
-EPISODE TITLE
+S3E3 EPISODE TITLE
 ```
 
 - Row 1: `[O]` (orange, Plex brand color) + mode label
 - Row 2: Show name (for episodes) or movie title (for movies)
-- Row 3: Episode title, with leading articles stripped (A, An, The)
-  For movies, row 3 is blank.
+- Row 3: Season/episode reference + episode title (e.g. `S3E3 BEEF`), truncated
+  with ellipsis if too long. For movies, row 3 is blank.
 
 Leading articles are stripped from episode titles only. Show names and
 movie titles are preserved as-is: "THE BEAR" stays "THE BEAR", but the

--- a/integrations/plex.py
+++ b/integrations/plex.py
@@ -106,10 +106,12 @@ def handle_webhook(payload: dict[str, Any]) -> WebhookMessage | None:
       show_name = metadata['grandparentTitle'].upper()
       episode_ref = f'S{metadata["parentIndex"]}E{metadata["index"]}'
       episode_detail = _strip_leading_article((metadata.get('title') or '').upper())
+      episode_line = f'{episode_ref} {episode_detail}'.strip()
     elif media_type == 'movie':
       show_name = metadata['title'].upper()
       episode_ref = ''
       episode_detail = ''
+      episode_line = ''
     else:
       return None
 
@@ -121,8 +123,7 @@ def handle_webhook(payload: dict[str, Any]) -> WebhookMessage | None:
         'templates': cfg['templates'],
         'variables': {
           'show_name': [[show_name]],
-          'episode_ref': [[episode_ref]],
-          'episode_detail': [[episode_detail]],
+          'episode_line': [[episode_line]],
         },
         'truncation': cfg['truncation'],
       },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.16.3"
+version = "0.16.4"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_plex.py
+++ b/tests/core/test_plex.py
@@ -124,35 +124,31 @@ def test_handle_webhook_missing_metadata_returns_none() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_handle_webhook_movie_has_empty_episode_detail() -> None:
+def test_handle_webhook_movie_has_empty_episode_line() -> None:
   result = _plex.handle_webhook(_movie_payload('media.play', 'Inception'))
   assert result is not None
   variables = result.data['variables']
-  assert variables['episode_detail'] == [['']]
+  assert variables['episode_line'] == [['']]
   assert variables['show_name'] == [['INCEPTION']]
 
 
-def test_handle_webhook_movie_has_empty_episode_ref() -> None:
-  result = _plex.handle_webhook(_movie_payload('media.play', 'Inception'))
-  assert result is not None
-  assert result.data['variables']['episode_ref'] == [['']]
-
-
 # ---------------------------------------------------------------------------
-# Article stripping (episode titles only)
+# episode_line formatting and article stripping
 # ---------------------------------------------------------------------------
 
 
-def test_handle_webhook_episode_strips_article_from_episode_title() -> None:
+def test_handle_webhook_episode_line_includes_season_episode_ref() -> None:
+  """episode_line must include the S/E reference so it appears on the board."""
   result = _plex.handle_webhook(_episode_payload('media.play', title='The Beef'))
   assert result is not None
-  assert result.data['variables']['episode_detail'] == [['BEEF']]
+  # parentIndex=2, index=1 → S2E1; article stripped from title → BEEF
+  assert result.data['variables']['episode_line'] == [['S2E1 BEEF']]
 
 
-def test_handle_webhook_episode_strips_a_article() -> None:
+def test_handle_webhook_episode_strips_a_article_in_episode_line() -> None:
   result = _plex.handle_webhook(_episode_payload('media.play', title='A New Hope'))
   assert result is not None
-  assert result.data['variables']['episode_detail'] == [['NEW HOPE']]
+  assert result.data['variables']['episode_line'] == [['S2E1 NEW HOPE']]
 
 
 def test_handle_webhook_show_name_preserves_article() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.16.3"
+version = "0.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
The integration already built `episode_ref = 'S3E3'` correctly, but `plex.json` only referenced `{episode_detail}` (the raw episode title) in row 3. When Plex metadata has a generic title like "Episode 3", that's all that appeared on the board — no season/episode context.

## Change

Combine `episode_ref` and `episode_detail` into a single `episode_line` variable in the integration:
- Episodes: `'S3E3 TITLE'` (or just `'S3E3'` if no episode title)
- Movies: `''` — blank row, no stray space from joining two empty strings

The template now uses `{episode_line}` in row 3 for both `now_playing` and `paused`.

## Tests

- `test_handle_webhook_episode_line_includes_season_episode_ref` — verifies `episode_line` = `'S2E1 BEEF'` for an episode with article-stripped title
- `test_handle_webhook_movie_has_empty_episode_line` — verifies movies get `''` not `' '`

Closes #205

— *Claude Code*
