### PR TITLE
chore(hook): extend version-bump check to cover .json file changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,7 +361,7 @@ step may be skipped — use judgement.
 2. Make changes; run the full check suite
 3. If release-worthy (see below), bump `version` in `pyproject.toml` **in the
    same commit as the source change** — never a follow-up PR. Rule of thumb:
-   if any `.py` file is staged, check whether a bump is needed. Always stage
+   if any `.py` or `.json` file is staged, check whether a bump is needed. Always stage
    `uv.lock` alongside `pyproject.toml` to avoid pre-commit stash conflicts.
 4. Commit with `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
    (commits are auto-signed via `commit.gpgsign = true` in global git config)
@@ -393,6 +393,7 @@ PR contains **release-worthy** changes:
 | Release-worthy | Not release-worthy |
 |---|---|
 | Source code changes (`.py` files) | CI/CD workflow changes |
+| Content JSON changes (`content/`) | Tooling config JSON changes |
 | Runtime dependency changes | Dev-only dependency changes |
 | `Dockerfile` changes | Docs-only changes |
 | Security fixes | Repo config / tooling changes |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.18.3"
+version = "0.18.4"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scripts/check-version-bump.sh
+++ b/scripts/check-version-bump.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
 # check-version-bump.sh
 #
-# Pre-commit hook: warn when .py files are staged without a version bump.
+# Pre-commit hook: warn when .py or .json files are staged without a version bump.
 #
-# Exits 1 if Python source files are staged but pyproject.toml's version
-# line is unchanged in the index. Bypassable with --no-verify for commits
-# that are intentionally not release-worthy (test-only, dev tooling, etc.).
+# Exits 1 if Python source files or content JSON files are staged but
+# pyproject.toml's version line is unchanged in the index. Bypassable with
+# --no-verify for commits that are intentionally not release-worthy
+# (test-only, dev tooling, etc.).
 
 set -euo pipefail
 
-# Check whether any staged file is a Python source file (not test/tooling).
-# We match any .py file; the committer uses --no-verify to bypass when the
-# change is genuinely not release-worthy.
-if ! git diff --cached --name-only | grep -q '\.py$'; then
+# Check whether any staged file is a Python source file or a JSON file.
+# We match any .py or .json file; the committer uses --no-verify to bypass
+# when the change is genuinely not release-worthy (e.g. tooling config JSON).
+if ! git diff --cached --name-only | grep -qE '\.(py|json)$'; then
   exit 0
 fi
 
@@ -24,8 +25,8 @@ fi
 echo "╔══════════════════════════════════════════════════════════════╗"
 echo "║  Version bump missing                                        ║"
 echo "║                                                              ║"
-echo "║  .py files are staged but pyproject.toml version is         ║"
-echo "║  unchanged. If this commit is release-worthy, bump the      ║"
+echo "║  .py or .json files are staged but pyproject.toml version   ║"
+echo "║  is unchanged. If this commit is release-worthy, bump the  ║"
 echo "║  version before committing.                                  ║"
 echo "║                                                              ║"
 echo "║  Not release-worthy? Bypass with: git commit --no-verify    ║"

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.18.3"
+version = "0.18.4"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

The `check-version-bump.sh` pre-commit hook warns when `.py` files are staged without a version bump, but `content/contrib/*.json` files are equally release-worthy (they ship in the Docker image) and are not covered.

This surfaced concretely in #253, where `weather.json` was changed without a version bump — and the hook correctly stayed silent only because the file isn't Python.

## Proposed fix

1. **`scripts/check-version-bump.sh`** — extend the staged-file check to also trigger on `.json` files (consistent with the existing approach: committers use `--no-verify` for genuinely non-release-worthy JSON changes like tooling config)
2. **`AGENTS.md`** — add a row to the release-worthy table for content JSON changes; update the rule-of-thumb in execution step 3 to mention `.json` alongside `.py`

## Tests

No test changes needed (the hook is a shell script exercised manually; existing pre-commit infra covers it).
