### PR TITLE
feat(scheduler): add disabled/private template overrides; rename public→private

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ for a physical split-flap device whose flaps need time to settle.
         "refresh_interval": 60  // optional: re-fetch integration data every N seconds during hold (min 30; integration templates only)
       },
       "priority": 5,           // integer 0–10; higher number = higher priority
-      "public": true,          // if false, skipped when running with --public
+      "private": false,        // if true, hidden when public mode is enabled in config.toml
       "truncation": "word",    // optional: "hard" (default), "word", "ellipsis"
       "webhook": false,        // optional: true makes cron optional; template fires on webhook only
       "templates": [

--- a/config.example.toml
+++ b/config.example.toml
@@ -11,7 +11,7 @@
 # Display model: "note" (3×15, default) or "flagship" (6×22)
 # model = "flagship"
 
-# Public mode: skip templates marked public = false. Useful when the display
+# Public mode: skip templates marked private = true. Useful when the display
 # is in a shared or guest-visible space.
 # public = true
 
@@ -54,6 +54,8 @@ line1_dest = "DALY"
 # timeout = 60
 # priority = 8
 # refresh_interval = 60  # re-fetch departure times every 60s during the hold (min 30)
+# disabled = true        # skip this template entirely (all other fields ignored)
+# private = true         # hide in public mode (overrides the template's private field)
 
 [weather]
 # City to display weather for. Geocoded via Open-Meteo on first call; no API
@@ -69,6 +71,8 @@ city = "San Francisco"
 # hold = 600
 # timeout = 1800
 # priority = 5
+# disabled = true  # skip this template entirely (all other fields ignored)
+# private = true   # hide in public mode (overrides the template's private field)
 
 [webhook]
 # Optional: enable the HTTP webhook listener so external systems (Plex,

--- a/content/README.md
+++ b/content/README.md
@@ -36,7 +36,7 @@ schedule and display settings.
         "timeout": 600
       },
       "priority": 5,
-      "public": true,
+      "private": false,
       "truncation": "word",
       "templates": [
         { "format": ["GOOD MORNING", "{quip}"] }
@@ -58,7 +58,7 @@ schedule and display settings.
 | `hold` | Seconds the message stays on display before the next update |
 | `timeout` | Seconds the message can wait in the queue before being discarded |
 | `priority` | Integer 0–10; higher number runs first when multiple messages are queued simultaneously |
-| `public` | If `false`, excluded when running with `--public` |
+| `private` | If `true`, excluded when public mode is enabled (`[scheduler] public = true` in config.toml) |
 | `truncation` | `hard` cuts mid-word (default); `word` stops at a word boundary; `ellipsis` adds `...` |
 
 ### Variables
@@ -129,8 +129,8 @@ Rules of thumb:
 
 ### Schedule overrides
 
-Override `cron`, `hold`, `timeout`, or `priority` for any named template
-directly in `config.toml`, without editing the content file:
+Override schedule fields or visibility for any named template directly in
+`config.toml`, without editing the content file:
 
 ```toml
 [bart.schedules.departures]
@@ -138,10 +138,15 @@ cron = "*/5 6-9 * * 1-5"  # extend window to start at 6am
 hold = 180
 timeout = 90
 priority = 9
+disabled = true            # skip this template entirely
+private = true             # hide in public mode
 ```
 
-The section name is `[<file-stem>.schedules.<template-name>]`. All four fields
-are optional; unspecified fields use the template's JSON default.
+The section name is `[<file-stem>.schedules.<template-name>]`. All fields are
+optional; unspecified fields use the template's JSON default. `disabled = true`
+takes precedence over all other fields — the template is skipped entirely.
+`private = true` marks a template as hidden in public mode even if the JSON
+does not.
 
 ## Contrib integrations
 

--- a/content/contrib/bart.json
+++ b/content/contrib/bart.json
@@ -8,7 +8,6 @@
         "refresh_interval": 60
       },
       "priority": 8,
-      "public": true,
       "truncation": "ellipsis",
       "integration": "bart",
       "templates": [

--- a/content/contrib/plex.json
+++ b/content/contrib/plex.json
@@ -7,7 +7,7 @@
         "timeout": 30
       },
       "priority": 8,
-      "public": false,
+      "private": true,
       "truncation": "ellipsis",
       "integration": "plex",
       "templates": [
@@ -27,7 +27,7 @@
         "timeout": 30
       },
       "priority": 8,
-      "public": false,
+      "private": true,
       "truncation": "ellipsis",
       "integration": "plex",
       "templates": [
@@ -47,7 +47,7 @@
         "timeout": 30
       },
       "priority": 8,
-      "public": false,
+      "private": true,
       "truncation": "hard",
       "integration": "plex",
       "templates": [

--- a/content/contrib/trakt.json
+++ b/content/contrib/trakt.json
@@ -7,7 +7,7 @@
         "timeout": 600
       },
       "priority": 4,
-      "public": false,
+      "private": true,
       "truncation": "ellipsis",
       "integration": "trakt",
       "integration_fn": "get_variables_calendar",
@@ -28,7 +28,7 @@
         "timeout": 120
       },
       "priority": 7,
-      "public": false,
+      "private": true,
       "truncation": "ellipsis",
       "integration": "trakt",
       "integration_fn": "get_variables_watching",

--- a/content/contrib/weather.json
+++ b/content/contrib/weather.json
@@ -7,7 +7,6 @@
         "timeout": 1800
       },
       "priority": 5,
-      "public": true,
       "truncation": "word",
       "integration": "weather",
       "templates": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.18.4"
+version = "0.19.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.18.4"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

Closes #243.

## Summary

- Adds `disabled = true` schedule override: skip a template entirely without editing JSON
- Adds `private = true` schedule override: hide a template in public mode without editing JSON
- Both keys accept native TOML booleans; string `"true"`/`"false"` values are coerced with a warning
- Renames the per-template JSON field `public` → `private` (inverts default), eliminating the double-negative of `public = false`
- Removes now-redundant `"public": true` entries from all content JSON files
- Removes stale `--public` CLI references from docs (the flag no longer exists; public mode is config-only)
- Bumps to v0.19.0 (minor: new feature + breaking JSON format change)

## Test plan

- [ ] 8 new tests covering `disabled`/`private` override combinations (bool true/false, string coercion, invalid type, webhook-only template, public mode on/off)
- [ ] Existing `public` mode tests updated to use renamed `private` field
- [ ] `uv run pytest` — 353 passed
