### PR TITLE
fix(plex,trakt): truncate show names to one row to preserve episode line

### DIFF
--- a/integrations/plex.py
+++ b/integrations/plex.py
@@ -21,6 +21,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+import integrations.vestaboard as _vb
 from scheduler import WebhookMessage
 
 _PLEX_JSON_PATH = Path(__file__).parent.parent / 'content' / 'contrib' / 'plex.json'
@@ -117,6 +118,7 @@ def handle_webhook(payload: dict[str, Any]) -> WebhookMessage | None:
 
     template_name = 'paused' if event == _PAUSE_EVENT else 'now_playing'
     cfg = _load_template_config(template_name)
+    show_name = _vb.truncate_line(show_name, _vb.model.cols, cfg['truncation'])
 
     return WebhookMessage(
       data={

--- a/integrations/trakt.py
+++ b/integrations/trakt.py
@@ -26,6 +26,7 @@ from datetime import datetime, timezone
 
 import requests
 
+import integrations.vestaboard as _vb
 from exceptions import IntegrationDataUnavailableError
 
 _TRAKT_API_BASE = 'https://api.trakt.tv'
@@ -253,7 +254,7 @@ def get_variables_calendar() -> dict[str, list[list[str]]]:
   future_entries.sort(key=lambda e: e['first_aired'])
   entry = future_entries[0]
 
-  show_name = entry['show']['title'].upper()
+  show_name = _vb.truncate_line(entry['show']['title'].upper(), _vb.model.cols, 'ellipsis')
   ep = entry['episode']
   episode_ref = _format_episode_ref(ep['season'], ep['number'])
   episode_title = _strip_leading_article((ep.get('title') or '').upper())
@@ -306,12 +307,12 @@ def get_variables_watching() -> dict[str, list[list[str]]]:
   media_type = data.get('type')
 
   if media_type == 'episode':
-    show_name = data['show']['title'].upper()
+    show_name = _vb.truncate_line(data['show']['title'].upper(), _vb.model.cols, 'ellipsis')
     ep = data['episode']
     episode_ref = _format_episode_ref(ep['season'], ep['number'])
     episode_title = _strip_leading_article((ep.get('title') or '').upper())
   elif media_type == 'movie':
-    show_name = data['movie']['title'].upper()
+    show_name = _vb.truncate_line(data['movie']['title'].upper(), _vb.model.cols, 'ellipsis')
     episode_ref = 'MOVIE'
     episode_title = ''
   else:

--- a/integrations/vestaboard.py
+++ b/integrations/vestaboard.py
@@ -358,7 +358,7 @@ def display_len(text: str) -> int:
   return count
 
 
-def _truncate(
+def truncate_line(
   text: str,
   max_cols: int,
   strategy: TruncationStrategy = 'hard',
@@ -425,7 +425,7 @@ def _wrap_lines(
           result.append(' '.join(current))
           current = []
           current_len = 0
-        result.append(_truncate(word, cols, truncation))
+        result.append(truncate_line(word, cols, truncation))
         continue
       if not current:
         current = [word]

--- a/tests/core/test_vestaboard.py
+++ b/tests/core/test_vestaboard.py
@@ -78,43 +78,43 @@ def test_encode_line_truncated_at_cols() -> None:
   assert len(result) == vb.model.cols
 
 
-# --- _truncate ---
+# --- truncate_line ---
 
 
 def test_truncate_exact_fit_unchanged() -> None:
   text = 'A' * vb.model.cols
-  assert vb._truncate(text, vb.model.cols) == text  # noqa: SLF001
+  assert vb.truncate_line(text, vb.model.cols) == text
 
 
 def test_truncate_short_text_unchanged() -> None:
-  assert vb._truncate('HI', 10) == 'HI'  # noqa: SLF001
+  assert vb.truncate_line('HI', 10) == 'HI'
 
 
 def test_truncate_hard() -> None:
-  assert vb._truncate('HELLO WORLD', 7) == 'HELLO W'  # noqa: SLF001
+  assert vb.truncate_line('HELLO WORLD', 7) == 'HELLO W'
 
 
 def test_truncate_word() -> None:
-  assert vb._truncate('HELLO WORLD', 7, 'word') == 'HELLO'  # noqa: SLF001
+  assert vb.truncate_line('HELLO WORLD', 7, 'word') == 'HELLO'
 
 
 def test_truncate_ellipsis() -> None:
   # target=7 (10-3): fits 'HELLO'(5) + space(6) + 'W'(7); base='HELLO' + '...'
-  assert vb._truncate('HELLO WORLD', 10, 'ellipsis') == 'HELLO...'  # noqa: SLF001
+  assert vb.truncate_line('HELLO WORLD', 10, 'ellipsis') == 'HELLO...'
 
 
 def test_truncate_word_no_space_falls_back_to_hard() -> None:
   # No space before the limit — word strategy behaves like hard
-  assert vb._truncate('HELLOWORLD', 5, 'word') == 'HELLO'  # noqa: SLF001
+  assert vb.truncate_line('HELLOWORLD', 5, 'word') == 'HELLO'
 
 
 def test_truncate_preserves_color_tag() -> None:
   # Truncating to 1 display char should return the full [G] token, not split it
-  assert vb._truncate('[G]AB', 1) == '[G]'  # noqa: SLF001
+  assert vb.truncate_line('[G]AB', 1) == '[G]'
 
 
 def test_truncate_preserves_heart() -> None:
-  assert vb._truncate('❤️AB', 1) == '❤️'  # noqa: SLF001
+  assert vb.truncate_line('❤️AB', 1) == '❤️'
 
 
 # --- _wrap_lines ---
@@ -256,19 +256,19 @@ def test_encode_line_escaped_color_tag_not_green() -> None:
   assert len(result) == vb.model.cols
 
 
-# --- _truncate (escaped tags) ---
+# --- truncate_line (escaped tags) ---
 
 
 def test_truncate_does_not_split_escaped_color_tag() -> None:
   # [[G]] is 3 display chars; truncating to 2 must not produce a partial sequence
-  result = vb._truncate('[[G]]AB', 2)  # noqa: SLF001
+  result = vb.truncate_line('[[G]]AB', 2)
   assert '[[G' not in result
   assert vb.display_len(result) <= 2
 
 
 def test_truncate_includes_escaped_color_tag_when_it_fits() -> None:
   # Truncating to 4 display chars: [[G]] (3) + A (1) fits
-  result = vb._truncate('[[G]]AB', 4)  # noqa: SLF001
+  result = vb.truncate_line('[[G]]AB', 4)
   assert result == '[[G]]A'
   assert vb.display_len(result) == 4
 


### PR DESCRIPTION
## Summary

- Exposes `_truncate` as public `truncate_line` in `vestaboard.py` so integrations can use it cleanly
- Plex: truncates `show_name` to `model.cols` using the template's configured truncation strategy before passing it as a variable
- Trakt: same truncation in both `get_variables_calendar` and `get_variables_watching` (hardcodes `ellipsis` to match `trakt.json`)
- Adds `test_handle_webhook_long_show_name_truncated_to_one_row` to `test_plex.py`
- Adds `test_get_variables_calendar_long_show_name_truncated` and `test_get_variables_watching_long_show_name_truncated` to `test_trakt.py`
- Updates all `vb._truncate(...)` references in `test_vestaboard.py` to use the new public name

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)
