### PR TITLE
chore: docs audit — fix stale content, add missing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Key `[scheduler]` settings:
 | `public` | `false` | Skip templates marked `public = false` (for shared spaces) |
 | `content_enabled` | _(absent)_ | Contrib content to enable: `["*"]` for all, or `["bart", "trakt"]` for specific stems |
 | `timezone` | system TZ | IANA timezone for cron job scheduling (e.g. `"America/Los_Angeles"`) |
+| `min_hold` | `60` | Minimum seconds any message stays on display before a high-priority (≥8) queued message can interrupt it. Set to `0` to disable (not recommended for physical displays). |
 
 ## Running directly
 
@@ -221,5 +222,8 @@ Required keys:
 |---|---|
 | `VESTABOARD_VIRTUAL_API_KEY` | [web.vestaboard.com](https://web.vestaboard.com) → Developer → Virtual Boards |
 | `BART_API_KEY` | [api.bart.gov/api/register.aspx](https://api.bart.gov/api/register.aspx) |
+| `TRAKT_CLIENT_ID` | [trakt.tv/oauth/applications](https://trakt.tv/oauth/applications) → your app |
+| `TRAKT_CLIENT_SECRET` | same app page |
+| `TRAKT_ACCESS_TOKEN` | run Trakt auth flow once and copy from `config.toml` |
 
 `.env` is git-ignored — never commit it.

--- a/content/README.md
+++ b/content/README.md
@@ -6,14 +6,14 @@ board. Restart the scheduler to pick up changes.
 ## Directories
 
 - **`contrib/`** — bundled community-contributed content, disabled by default.
-  Enable files by stem using `--content-enabled` (or the `CONTENT_ENABLED` env var):
-  ```bash
-  python scheduler.py --content-enabled bart        # enable one file
-  python scheduler.py --content-enabled bart,other  # enable multiple
-  python scheduler.py --content-enabled '*'         # enable all
+  Enable files by setting `content_enabled` in `config.toml` under `[scheduler]`:
+  ```toml
+  content_enabled = ["bart"]   # enable one file
+  content_enabled = ["bart", "trakt"]  # enable multiple
+  content_enabled = ["*"]      # enable all
   ```
   To contribute content, open a pull request adding a `.json` file and a
-  companion `.md` doc (see template in `CLAUDE.md`).
+  companion `.md` doc (see template in `content/contrib/TEMPLATE.md`).
 
 - **`user/`** — your personal content. Files placed here are always loaded
   automatically — no opt-in needed. This directory is git-ignored so personal


### PR DESCRIPTION
— *Claude Code*

## Summary

- **`content/README.md`**: Replaced non-existent `--content-enabled` CLI flag (and `CONTENT_ENABLED` env var) with correct `config.toml` TOML syntax; fixed template sidecar pointer (`CLAUDE.md` → `content/contrib/TEMPLATE.md`)
- **`AGENTS.md`**: Added Trakt env vars to integration test section and health review checklist; clarified CodeQL runs as GitHub's built-in code scanning (not a `ci.yml` job); added `supersede_tag` to `WebhookMessage` docs with explanation; documented idle refresh as step 4 in How It Works; moved version bump + `uv.lock` discipline from project MEMORY.md into execution step 3
- **`README.md`**: Added `min_hold` to `[scheduler]` config table; added Trakt keys to integration tests required keys table

## Test plan

- [ ] Docs-only changes — no code modified, no tests needed
- [ ] CI `check` and `docker` jobs pass
