### PR TITLE
chore(discogs): reschedule to 8:30am and fix CI integration token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,3 +97,4 @@ jobs:
           TRAKT_CLIENT_ID: ${{ vars.TRAKT_CLIENT_ID }}
           TRAKT_CLIENT_SECRET: ${{ secrets.TRAKT_CLIENT_SECRET }}
           TRAKT_ACCESS_TOKEN: ${{ secrets.TRAKT_ACCESS_TOKEN }}
+          DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,13 +298,14 @@ come from GitHub secrets env vars directly.
   - BART: `BART_API_KEY`
   - Vestaboard: `VESTABOARD_VIRTUAL_API_KEY` (use a virtual board, not physical)
   - Trakt: `TRAKT_CLIENT_ID`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`
+  - Discogs: `DISCOGS_TOKEN`
 - CI runs the `integration` job on `main` pushes only; it is advisory
   (`continue-on-error: true`) and not required by the branch ruleset
 - GitHub secrets/vars needed — store as **environment secrets** (or vars) on the
   `integration` environment (Settings → Environments), restricted to the `main`
   branch; this scopes them tighter than repo secrets and prevents any PR branch
   from accessing them even if a workflow runs there:
-  - Secrets: `VESTABOARD_VIRTUAL_API_KEY`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`
+  - Secrets: `VESTABOARD_VIRTUAL_API_KEY`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `DISCOGS_TOKEN`
   - Variables: `TRAKT_CLIENT_ID` (non-sensitive; stored as an environment variable, not a secret)
 - If any integration test is skipped, the pytest session exits with code 5
   (NO_TESTS_COLLECTED), making the advisory job visibly fail rather than silently pass
@@ -329,7 +330,7 @@ prevention here — not just a one-off fix. See #65 for extended notes.
    ```
    gh api repos/JasonPuglisi/e-note-ion/rulesets/13082160 --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
    ```
-9. **Integration test hygiene** — advisory CI job passing on `main`; GitHub environment secrets/vars present (`BART_API_KEY`, `VESTABOARD_VIRTUAL_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN` as secrets; `TRAKT_CLIENT_ID` as a variable); new integrations have `test_<name>_integration.py` and env vars in `tests/integrations/conftest.py`
+9. **Integration test hygiene** — advisory CI job passing on `main`; GitHub environment secrets/vars present (`BART_API_KEY`, `VESTABOARD_VIRTUAL_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `DISCOGS_TOKEN` as secrets; `TRAKT_CLIENT_ID` as a variable); new integrations have `test_<name>_integration.py` and env vars in `tests/integrations/conftest.py`
 10. **Issue/milestone hygiene**:
     - Every open issue has a milestone (no orphans); scope is right-sized
     - Blocking relationships explicit ("Blocked by #X" in body)

--- a/content/contrib/discogs.json
+++ b/content/contrib/discogs.json
@@ -2,7 +2,7 @@
   "templates": {
     "morning_spin": {
       "schedule": {
-        "cron": "0 8 * * *",
+        "cron": "30 8 * * *",
         "hold": 600,
         "timeout": 3600
       },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.23.0"
+version = "0.23.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [


### PR DESCRIPTION
— *Claude Code*

## Summary

- Reschedules the Discogs `morning_spin` cron from `0 8 * * *` to `30 8 * * *` (8:30am)
- Adds `DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN }}` to the integration CI job's `env:` block — this was the root cause of the advisory test failure; the secret existed in the `integration` environment but was never passed through to the job
- Documents `DISCOGS_TOKEN` in AGENTS.md alongside the other integration secrets

## Test plan

- [x] `uv run pytest tests/integrations/test_discogs_integration.py -m integration -v` passes locally
- [x] Full check suite passes (`ruff`, `pyright`, `bandit`, `pip-audit`, `pytest`)
- [ ] Advisory integration job on `main` should pass after merge (no more skip exit code 5)
