### PR TITLE
fix(scheduler): gate webhook interrupt on hold priority threshold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.22.1"
+version = "0.22.2"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.22.1"
+version = "0.22.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Gate webhook `_hold_interrupt` on hold priority threshold — mirrors cron

Closes #283

## Summary

- Tracks `_current_hold_priority` in the worker alongside `_current_hold_supersede_tag`, set/cleared under `_current_hold_lock` around `_do_hold()`
- Adds `_current_hold_is_interruptible()`: returns `True` only when no hold is active or the current hold's priority is below `_INTERRUPT_PRIORITY_THRESHOLD` (8)
- Gates both `_hold_interrupt.set()` call sites in `do_POST` on this check — applies to both `interrupt=True` and `interrupt_only=True` paths
- High-priority holds (priority ≥ 8) now run to completion and cannot be cut short by any webhook event, matching the cron interrupt invariant at lines 270–273

## Test plan

- [ ] `test_interrupt_blocked_when_current_hold_is_high_priority` — priority=8 hold, `interrupt=True` webhook → event not set
- [ ] `test_interrupt_allowed_when_current_hold_is_low_priority` — priority=7 hold, `interrupt=True` webhook → event set
- [ ] `test_interrupt_only_blocked_when_current_hold_is_high_priority` — priority=8 hold, `interrupt_only=True` → event not set, still 200
- [ ] `test_interrupt_only_allowed_when_current_hold_is_low_priority` — priority=7 hold, `interrupt_only=True` → event set
- [ ] Existing interrupt tests continue to pass (no active hold = always interruptible)
- [ ] Full suite: 431 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
