### PR TITLE
fix(plex): state machine + board displacement check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.22.0"
+version = "0.22.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_webhook.py
+++ b/tests/core/test_webhook.py
@@ -82,10 +82,14 @@ def _post_multipart(
 
 @pytest.fixture(autouse=True)
 def reset_hold_interrupt() -> Generator[None, None, None]:
-  """Clear the hold interrupt event before and after each test."""
+  """Clear the hold interrupt event and current hold tag before and after each test."""
   _mod._hold_interrupt.clear()
+  with _mod._current_hold_lock:
+    _mod._current_hold_supersede_tag = ''
   yield
   _mod._hold_interrupt.clear()
+  with _mod._current_hold_lock:
+    _mod._current_hold_supersede_tag = ''
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.22.0"
+version = "0.22.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Fixes #282.

## Summary

- Replaces `_stop_processed: bool` in `integrations/plex.py` with an explicit `_State` enum (`IDLE` / `PLAYING` / `PAUSED`) enforcing a proper state machine
- Invalid transitions (pause or stop in `IDLE`; pause in `PAUSED`) return `None` immediately
- Pause and stop additionally check `scheduler.current_hold_tag()`: if Plex no longer owns the board (displaced by a higher-priority cron message), state still transitions to reflect reality but no `WebhookMessage` is returned — preventing stale Plex events from interrupting unrelated content
- `play` and `resume` always fire regardless of board state, as they initiate a new session
- Adds `_current_hold_supersede_tag` (+ lock + `current_hold_tag()` accessor) to `scheduler.py` so integrations can detect board displacement without coupling to scheduler internals

## Test plan

- All existing plex tests updated to use the new `_State` fixture; full semantics preserved
- New tests cover: invalid state transitions, board displacement (pause/stop suppressed; state still transitions), play after a displaced stop, duplicate pause suppression
- `test_webhook.py` fixture resets `_current_hold_supersede_tag` for isolation
- 427 tests passing, all checks clean
