### PR TITLE
fix(weather): catch network errors and raise IntegrationDataUnavailableError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.19.0"
+version = "0.19.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.19.0"
+version = "0.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- Geocoding and forecast network failures (timeouts, connection errors) in `weather.py` were not caught, so they surfaced as `requests.RequestException` in the scheduler's generic `except Exception` handler and got logged as the misleading **"Error sending to board"** message — making the weather template silently skip on every fire until the process restarted
- The forecast HTTP error path re-raised `requests.HTTPError` instead of `IntegrationDataUnavailableError`, also falling through to the generic handler
- Both paths now catch `requests.RequestException`, print a descriptive log line (`Weather: geocoding request failed — ...`), and raise `IntegrationDataUnavailableError` so the worker skips the message cleanly without noise

## Root cause from logs

```
Error sending to board: HTTPSConnectionPool(host='geocoding-api.open-meteo.com', port=443): Read timed out. (read timeout=10)
```

Geocoding cache was `None`, geocoding API timed out, exception bubbled past `get_variables()` uncaught.

## Test plan

- [x] `test_geocoding_timeout_raises_unavailable` — new test for geocoding timeout path
- [x] `test_forecast_timeout_raises_unavailable` — new test for forecast timeout path  
- [x] `test_forecast_http_error_raises_unavailable` — renamed + updated from `test_forecast_http_error_does_not_leak_city`; now asserts `IntegrationDataUnavailableError` (the city non-leakage assertion is preserved)
- [x] Full suite: 355 passed

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)
