### PR TITLE
feat(scheduler): print version on startup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.16.6"
+version = "0.16.7"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -18,6 +18,7 @@ import email.message
 import email.parser
 import heapq
 import importlib
+import importlib.metadata
 import json
 import secrets
 import sys
@@ -764,7 +765,8 @@ def main() -> None:
     extras.append('public mode')
   if not extras:
     extras.append('user content only')
-  print(f'Starting e-note-ion — {board_desc}, {", ".join(extras)}')
+  version = importlib.metadata.version('e-note-ion')
+  print(f'Starting e-note-ion v{version} — {board_desc}, {", ".join(extras)}')
 
   print('Current message:')
   try:

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -706,6 +706,25 @@ def test_main_note_startup_banner(monkeypatch: pytest.MonkeyPatch, capsys: pytes
   assert 'Note (3×15)' in out
 
 
+def test_main_version_in_banner(capsys: pytest.CaptureFixture[str]) -> None:
+  mock_sched = _mock_sched()
+  with (
+    patch.object(_mod, '_validate_startup'),
+    patch('config.load_config'),
+    patch('config.get_model', return_value='note'),
+    patch('config.get_public_mode', return_value=False),
+    patch('config.get_content_enabled', return_value=set()),
+    patch.object(_mod, 'load_content'),
+    patch('integrations.vestaboard.get_state', return_value=MagicMock(__str__=lambda s: '')),
+    patch('threading.Thread'),
+    patch('apscheduler.schedulers.background.BackgroundScheduler', return_value=mock_sched),
+    patch('time.sleep', side_effect=KeyboardInterrupt),
+    patch('importlib.metadata.version', return_value='1.2.3'),
+  ):
+    _mod.main()
+  assert 'v1.2.3' in capsys.readouterr().out
+
+
 def test_main_flagship_sets_model_and_banner(
   monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.16.6"
+version = "0.16.7"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Reads the installed package version via `importlib.metadata.version` at startup
- Includes it in the startup banner: `Starting e-note-ion v0.16.7 — Note (3×15), ...`
- Version is now visible in container logs without inspecting the image

Closes #209

## Test plan

- [x] `test_main_version_in_banner` — verifies the version string appears in startup output

🤖 Generated with [Claude Code](https://claude.com/claude-code)