### PR TITLE
fix(weather): parse "City, ST/CC" config notation for geocoding disambiguation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.19.1"
+version = "0.19.2"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.19.1"
+version = "0.19.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- `city = "Santa Clara, CA"` in config.toml returned no geocoding results because the Open-Meteo API only accepts plain city names — it doesn't understand `"City, State"` notation
- Add `_parse_city_config()` to strip the disambiguation suffix and infer a country code to narrow results:
  - Known US state codes (`CA`, `NY`, `TX`, …) → `countryCode=US`
  - Any other 2-letter suffix → treated as ISO 3166-1 alpha-2 country code (e.g. `FR`, `DE`)
  - Longer/unrecognised suffixes → passed through as-is (best-effort)
- Work around an Open-Meteo API bug where `count=1 + countryCode` always returns empty results by using `count=2` when a country filter is active
- The `city` config key remains a single human-readable string — no separate `country_code` key needed

## Test plan

- [x] `test_parse_city_config_*` — 4 new unit tests covering bare city, US state, ISO country code, and unrecognised suffix
- [x] `test_geocoding_uses_count2_with_country_code` — verifies the `count=1` API bug workaround
- [x] `test_geocoding_uses_count1_without_country_code` — verifies no regression for bare city names
- [x] Full suite: 361 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
