### PR TITLE
feat(scheduler): continue refresh_interval updates after hold expires when board is idle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.16.7"
+version = "0.17.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.16.7"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Introduces idle refresh state in the `worker()` loop: after `_do_hold()` returns for an integration message with `refresh_interval`, the refresh fn is transferred to idle state so the display keeps updating while the queue is empty
- Idle refresh fires immediately on the first loop iteration after hold expires (`_idle_last_refresh = 0.0`), then on every subsequent iteration where `refresh_interval` seconds have elapsed
- Idle state is cleared as soon as a new message is successfully sent (including `DuplicateContentError` fall-through); errors from the idle refresh fn are logged and the loop continues
- Non-integration messages and messages without `refresh_interval` are unaffected

## Test plan

- [x] `test_worker_idle_refresh_called_after_hold_expires` — hold returns, queue empty, set_state called for idle refresh
- [x] `test_worker_idle_refresh_cleared_on_new_send` — idle refresh active, new message sent, idle refresh not called after
- [x] `test_worker_idle_refresh_error_logged_and_continues` — idle refresh fn raises, error logged, loop continues
- [x] `test_worker_idle_refresh_not_set_for_non_integration_message` — static message, no idle refresh after hold
- [x] Full test suite (326 tests passing)
- [x] All checks passing (ruff, pyright, bandit, pip-audit)

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)
