### PR TITLE
fix(trakt): debounce stopped indicator with two consecutive 204s

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.20.2"
+version = "0.20.3"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.20.2"
+version = "0.20.3"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Adds a two-consecutive-204 debounce to `get_variables_watching()` in `integrations/trakt.py`
- First 204 after a watching session sets `_stop_pending = True` and skips the stopped indicator for that cycle, preventing a false violet card during back-to-back episode gaps (~30 s autoplay transition)
- Second consecutive 204 confirms a genuine stop and emits the violet `[V] NOW PLAYING` indicator
- Any new playing data or `clear_watching_state()` resets `_stop_pending`

## Tests

- Replaced old single-204 test with two new tests covering the debounce sequence
- Added test confirming that a play event after the first 204 resets pending state
- Updated existing cleared-state test to account for the now-required two-204 sequence

Closes #273
