### PR TITLE
feat: extend content_enabled filter to user content files

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Key `[scheduler]` settings:
 |---|---|---|
 | `model` | `"note"` | Display model: `"note"` (3×15) or `"flagship"` (6×22) |
 | `public` | `false` | Skip templates marked `public = false` (for shared spaces) |
-| `content_enabled` | _(absent)_ | Contrib content to enable: `["*"]` for all, or `["bart", "trakt"]` for specific stems |
+| `content_enabled` | _(absent)_ | Content filter for both `user/` and `contrib/`: absent = all user loads, no contrib; `["*"]` = all user + all contrib; `["bart", "my_quotes"]` = only matching stems from either directory |
 | `timezone` | system TZ | IANA timezone for cron job scheduling (e.g. `"America/Los_Angeles"`) |
 | `min_hold` | `60` | Minimum seconds any message stays on display before a high-priority (≥8) queued message can interrupt it. Set to `0` to disable (not recommended for physical displays). |
 
@@ -155,7 +155,7 @@ cp config.example.toml config.toml  # fill in your API key
 uv run e-note-ion
 ```
 
-Display model, public mode, and enabled contrib content are set in `config.toml`
+Display model, public mode, and content filter are set in `config.toml`
 under `[scheduler]`. See [Configuration](#configuration) for details.
 
 ## Content files
@@ -163,9 +163,10 @@ under `[scheduler]`. See [Configuration](#configuration) for details.
 Content is defined as JSON files in two directories:
 
 - **`content/contrib/`** — bundled community-contributed content, disabled by
-  default. Enable files via `[scheduler].content_enabled` in `config.toml`.
-- **`content/user/`** — personal content, always loaded. Git-ignored; mount
-  your own directory here or symlink to a private repo for versioning.
+  default. Enable via `[scheduler].content_enabled` in `config.toml`.
+- **`content/user/`** — personal content. Loaded automatically when
+  `content_enabled` is absent; filtered alongside contrib when it is set.
+  Git-ignored; mount your own directory here or symlink to a private repo.
 
 See [`content/README.md`](content/README.md) for the full content format
 reference, including template fields, variables, color squares, priority

--- a/config.example.toml
+++ b/config.example.toml
@@ -15,8 +15,11 @@
 # is in a shared or guest-visible space.
 # public = true
 
-# Bundled contrib content to enable. Use ["*"] to enable all, or list specific
-# stems: ["bart", "trakt"]. Omit or leave empty to disable all contrib content.
+# Content filter. When absent, all user content loads and no contrib content
+# loads. When set, the filter applies to both user and contrib directories:
+#   ["*"]              — all user + all contrib
+#   ["bart", "trakt"]  — only these stems from either directory
+#   ["my_quotes"]      — only my_quotes.json from content/user/
 # content_enabled = ["*"]
 
 # Global minimum hold (seconds). Every message is guaranteed to display for at

--- a/config.py
+++ b/config.py
@@ -174,17 +174,20 @@ def get_public_mode() -> bool:
   return get_optional_bool('scheduler', 'public', default=False)
 
 
-def get_content_enabled() -> set[str]:
-  """Return the set of enabled contrib content stems.
+def get_content_enabled() -> set[str] | None:
+  """Return the configured content filter, or None if the key is absent.
 
   Reads [scheduler].content_enabled (a TOML array of strings).
-  Returns {"*"} to enable all, a set of stems for specific files,
-  or an empty set when the key is absent or the list is empty.
+  Returns None when the key is absent (user content loads unconditionally,
+  no contrib content loads). When the key is present, returns a set of stems
+  (possibly empty) that filters both user and contrib directories: {"*"} to
+  enable all, or specific stems such as {"bart", "my_quotes"}.
   """
-  value = _config.get('scheduler', {}).get('content_enabled')
-  if not value:
-    return set()
-  return set(value)
+  scheduler_cfg = _config.get('scheduler', {})
+  if 'content_enabled' not in scheduler_cfg:
+    return None
+  value = scheduler_cfg['content_enabled']
+  return set(value) if value else set()
 
 
 def get_schedule_override(template_id: str) -> dict:

--- a/content/README.md
+++ b/content/README.md
@@ -6,20 +6,29 @@ board. Restart the scheduler to pick up changes.
 ## Directories
 
 - **`contrib/`** — bundled community-contributed content, disabled by default.
-  Enable files by setting `content_enabled` in `config.toml` under `[scheduler]`:
-  ```toml
-  content_enabled = ["bart"]   # enable one file
-  content_enabled = ["bart", "trakt"]  # enable multiple
-  content_enabled = ["*"]      # enable all
-  ```
   To contribute content, open a pull request adding a `.json` file and a
   companion `.md` doc (see template in `content/contrib/TEMPLATE.md`).
 
-- **`user/`** — your personal content. Files placed here are always loaded
-  automatically — no opt-in needed. This directory is git-ignored so personal
-  schedules are never committed to the project repo. To version your personal
-  content, create a private git repository and volume-mount it at
-  `/app/content/user` (Docker) or symlink it to this directory directly.
+- **`user/`** — your personal content. Files here are loaded automatically
+  unless `content_enabled` is set (see below). This directory is git-ignored
+  so personal schedules are never committed to the project repo. To version
+  your personal content, create a private git repository and volume-mount it
+  at `/app/content/user` (Docker) or symlink it to this directory directly.
+
+## Content filter (`content_enabled`)
+
+The `[scheduler].content_enabled` key in `config.toml` controls which files
+are loaded from both directories:
+
+```toml
+# Absent (default): all user content loads, no contrib content loads
+content_enabled = ["*"]              # all user + all contrib
+content_enabled = ["bart", "trakt"]  # only these stems from either directory
+content_enabled = ["my_quotes"]      # only my_quotes.json from content/user/
+```
+
+When the key is absent, user files always load and no contrib files load.
+When the key is set, the filter applies to both `user/` and `contrib/`.
 
 ## Content file format
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.20.5"
+version = "0.21.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -142,12 +142,13 @@ def test_get_public_mode_true(monkeypatch: pytest.MonkeyPatch) -> None:
 # --- get_content_enabled ---
 
 
-def test_get_content_enabled_absent_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_content_enabled_absent_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
   monkeypatch.setattr(_mod, '_config', {})
-  assert _mod.get_content_enabled() == set()
+  assert _mod.get_content_enabled() is None
 
 
-def test_get_content_enabled_empty_list(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_content_enabled_empty_list_returns_empty_set(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Explicit empty list is distinct from absent — returns set(), not None."""
   monkeypatch.setattr(_mod, '_config', {'scheduler': {'content_enabled': []}})
   assert _mod.get_content_enabled() == set()
 

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.20.5"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Closes #221

Previously `content_enabled` only gated contrib content; user files always loaded unconditionally. This extends the filter to both directories while preserving the existing default behaviour.

**Behaviour matrix:**

| `content_enabled` | user/ | contrib/ |
|---|---|---|
| absent (default) | all load | none load |
| `["*"]` | all load | all load |
| `["bart"]` | none (no match) | `bart.json` only |
| `["my_quotes"]` | `my_quotes.json` only | none (no match) |

**Breaking change (pre-v1.0):** if `content_enabled` was previously set to a contrib-only stem list (e.g. `["bart"]`), user files are now also filtered — they will no longer load unless their stem appears in the list or `"*"` is used.

**Implementation:** `get_content_enabled()` now returns `None` (key absent) vs `set[str]` (key present), allowing `load_content()` to distinguish the two cases. `load_content()` applies the filter to user files when the set is not `None`.

Docs updated in `config.example.toml`, `content/README.md`, and `README.md`.

— *Claude Code*