### PR TITLE
fix(weather): use word truncation and single space in temp/high/low line

### DIFF
--- a/content/contrib/weather.json
+++ b/content/contrib/weather.json
@@ -8,14 +8,14 @@
       },
       "priority": 5,
       "public": true,
-      "truncation": "ellipsis",
+      "truncation": "word",
       "integration": "weather",
       "templates": [
         {
           "format": [
             "{city}",
             "{condition}",
-            "{temp}  H:{high} L:{low}"
+            "{temp} H:{high} L:{low}"
           ]
         }
       ]


### PR DESCRIPTION
— *Claude Code*

The weather template's third line currently uses `"truncation": "ellipsis"` and two spaces between the current temp and the high:

```
{temp}  H:{high} L:{low}
```

Two problems:

1. **Double space** wastes a column that Note (15 cols) can't afford.
2. **Ellipsis truncation** clips mid-value when the line overflows — e.g. `72F  H:85F L:6...` — which is meaningless.

## Proposed fix

Change to single space and `"truncation": "word"`:

```
{temp} H:{high} L:{low}
```

With one space, typical 2-digit positive temps land at exactly 15 chars (`72F H:85F L:60F` = 15). When the line does overflow (3-digit, negative, or long combos), word truncation drops `L:{low}` as a clean unit rather than showing a partial value — worst case the display shows current temp and high only, which is still useful.

**Files:**
- `content/contrib/weather.json` — change format string and truncation mode

Fixes #252.