### PR TITLE
feat(plex,trakt): word-boundary truncation and stop-state display

### DIFF
--- a/content/contrib/plex.json
+++ b/content/contrib/plex.json
@@ -48,12 +48,14 @@
       },
       "priority": 8,
       "private": true,
-      "truncation": "hard",
+      "truncation": "word",
       "integration": "plex",
       "templates": [
         {
           "format": [
-            "[R] NOW PLAYING"
+            "[R] NOW PLAYING",
+            "{show_name}",
+            "{episode_line}"
           ]
         }
       ]

--- a/content/contrib/trakt.json
+++ b/content/contrib/trakt.json
@@ -25,7 +25,8 @@
       "schedule": {
         "cron": "*/3 * * * *",
         "hold": 180,
-        "timeout": 120
+        "timeout": 120,
+        "refresh_interval": 30
       },
       "priority": 7,
       "private": true,
@@ -35,7 +36,7 @@
       "templates": [
         {
           "format": [
-            "[G] NOW PLAYING",
+            "{status_line}",
             "{show_name}",
             "{episode_ref} {episode_title}"
           ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.19.2"
+version = "0.20.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.19.2"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Closes #259, closes #230. Partial fix for #268 (stale Trakt stopped state after Plex stop; sub-second idle-refresh flash tracked separately in that issue).

## Summary

- **Word-boundary truncation (#259):** Show and movie name lines in both Plex and Trakt now truncate at word boundaries instead of mid-character, so the display never shows a partial word
- **Plex stop state (#230):** `media.stop` now parses metadata and returns `[R] NOW PLAYING` with the same `{show_name}` and `{episode_line}` variables as the now-playing card — only the color-square flap moves on stop. Falls back to a bare `[R] NOW PLAYING` card if metadata is absent
- **Trakt stop state (#230):** `watching` template gains `refresh_interval: 30` for real-time polling and uses a `{status_line}` variable instead of a hardcoded `[G]`. On the first poll after playback ends (204), the integration returns `[V] NOW PLAYING` (violet = Trakt brand colour) with the last known show content, then clears state; subsequent 204s raise `IntegrationDataUnavailableError` as before
- **Plex/Trakt coordination (#268):** `plex.handle_webhook()` clears Trakt's cached watching state on any handled event, preventing a stale Trakt `[V]` indicator from appearing after Plex has already handled a stop

Full Plex state matrix after this PR:

| Event | Color | `indefinite` |
|---|---|---|
| `media.play` / `media.resume` | `[G]` green | `true` |
| `media.pause` | `[Y]` yellow | `true` |
| `media.stop` | `[R]` red | `false` |

## Test plan

- [x] All 370 unit tests pass
- [x] ruff, pyright, bandit, pip-audit all clean
- [x] Word-boundary truncation asserted: result is a whole-word prefix of the original title
- [x] Stop-with-metadata tests: `show_name` and `episode_line` present in variables
- [x] Stop-without-metadata test: bare card fallback
- [x] Trakt `status_line` variable present in all watching results
- [x] Trakt stopped-state lifecycle: play → 204 returns `[V]` → 204 again raises `IntegrationDataUnavailableError`
- [x] `clear_watching_state()` called by Plex, verified by test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
