### PR TITLE
fix(plex): ignore duplicate stop events after board has moved on

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.20.3"
+version = "0.20.4"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.20.3"
+version = "0.20.4"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Closes #275

Tracks a `_stop_processed` flag in `integrations/plex.py`. The flag is set when the first `media.stop` is processed and cleared on any `media.play` or `media.resume`. A second `media.stop` arriving while the flag is set is silently discarded.

`media.pause` is intentionally excluded — it doesn't set the flag, so a stop following a pause still fires normally.

Five new test cases added to `tests/core/test_plex.py`; a `_reset_stop_processed` autouse fixture ensures module state is clean between tests.

— *Claude Code*