### PR TITLE
fix(scheduler): DuplicateContentError must fall through to hold, not skip it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.16.4"
+version = "0.16.5"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -288,8 +288,9 @@ def worker() -> None:
     except IntegrationDataUnavailableError:
       continue  # expected empty state — skip silently
     except vestaboard.DuplicateContentError:
-      print('Duplicate content, skipping.')
-      continue
+      print(f'Duplicate content for {message.name} — already on board, still holding.')
+      # Fall through to _do_hold(): content is already showing; we must still
+      # hold it so lower-priority queued messages cannot preempt it.
     except vestaboard.BoardLockedError as e:
       print(f'Board locked: {e}. Retrying in {_LOCK_RETRY_DELAY}s.')
       time.sleep(_LOCK_RETRY_DELAY)

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.16.4"
+version = "0.16.5"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
When `set_state()` raises `DuplicateContentError`, the worker was doing `continue`, skipping `_do_hold()` entirely. This caused a priority inversion when Plex re-sends `media.play` (which it does on stream verification):

1. Plex `media.play` → board shows NOW PLAYING (indefinite hold, priority 8)
2. Plex re-sends `media.play` → `_hold_interrupt` set → first hold exits → new plex message enqueued
3. Second plex message: `set_state()` → `DuplicateContentError` → old code: `continue`, hold skipped
4. trakt.watching (priority 7) next in queue → immediately displayed, overwriting now-playing

## Fix

Fall through to `_do_hold()` on `DuplicateContentError`. The content is already on the board; we still need to hold it so the priority queue is respected.

## Test

`test_worker_still_holds_on_duplicate_content` — asserts `_do_hold` is called even when `set_state` raises `DuplicateContentError`. Updates the previous test which asserted the wrong (skip) behaviour.

Closes #207

— *Claude Code*
