### PR TITLE
feat(plex,trakt): color-coded playback status squares

### DIFF
--- a/content/contrib/plex.json
+++ b/content/contrib/plex.json
@@ -13,7 +13,7 @@
       "templates": [
         {
           "format": [
-            "[O] NOW PLAYING",
+            "[G] NOW PLAYING",
             "{show_name}",
             "{episode_line}"
           ]
@@ -33,9 +33,27 @@
       "templates": [
         {
           "format": [
-            "[O] PAUSED",
+            "[Y] NOW PLAYING",
             "{show_name}",
             "{episode_line}"
+          ]
+        }
+      ]
+    },
+    "stopped": {
+      "webhook": true,
+      "schedule": {
+        "hold": 60,
+        "timeout": 30
+      },
+      "priority": 8,
+      "public": false,
+      "truncation": "hard",
+      "integration": "plex",
+      "templates": [
+        {
+          "format": [
+            "[R] NOW PLAYING"
           ]
         }
       ]

--- a/content/contrib/trakt.json
+++ b/content/contrib/trakt.json
@@ -35,7 +35,7 @@
       "templates": [
         {
           "format": [
-            "[V] NOW PLAYING",
+            "[G] NOW PLAYING",
             "{show_name}",
             "{episode_ref} {episode_title}"
           ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.18.2"
+version = "0.18.3"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.18.2"
+version = "0.18.3"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Closes #250

## Summary

- `[G] NOW PLAYING` for active playback (Plex and Trakt), `[Y] NOW PLAYING` for paused — only the color square changes on state transitions, not the header text, minimising flap refreshes
- `media.stop` now enqueues a short `[R] NOW PLAYING` card (`hold=60s`, `timeout=30s`) instead of `interrupt_only=True` — the display shows an intentional stopped state rather than leaving the last frame up until the next scheduled message
- Adds `stopped` template to `content/contrib/plex.json` with config override support (`[plex.schedules.stopped]`)
- Bumps to v0.18.3

## Test plan

- [ ] `uv run pytest` — all tests pass
- [ ] Live Plex: play → green square; pause → yellow square; stop → red square for ~60s then yields to next content
- [ ] Live Trakt: `watching` template shows green square

🤖 Generated with [Claude Code](https://claude.com/claude-code)
