### PR TITLE
feat(scheduler): add supersede_tag to invalidate stale same-source queue messages

### DIFF
--- a/integrations/plex.py
+++ b/integrations/plex.py
@@ -132,6 +132,7 @@ def handle_webhook(payload: dict[str, Any]) -> WebhookMessage | None:
       timeout=cfg['timeout'],
       indefinite=True,
       interrupt=True,
+      supersede_tag='plex',
     )
   except Exception as e:  # noqa: BLE001
     print(f'Plex webhook error: {e}')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.16.5"
+version = "0.16.6"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_plex.py
+++ b/tests/core/test_plex.py
@@ -180,3 +180,26 @@ def test_handle_webhook_applies_config_override(monkeypatch: pytest.MonkeyPatch)
   assert result is not None
   assert result.hold == 7200
   assert result.priority == 9
+
+
+# ---------------------------------------------------------------------------
+# supersede_tag
+# ---------------------------------------------------------------------------
+
+
+def test_handle_webhook_play_has_supersede_tag() -> None:
+  result = _plex.handle_webhook(_episode_payload('media.play'))
+  assert result is not None
+  assert result.supersede_tag == 'plex'
+
+
+def test_handle_webhook_pause_has_supersede_tag() -> None:
+  result = _plex.handle_webhook(_episode_payload('media.pause'))
+  assert result is not None
+  assert result.supersede_tag == 'plex'
+
+
+def test_handle_webhook_stop_has_no_supersede_tag() -> None:
+  result = _plex.handle_webhook({'event': 'media.stop'})
+  assert result is not None
+  assert result.supersede_tag == ''

--- a/tests/core/test_webhook.py
+++ b/tests/core/test_webhook.py
@@ -344,6 +344,7 @@ def test_handle_webhook_result_enqueues_message() -> None:
           timeout=60,
           name='test.webhook',
           indefinite=False,
+          supersede_tag='',
         )
       finally:
         server.shutdown()

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.16.5"
+version = "0.16.6"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Adds `supersede_tag` field to `WebhookMessage` and `QueuedMessage`
- When `enqueue()` is called with a non-empty `supersede_tag`, any existing messages in the queue with the same tag are atomically removed before the new one is inserted
- Plex integration sets `supersede_tag='plex'` on all play/pause messages, so a resume event always supersedes a stale paused message (and vice versa)

Fixes the race condition where pausing, having a higher-priority cron job preempt the paused message, then resuming would leave the stale "PAUSED" message in the queue — causing it to display after playback had already resumed.

Closes #210

## Test plan

- [x] `test_enqueue_supersede_tag_removes_earlier_same_tagged` — tagged enqueue removes prior same-tagged messages
- [x] `test_enqueue_supersede_tag_leaves_other_tags_intact` — untagged and differently-tagged messages are unaffected
- [x] `test_handle_webhook_play_has_supersede_tag` — play returns `supersede_tag='plex'`
- [x] `test_handle_webhook_pause_has_supersede_tag` — pause returns `supersede_tag='plex'`
- [x] `test_handle_webhook_stop_has_no_supersede_tag` — stop (interrupt_only) has no tag
- [x] Existing webhook enqueue test updated for new parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
