### PR TITLE
fix(weather): add weather to _KNOWN_INTEGRATIONS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.18.1"
+version = "0.18.2"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -41,7 +41,7 @@ from exceptions import IntegrationDataUnavailableError
 
 # Allowlist of valid integration names. Must be extended when a new integration
 # is added to integrations/.
-_KNOWN_INTEGRATIONS: frozenset[str] = frozenset({'bart', 'plex', 'trakt'})
+_KNOWN_INTEGRATIONS: frozenset[str] = frozenset({'bart', 'plex', 'trakt', 'weather'})
 
 # Cache of loaded integration modules, keyed by name.
 _integrations: dict[str, Any] = {}

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -1628,3 +1628,14 @@ def test_load_file_webhook_only_logged_in_startup_table(
   out = capsys.readouterr().out
   assert 'webhook=true' in out
   assert 'now_playing' in out
+
+
+def test_known_integrations_covers_all_integration_modules() -> None:
+  """Every module in integrations/ (except vestaboard) must be in _KNOWN_INTEGRATIONS."""
+  import importlib
+  from pathlib import Path
+
+  integrations_dir = Path(importlib.import_module('integrations').__file__).parent  # type: ignore[arg-type]
+  modules = {p.stem for p in integrations_dir.glob('*.py') if p.stem not in ('__init__', 'vestaboard')}
+  missing = modules - _mod._KNOWN_INTEGRATIONS
+  assert not missing, f'Integrations missing from _KNOWN_INTEGRATIONS: {missing}'

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.18.1"
+version = "0.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Closes #248

## Summary

- Adds `'weather'` to `_KNOWN_INTEGRATIONS` in `scheduler.py` — it was omitted when the integration was added in #242, causing a spurious preflight warning on startup
- Adds `test_known_integrations_covers_all_integration_modules` to `tests/core/test_scheduler.py` — asserts every module in `integrations/` (except `vestaboard`) is listed in `_KNOWN_INTEGRATIONS`, so this can't regress silently when future integrations are added
- Bumps to v0.18.2 (bug fix)

## Test plan

- [ ] `uv run pytest` — all tests pass
- [ ] Startup log no longer shows `Warning: preflight for 'weather' failed: Unknown integration: 'weather'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
