### PR TITLE
fix(vestaboard): ellipsis strategy truncates long lines instead of wrapping

### DIFF
--- a/integrations/vestaboard.py
+++ b/integrations/vestaboard.py
@@ -407,12 +407,19 @@ def _wrap_lines(
   A word that alone exceeds model.cols is truncated using `truncation`. Lines
   are never joined together — wrapping only splits; short lines pass through
   unchanged.
+
+  Exception: when `truncation` is 'ellipsis', long lines are truncated to one
+  row with '...' rather than wrapped. This preserves fixed-layout templates
+  where each format entry must occupy exactly one row.
   """
   cols = model.cols
   result: list[str] = []
   for line in lines:
     if display_len(line) <= cols:
       result.append(line)
+      continue
+    if truncation == 'ellipsis':
+      result.append(truncate_line(line, cols, 'ellipsis'))
       continue
     words = line.split(' ')
     current: list[str] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.23.1"
+version = "0.23.2"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_vestaboard.py
+++ b/tests/core/test_vestaboard.py
@@ -151,6 +151,26 @@ def test_wrap_lines_does_not_join_separate_lines() -> None:
   assert result[1] == 'LINE TWO'
 
 
+def test_wrap_lines_ellipsis_truncates_instead_of_wrapping() -> None:
+  # With ellipsis strategy a long line must stay on one row, not wrap.
+  # This is the Discogs bug: a long album title was wrapping onto row 3,
+  # pushing the artist name off the board entirely.
+  long_line = 'HOLLOW KNIGHT GODS AND MONSTERS'  # > 15 cols
+  result = vb._wrap_lines([long_line], truncation='ellipsis')  # noqa: SLF001
+  assert len(result) == 1
+  assert vb.display_len(result[0]) <= vb.model.cols
+  assert result[0].endswith('...')
+
+
+def test_wrap_lines_ellipsis_preserves_fixed_layout() -> None:
+  # Three-line fixed layout: long album must not push artist off row 3.
+  lines = ['[Y] MORNING SPIN', 'HOLLOW KNIGHT GODS AND MONSTERS', 'TEAM CHERRY']
+  result = vb._wrap_lines(lines, truncation='ellipsis')  # noqa: SLF001
+  assert result[0] == '[Y] MORNING SPIN'
+  assert result[1].endswith('...')
+  assert result[2] == 'TEAM CHERRY'
+
+
 # --- _expand_format ---
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.23.0"
+version = "0.23.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

Fixes #292.

## Summary

- `_wrap_lines` was always word-wrapping long lines regardless of truncation strategy
- When `truncation='ellipsis'`, long lines are now truncated to one row with `...` instead of being wrapped across multiple rows
- Discovered live: Discogs `morning_spin` album title `HOLLOW KNIGHT GODS AND MONSTERS` wrapped onto row 3, pushing the artist name off the Note entirely

## Test plan

- [x] `test_wrap_lines_ellipsis_truncates_instead_of_wrapping` — single long line stays on one row with `...`
- [x] `test_wrap_lines_ellipsis_preserves_fixed_layout` — 3-line template: long album stays on row 2, artist visible on row 3
- [x] All 450 tests pass
