### PR TITLE
feat(calendar): iCalendar integration (ICS + CalDAV)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,16 @@
 # .env is git-ignored — never commit it.
 # Use bare values (no surrounding quotes) — e.g. KEY=value, not KEY="value".
 #
-# Required for Vestaboard integration tests:
+# Required for Vestaboard integration tests (use a virtual board, not physical):
 VESTABOARD_VIRTUAL_API_KEY=your-virtual-board-read-write-key
+#
+# Required for Calendar integration tests (at least one mode):
+# ICS mode — a public or secret-address .ics URL you control:
+CALENDAR_URL=https://calendar.google.com/calendar/ical/.../basic.ics
+# CalDAV mode — private iCloud (app-specific password from appleid.apple.com):
+CALENDAR_CALDAV_URL=https://caldav.icloud.com/
+CALENDAR_USERNAME=you@icloud.com
+CALENDAR_PASSWORD=xxxx-xxxx-xxxx-xxxx
 #
 # Required for BART integration tests:
 BART_API_KEY=your-bart-api-key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,8 +295,10 @@ come from GitHub secrets env vars directly.
 - Tests skip automatically when required env vars are absent (no failures)
 - Required env vars per integration (real API keys only; other settings are
   hardcoded in the test via `config._config` patching):
-  - BART: `BART_API_KEY`
   - Vestaboard: `VESTABOARD_VIRTUAL_API_KEY` (use a virtual board, not physical)
+  - Calendar (ICS mode): `CALENDAR_URL`
+  - Calendar (CalDAV mode): `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD`
+  - BART: `BART_API_KEY`
   - Trakt: `TRAKT_CLIENT_ID`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`
   - Discogs: `DISCOGS_TOKEN`
 - CI runs the `integration` job on `main` pushes only; it is advisory
@@ -305,7 +307,7 @@ come from GitHub secrets env vars directly.
   `integration` environment (Settings → Environments), restricted to the `main`
   branch; this scopes them tighter than repo secrets and prevents any PR branch
   from accessing them even if a workflow runs there:
-  - Secrets: `VESTABOARD_VIRTUAL_API_KEY`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `DISCOGS_TOKEN`
+  - Secrets: `VESTABOARD_VIRTUAL_API_KEY`, `CALENDAR_URL`, `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `DISCOGS_TOKEN`
   - Variables: `TRAKT_CLIENT_ID` (non-sensitive; stored as an environment variable, not a secret)
 - If any integration test is skipped, the pytest session exits with code 5
   (NO_TESTS_COLLECTED), making the advisory job visibly fail rather than silently pass
@@ -330,7 +332,7 @@ prevention here — not just a one-off fix. See #65 for extended notes.
    ```
    gh api repos/JasonPuglisi/e-note-ion/rulesets/13082160 --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
    ```
-9. **Integration test hygiene** — advisory CI job passing on `main`; GitHub environment secrets/vars present (`BART_API_KEY`, `VESTABOARD_VIRTUAL_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `DISCOGS_TOKEN` as secrets; `TRAKT_CLIENT_ID` as a variable); new integrations have `test_<name>_integration.py` and env vars in `tests/integrations/conftest.py`
+9. **Integration test hygiene** — advisory CI job passing on `main`; GitHub environment secrets/vars present (`BART_API_KEY`, `VESTABOARD_VIRTUAL_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `DISCOGS_TOKEN`, `ICAL_URL`, `ICAL_CALDAV_URL`, `ICAL_USERNAME`, `ICAL_PASSWORD` as secrets; `TRAKT_CLIENT_ID` as a variable); new integrations have `test_<name>_integration.py` and env vars in `tests/integrations/conftest.py`
 10. **Issue/milestone hygiene**:
     - Every open issue has a milestone (no orphans); scope is right-sized
     - Blocking relationships explicit ("Blocked by #X" in body)
@@ -456,7 +458,8 @@ template output, consult and follow both content docs:
 
 - `content/README.md` — content author reference: JSON format, priority
   guidelines (0–10 scale with tier definitions), `timeout` pairing rules,
-  schedule overrides, and the contrib integrations table
+  schedule overrides, schedule coordination guidelines (cron slot conventions,
+  timeout/hold pairing rules), and the contrib integrations table
 - `content/DESIGN.md` — visual/design conventions: layout, color use,
   tone, character set, time formatting, and the pre-ship checklist
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -18,7 +18,7 @@
 # Content filter. When absent, all user content loads and no contrib content
 # loads. When set, the filter applies to both user and contrib directories:
 #   ["*"]              — all user + all contrib
-#   ["bart", "trakt"]  — only these stems from either directory
+#   ["calendar", "weather"]  — only these stems from either directory
 #   ["my_quotes"]      — only my_quotes.json from content/user/
 # content_enabled = ["*"]
 
@@ -28,9 +28,65 @@
 # displays — flaps need time to settle). Default: 60.
 # min_hold = 60
 
+# ── Schedule overrides ─────────────────────────────────────────────────────────
+# Override schedule fields or visibility for any named template without editing
+# JSON. Section name: [<integration>.schedules.<template-name>]. All fields are
+# optional; unspecified fields use the template's JSON default.
+#
+# Common fields (apply to every integration):
+#   cron = "..."       — change when the template fires
+#   hold = 300         — seconds to display before advancing
+#   timeout = 1800     — seconds before discarding if not yet shown
+#   priority = 5       — 0–10; higher number runs first
+#   disabled = true    — skip this template entirely (overrides all other fields)
+#   private = true     — hide in public mode (overrides the template's private field)
+
 [vestaboard]
 # Read/Write API key from https://store.vestaboard.com/pages/read-write-api
 api_key = "your-vestaboard-read-write-api-key"
+
+[weather]
+# City to display weather for. Geocoded via Open-Meteo on first call; no API
+# key required.
+city = "San Francisco"
+
+# Unit system: "imperial" (°F, mph, default) or "metric" (°C, km/h).
+# units = "imperial"
+
+# [weather.schedules.conditions]
+# cron = "0 * * * *"
+# hold = 600
+# timeout = 1800
+# priority = 5
+
+[calendar]
+# Fetch today's events from ICS feeds and/or a private iCloud account.
+# Both modes can be active simultaneously — events are merged and sorted.
+
+# ICS mode — public/secret-address feeds (any number of URLs).
+# Google Calendar: Settings → calendar → "Secret address in iCal format"
+# iCloud: share calendar → enable "Public Calendar" → copy link (replace webcal:// with https://)
+# urls = [
+#   "https://calendar.google.com/calendar/ical/.../basic.ics",
+# ]
+
+# Optional: Vestaboard color letter per URL, parallel to urls.
+# Options: R (red), O (orange), Y (yellow), G (green), B (blue), V (violet), W (white), K (black)
+# iCloud feeds auto-detect calendar color from the feed — omit to use it.
+# colors = ["B", "G"]
+
+# CalDAV mode — private iCloud calendars.
+# Requires an app-specific password from appleid.apple.com (not your Apple ID password).
+# caldav_url = "https://caldav.icloud.com/"
+# username = "you@icloud.com"
+# password = "xxxx-xxxx-xxxx-xxxx"
+# calendar_names = ["Work", "Personal"]  # optional; default: all calendars
+
+# [calendar.schedules.today]
+# cron = "30 * * * *"
+# hold = 300
+# timeout = 1800
+# priority = 5
 
 [bart]
 # Free API key — register at https://api.bart.gov/api/register.aspx
@@ -46,36 +102,12 @@ line1_dest = "DALY"
 # Second departure line (optional — remove or leave blank for one line).
 # line2_dest = "BERY"
 
-# ── Schedule overrides (optional) ─────────────────────────────────────────────
-# Override cron, hold, timeout, or priority for a named template without
-# editing JSON. All fields are optional; unspecified fields use the template
-# default.
-
 # [bart.schedules.departures]
 # cron = "*/5 7-9 * * 1-5"
 # hold = 290
 # timeout = 60
 # priority = 8
 # refresh_interval = 60  # re-fetch departure times every 60s during the hold (min 30)
-# disabled = true        # skip this template entirely (all other fields ignored)
-# private = true         # hide in public mode (overrides the template's private field)
-
-[weather]
-# City to display weather for. Geocoded via Open-Meteo on first call; no API
-# key required.
-city = "San Francisco"
-
-# Unit system: "imperial" (°F, mph, default) or "metric" (°C, km/h).
-# units = "imperial"
-
-# ── Schedule overrides (optional) ─────────────────────────────────────────────
-# [weather.schedules.conditions]
-# cron = "0 * * * *"
-# hold = 600
-# timeout = 1800
-# priority = 5
-# disabled = true  # skip this template entirely (all other fields ignored)
-# private = true   # hide in public mode (overrides the template's private field)
 
 [discogs]
 # Personal access token (read-only) — generate at https://www.discogs.com/settings/developers
@@ -86,14 +118,26 @@ token = "your-discogs-personal-access-token"
 # List your folders at https://www.discogs.com/users/<username>/collection
 # folder_id = "0"
 
-# ── Schedule overrides (optional) ─────────────────────────────────────────────
 # [discogs.schedules.morning_spin]
 # cron = "0 9 * * *"
 # hold = 600
 # timeout = 3600
 # priority = 5
-# disabled = true  # skip this template entirely (all other fields ignored)
-# private = true   # hide in public mode (overrides the template's private field)
+
+[trakt]
+# OAuth credentials — create an application at https://trakt.tv/oauth/applications/new
+# Set Redirect URI to: urn:ietf:wg:oauth:2.0:oob
+client_id = "your-trakt-client-id"
+client_secret = "your-trakt-client-secret"
+
+# Written by the auth flow — do not edit manually.
+# Start the container, check logs for auth instructions, then approve in a browser.
+# access_token = "..."
+# refresh_token = "..."
+# expires_at = 1234567890
+
+# Optional: number of days ahead to show in the calendar (default 7, max 33)
+# calendar_days = 7
 
 [webhook]
 # Optional: enable the HTTP webhook listener so external systems (Plex,
@@ -114,18 +158,3 @@ token = "your-discogs-personal-access-token"
 # Unraid: the template maps container port 8080 → host port 32800 by default.
 # Requires a TLS-terminating reverse proxy for external webhook sources.
 # bind = "0.0.0.0"
-
-[trakt]
-# OAuth credentials — create an application at https://trakt.tv/oauth/applications/new
-# Set Redirect URI to: urn:ietf:wg:oauth:2.0:oob
-client_id = "your-trakt-client-id"
-client_secret = "your-trakt-client-secret"
-
-# Written by the auth flow — do not edit manually.
-# Start the container, check logs for auth instructions, then approve in a browser.
-# access_token = "..."
-# refresh_token = "..."
-# expires_at = 1234567890
-
-# Optional: number of days ahead to show in the calendar (default 7, max 33)
-# calendar_days = 7

--- a/content/contrib/calendar.json
+++ b/content/contrib/calendar.json
@@ -1,0 +1,22 @@
+{
+  "templates": {
+    "today": {
+      "schedule": {
+        "cron": "30 * * * *",
+        "hold": 300,
+        "timeout": 1800
+      },
+      "priority": 5,
+      "truncation": "ellipsis",
+      "integration": "calendar",
+      "templates": [
+        {
+          "format": [
+            "TODAY",
+            "{events}"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/content/contrib/calendar.md
+++ b/content/contrib/calendar.md
@@ -1,0 +1,96 @@
+# calendar.json
+
+Today's calendar events, updated every half-hour. Shows timed events (sorted
+soonest first) then all-day events. Supports multiple calendars with optional
+per-calendar color squares.
+
+Both modes can be active simultaneously — events from ICS feeds and CalDAV
+are merged and sorted together.
+
+- **ICS mode**: public or secret-address `.ics` feeds (Google Calendar, iCloud
+  public link, any provider). No authentication required.
+- **CalDAV mode**: private iCloud calendars via app-specific password.
+
+## Configuration
+
+### ICS mode
+
+```toml
+[calendar]
+urls = [
+  "https://calendar.google.com/calendar/ical/.../basic.ics",
+]
+# colors = ["B", "G"]
+```
+
+| Key | Required | Description |
+|---|---|---|
+| `urls` | Yes | One or more public `.ics` URLs. Google: Settings → calendar → "Secret address in iCal format". iCloud: share → enable "Public Calendar" → copy link (replace `webcal://` with `https://`). |
+| `colors` | No | Vestaboard color letter per URL, parallel to `urls`. Options: `R` `O` `Y` `G` `B` `V` `W` `K`. iCloud feeds include the calendar color automatically — omit `colors` to use it. |
+
+iCloud public feeds include `X-APPLE-CALENDAR-COLOR` in the feed itself, so
+the calendar's color is auto-detected with no config. Google feeds include no
+color; assign one via `colors` or omit for no color prefix.
+
+### CalDAV mode (private iCloud)
+
+```toml
+[calendar]
+caldav_url = "https://caldav.icloud.com/"
+username = "you@icloud.com"
+password = "xxxx-xxxx-xxxx-xxxx"
+# calendar_names = ["Work", "Personal"]
+```
+
+| Key | Required | Description |
+|---|---|---|
+| `caldav_url` | Yes | CalDAV server URL. iCloud: `https://caldav.icloud.com/` |
+| `username` | Yes | Apple ID email address |
+| `password` | Yes | App-specific password. Generate at https://appleid.apple.com → Security → App-Specific Passwords. Required when your Apple ID has two-factor authentication. |
+| `calendar_names` | No | List of calendar names to include. Default: all calendars. Order controls tie-breaking when two events start at the same time. |
+
+Calendar colors are read automatically from each calendar's CalDAV properties
+(`apple:calendar-color`) and mapped to the nearest Vestaboard color tag.
+
+> **Note on Google CalDAV:** Google requires OAuth 2.0 for CalDAV as of
+> March 2025 — use the ICS secret-address URL for Google Calendar instead.
+
+### Both modes together
+
+```toml
+[calendar]
+urls = ["https://calendar.google.com/calendar/ical/.../basic.ics"]
+colors = ["B"]
+caldav_url = "https://caldav.icloud.com/"
+username = "you@icloud.com"
+password = "xxxx-xxxx-xxxx-xxxx"
+```
+
+Events from all sources are merged and sorted together. ICS events sort before
+CalDAV events when start times tie.
+
+## Color mapping
+
+When a calendar color is present (auto-detected or configured), each event
+line is prefixed with the corresponding Vestaboard color square:
+
+```
+[B] 14:30 TEAM MEETING
+[G] PROJECT DEADLINE
+```
+
+The nearest Vestaboard color is chosen by Euclidean distance in RGB space from
+the calendar's hex color value.
+
+## Keeping data current
+
+### iCloud `.ics` URLs
+
+If you re-share or disable public sharing on an iCloud calendar, the URL
+changes. Update `urls` in `config.toml` with the new link.
+
+### CalDAV
+
+App-specific passwords do not expire but can be revoked at
+https://appleid.apple.com → Security → App-Specific Passwords. If the
+password is revoked, generate a new one and update `config.toml`.

--- a/content/contrib/trakt.json
+++ b/content/contrib/trakt.json
@@ -4,7 +4,7 @@
       "schedule": {
         "cron": "0 */4 * * *",
         "hold": 3600,
-        "timeout": 600
+        "timeout": 1800
       },
       "priority": 4,
       "private": true,

--- a/integrations/calendar.py
+++ b/integrations/calendar.py
@@ -1,0 +1,508 @@
+# integrations/calendar.py
+#
+# Calendar integration.
+#
+# Fetches events from ICS feeds and/or a private iCloud CalDAV account and
+# returns them as a variables dict for use with content templates.
+# Both modes can be active simultaneously — events are merged and sorted.
+#
+# ICS mode — public or secret-address feeds (Google Calendar, iCloud public):
+#   [calendar]
+#   urls = ["https://..."]
+#   colors = ["B", "G"]   # optional; R/O/Y/G/B/V/W/K, parallel to urls
+#
+# CalDAV mode — private iCloud:
+#   [calendar]
+#   caldav_url = "https://caldav.icloud.com/"
+#   username = "you@icloud.com"
+#   password = "xxxx-xxxx-xxxx-xxxx"   # app-specific password from appleid.apple.com
+#   calendar_names = ["Work", "Personal"]  # optional; default: all calendars
+#
+# Both modes may be configured at once; events are merged and sorted together.
+#
+# Events are sorted: timed (soonest first) then all-day (alphabetical).
+# Source order (URL index, then CalDAV calendar order) breaks start-time ties.
+# Timed events that have already ended are excluded.
+# Events with no SUMMARY or STATUS:CANCELLED are silently skipped.
+# If no events remain after filtering, raises IntegrationDataUnavailableError.
+
+import math
+import time
+from datetime import date, datetime, timedelta
+from typing import Any
+
+import recurring_ical_events
+import requests
+from icalendar import Calendar
+from icalendar.cal import Component
+
+from exceptions import IntegrationDataUnavailableError
+from integrations.http import fetch_with_retry
+
+# Approximate sRGB values for each Vestaboard color letter. Used for
+# nearest-color matching when reading hex color values from ICS/CalDAV data.
+_COLOR_RGB: dict[str, tuple[int, int, int]] = {
+  'R': (255, 59, 48),
+  'O': (255, 149, 0),
+  'Y': (255, 204, 0),
+  'G': (52, 199, 89),
+  'B': (0, 122, 255),
+  'V': (175, 82, 222),
+  'W': (255, 255, 255),
+  'K': (0, 0, 0),
+}
+
+_VALID_COLORS = frozenset(_COLOR_RGB)
+
+# Per-URL ICS bytes cache: url → (raw_bytes, monotonic_fetch_time).
+_ics_cache: dict[str, tuple[bytes, float]] = {}
+_ICS_CACHE_TTL = 30 * 60  # 30 minutes
+
+# CalDAV calendar cache: list of (caldav.Calendar, color_tag | None) pairs.
+# None = not yet populated.
+_caldav_cache: list[tuple[Any, str | None]] | None = None
+
+
+# ── Color helpers ──────────────────────────────────────────────────────────────
+
+
+def _wrap_color(letter: str) -> str:
+  """Validate a color letter from config and wrap it as a Vestaboard tag.
+
+  Raises ValueError if the letter is not a recognised Vestaboard color.
+  Input is case-insensitive.
+  """
+  upper = letter.strip().upper()
+  if upper not in _VALID_COLORS:
+    raise ValueError(f'Invalid calendar color {letter!r} — valid options: R, O, Y, G, B, V, W, K')
+  return f'[{upper}]'
+
+
+def _nearest_color_tag(hex_color: str) -> str:
+  """Return the nearest Vestaboard color tag for a hex color string.
+
+  Accepts #RRGGBB or #RRGGBBAA (Apple's format). Alpha channel is ignored.
+  Finds the closest color by Euclidean distance in RGB space.
+  """
+  hex_color = hex_color.strip().lstrip('#')
+  r = int(hex_color[0:2], 16)
+  g = int(hex_color[2:4], 16)
+  b = int(hex_color[4:6], 16)
+
+  best_letter = 'W'
+  best_dist = float('inf')
+  for letter, (cr, cg, cb) in _COLOR_RGB.items():
+    dist = math.sqrt((r - cr) ** 2 + (g - cg) ** 2 + (b - cb) ** 2)
+    if dist < best_dist:
+      best_dist = dist
+      best_letter = letter
+  return f'[{best_letter}]'
+
+
+# ── Timezone ───────────────────────────────────────────────────────────────────
+
+
+def _display_tz() -> Any:
+  """Return the display timezone (ZoneInfo | None for system local).
+
+  Reads [scheduler].timezone from config. Returns None to use system local
+  timezone, matching the behaviour of config.get_timezone().
+  """
+  import config as _cfg
+
+  return _cfg.get_timezone()
+
+
+def _get_now(tz: Any) -> datetime:
+  """Return current time in the given timezone. Extracted for testability."""
+  return datetime.now(tz) if tz else datetime.now().astimezone()
+
+
+# ── ICS fetching and parsing ───────────────────────────────────────────────────
+
+
+def _fetch_ics_bytes(url: str) -> bytes:
+  """Fetch raw ICS bytes from a URL, with per-URL caching.
+
+  Returns cached bytes if within _ICS_CACHE_TTL. On transient failure,
+  returns cached bytes if available (even if stale). Raises
+  IntegrationDataUnavailableError on cold-start fetch failure.
+  """
+  cached = _ics_cache.get(url)
+  if cached is not None:
+    data, fetched_at = cached
+    if time.monotonic() - fetched_at <= _ICS_CACHE_TTL:
+      return data
+
+  try:
+    r = fetch_with_retry('GET', url, timeout=15)
+    r.raise_for_status()
+    data = r.content
+    _ics_cache[url] = (data, time.monotonic())
+    return data
+  except requests.RequestException as e:
+    if cached is not None:
+      print(f'calendar: fetch failed for {url!r}, serving stale cache — {e}')
+      return cached[0]
+    raise IntegrationDataUnavailableError(f'calendar: fetch failed for {url!r} — {e}') from None
+
+
+def _ics_calendar_color(cal: Calendar) -> str | None:
+  """Return the nearest Vestaboard color tag from X-APPLE-CALENDAR-COLOR, or None."""
+  raw = cal.get('X-APPLE-CALENDAR-COLOR')
+  if not raw:
+    return None
+  try:
+    return _nearest_color_tag(str(raw))
+  except ValueError, IndexError:
+    return None
+
+
+# ── Event helpers ──────────────────────────────────────────────────────────────
+
+
+def _is_allday(component: Component) -> bool:
+  """Return True if the event is an all-day event (DATE-only DTSTART)."""
+  dtstart = component.get('DTSTART')
+  if dtstart is None:
+    return False
+  return isinstance(dtstart.dt, date) and not isinstance(dtstart.dt, datetime)
+
+
+def _event_start(component: Component, tz: Any) -> datetime:
+  """Return the event start as a timezone-aware datetime in the display timezone.
+
+  For all-day events, returns midnight of the start date in the display TZ.
+  For timed events, converts to display TZ (attaches TZ to floating times).
+  """
+  dtstart = component.get('DTSTART')
+  dt = dtstart.dt if dtstart else datetime.now(tz)
+
+  if isinstance(dt, date) and not isinstance(dt, datetime):
+    # All-day event: treat as midnight in display TZ.
+    result = datetime(dt.year, dt.month, dt.day, tzinfo=tz)
+  elif dt.tzinfo is None:
+    # Floating time — attach display TZ.
+    result = dt.replace(tzinfo=tz)
+  else:
+    result = dt.astimezone(tz)
+  return result
+
+
+def _event_end(component: Component, tz: Any, start: datetime) -> datetime | None:
+  """Return the event end as a timezone-aware datetime in the display timezone.
+
+  Handles DTEND, DURATION, and all-day end dates. Returns None for
+  point-in-time events with no end or duration.
+  """
+  dtend = component.get('DTEND')
+  if dtend is not None:
+    dt = dtend.dt
+    if isinstance(dt, date) and not isinstance(dt, datetime):
+      return datetime(dt.year, dt.month, dt.day, tzinfo=tz)
+    if dt.tzinfo is None:
+      return dt.replace(tzinfo=tz)
+    return dt.astimezone(tz)
+
+  duration = component.get('DURATION')
+  if duration is not None:
+    return start + duration.dt
+
+  return None
+
+
+def _format_event(component: Component, tz: Any, color_tag: str | None) -> str | None:
+  """Format a VEVENT component as a single display line, or None to skip.
+
+  Timed events: '[TAG ]HH:MM TITLE'
+  All-day events: '[TAG ]TITLE'
+
+  Returns None if the event has no SUMMARY or is CANCELLED.
+  """
+  summary = component.get('SUMMARY')
+  if not summary:
+    return None
+  if str(component.get('STATUS', '')).upper() == 'CANCELLED':
+    return None
+
+  title = str(summary).upper()
+  prefix = f'{color_tag} ' if color_tag else ''
+
+  if _is_allday(component):
+    return f'{prefix}{title}'
+
+  start = _event_start(component, tz)
+  return f'{prefix}{start.strftime("%H:%M")} {title}'
+
+
+# ── ICS mode ───────────────────────────────────────────────────────────────────
+
+
+def _collect_candidates_ics(
+  cal_cfg: dict[str, Any],
+  now: datetime,
+  tz: Any,
+  index_offset: int = 0,
+) -> list[tuple[Component, str | None, int]]:
+  """Collect event candidates from one or more ICS URLs.
+
+  Returns (component, color_tag, cal_index) tuples for events in today's
+  window. One URL failing serves stale cache if available; cold-start
+  failures log a warning and skip that URL.
+  """
+  urls: list[str] = cal_cfg.get('urls', [])
+  color_letters: list[str] = cal_cfg.get('colors', [])
+
+  window_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+  window_end = window_start + timedelta(days=1)
+
+  candidates: list[tuple[Component, str | None, int]] = []
+
+  for i, url in enumerate(urls):
+    configured_color: str | None = None
+    if i < len(color_letters):
+      try:
+        configured_color = _wrap_color(color_letters[i])
+      except ValueError as e:
+        print(f'calendar: {e}')
+
+    try:
+      raw = _fetch_ics_bytes(url)
+    except IntegrationDataUnavailableError as e:
+      print(f'calendar: skipping URL {i + 1} — {e}')
+      continue
+
+    cal = Calendar.from_ical(raw)
+    auto_color = _ics_calendar_color(cal)
+    color_tag = configured_color or auto_color
+
+    try:
+      occurrences = recurring_ical_events.of(cal).between(window_start, window_end)
+    except Exception as e:  # noqa: BLE001
+      print(f'calendar: failed to expand events for URL {i + 1} — {e}')
+      continue
+
+    for component in occurrences:
+      candidates.append((component, color_tag, index_offset + i))
+
+  return candidates
+
+
+# ── CalDAV mode ────────────────────────────────────────────────────────────────
+
+
+def _get_caldav_calendars(
+  caldav_url: str,
+  username: str,
+  password: str,
+  calendar_names: list[str] | None,
+) -> list[tuple[Any, str | None]]:
+  """Discover iCloud CalDAV calendars and their colors. Cached for process lifetime.
+
+  Returns a list of (caldav.Calendar, color_tag | None) pairs in the order
+  specified by calendar_names (or all calendars if calendar_names is empty).
+  """
+  global _caldav_cache
+
+  if _caldav_cache is not None:
+    return _caldav_cache
+
+  import caldav
+  from caldav.elements import ical as caldav_ical
+
+  client = caldav.DAVClient(
+    url=caldav_url,
+    username=username,
+    password=password,
+    timeout=15,
+  )
+  try:
+    principal = client.principal()
+    all_cals = principal.calendars()
+  except Exception as e:  # noqa: BLE001
+    raise IntegrationDataUnavailableError(f'calendar: CalDAV connection failed — {e}') from None
+
+  result: list[tuple[Any, str | None]] = []
+
+  # Filter to requested calendar names if specified.
+  name_filter: set[str] | None = set(calendar_names) if calendar_names else None
+
+  for cal in all_cals:
+    cal_name = str(cal.name or '')
+    if name_filter is not None and cal_name not in name_filter:
+      continue
+
+    color_tag: str | None = None
+    try:
+      props = cal.get_properties([caldav_ical.CalendarColor()])
+      raw_color = props.get('{http://apple.com/ns/ical/}calendar-color') if props else None
+      if raw_color:
+        color_tag = _nearest_color_tag(str(raw_color))
+    except Exception:  # noqa: BLE001  # nosec B110 — color is optional; CalDAV property fetch may fail on non-Apple servers
+      pass
+
+    result.append((cal, color_tag))
+
+  # If calendar_names was specified, reorder to match the requested order.
+  if name_filter is not None:
+    order = {name: i for i, name in enumerate(calendar_names or [])}
+    result.sort(key=lambda item: order.get(str(item[0].name or ''), len(order)))
+
+  _caldav_cache = result
+  return result
+
+
+def _collect_candidates_caldav(
+  cal_cfg: dict[str, Any],
+  now: datetime,
+  tz: Any,
+  index_offset: int = 0,
+) -> list[tuple[Component, str | None, int]]:
+  """Collect event candidates from iCloud CalDAV.
+
+  Returns (component, color_tag, cal_index) tuples for events in today's
+  window. Raises IntegrationDataUnavailableError on missing credentials or
+  connection failure. Returns an empty list if no calendars are found or
+  all calendars fail to fetch.
+  """
+  caldav_url = cal_cfg.get('caldav_url', '')
+  username = cal_cfg.get('username', '')
+  password = cal_cfg.get('password', '')
+  calendar_names_raw = cal_cfg.get('calendar_names')
+  calendar_names: list[str] | None = list(calendar_names_raw) if calendar_names_raw else None
+
+  if not caldav_url or not username or not password:
+    raise IntegrationDataUnavailableError(
+      'calendar: CalDAV mode requires caldav_url, username, and password in config.toml'
+    )
+
+  calendars = _get_caldav_calendars(caldav_url, username, password, calendar_names)
+  if not calendars:
+    print('calendar: no CalDAV calendars found')
+    return []
+
+  window_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+  window_end = window_start + timedelta(days=1)
+
+  candidates: list[tuple[Component, str | None, int]] = []
+
+  for i, (cal, color_tag) in enumerate(calendars):
+    try:
+      events = cal.events()
+    except Exception as e:  # noqa: BLE001
+      print(f'calendar: failed to fetch events from CalDAV calendar {i + 1} — {e}')
+      continue
+
+    # Build a merged Calendar for client-side recurring event expansion.
+    merged = Calendar()
+    for event_obj in events:
+      try:
+        for component in event_obj.icalendar_object.subcomponents:
+          if component.name == 'VEVENT':
+            merged.add_component(component)
+      except Exception:  # noqa: BLE001  # nosec B112 — skip malformed CalDAV event objects; continue to next
+        continue
+
+    try:
+      occurrences = recurring_ical_events.of(merged).between(window_start, window_end)
+    except Exception as e:  # noqa: BLE001
+      print(f'calendar: failed to expand CalDAV events for calendar {i + 1} — {e}')
+      continue
+
+    for component in occurrences:
+      candidates.append((component, color_tag, index_offset + i))
+
+  return candidates
+
+
+# ── Sorting and formatting ─────────────────────────────────────────────────────
+
+
+def _sort_and_format(
+  candidates: list[tuple[Component, str | None, int]],
+  now: datetime,
+  tz: Any,
+) -> list[str]:
+  """Filter, sort, and format event candidates into display lines.
+
+  Sort order:
+    1. Timed events by start time (soonest first).
+    2. All-day / multi-day events alphabetically by title.
+    3. Source index as tiebreaker (ICS URLs first, then CalDAV calendars).
+
+  Timed events whose end time is already in the past are excluded.
+  Events with no SUMMARY or STATUS:CANCELLED are excluded.
+  Returns up to 10 lines (scheduler row limit handles further truncation).
+  """
+  lines: list[str] = []
+
+  def sort_key(item: tuple[Component, str | None, int]) -> tuple:
+    component, _, cal_index = item
+    allday = _is_allday(component)
+    if allday:
+      title = str(component.get('SUMMARY', '')).upper()
+      return (1, '', title, cal_index)
+    start = _event_start(component, tz)
+    return (0, start.isoformat(), '', cal_index)
+
+  for component, color_tag, _ in sorted(candidates, key=sort_key):
+    # Skip ended timed events.
+    if not _is_allday(component):
+      start = _event_start(component, tz)
+      end = _event_end(component, tz, start)
+      if end is not None and end < now:
+        continue
+
+    line = _format_event(component, tz, color_tag)
+    if line is not None:
+      lines.append(line)
+
+    if len(lines) >= 10:
+      break
+
+  return lines
+
+
+# ── Entry point ────────────────────────────────────────────────────────────────
+
+
+def get_variables() -> dict[str, list[list[str]]]:
+  """Return today's calendar events as a variables dict for template rendering.
+
+  Returns key 'events' as a single option containing one line per event.
+  Collects from ICS URLs and/or CalDAV if configured (both may be active).
+  Raises IntegrationDataUnavailableError if no events are available.
+  """
+  import config as _cfg
+
+  cal_cfg: dict[str, Any] = _cfg._config.get('calendar', {})
+  if not cal_cfg:
+    raise IntegrationDataUnavailableError('calendar: no [calendar] section in config.toml')
+
+  has_ics = 'urls' in cal_cfg
+  has_caldav = 'caldav_url' in cal_cfg
+
+  if not has_ics and not has_caldav:
+    raise IntegrationDataUnavailableError(
+      'calendar: [calendar] section must have urls (ICS) and/or caldav_url/username/password (CalDAV)'
+    )
+
+  tz = _display_tz()
+  now = _get_now(tz)
+  tz_ = tz or now.tzinfo
+
+  candidates: list[tuple[Component, str | None, int]] = []
+
+  if has_ics:
+    candidates += _collect_candidates_ics(cal_cfg, now, tz_)
+
+  if has_caldav:
+    ics_count = len(cal_cfg.get('urls', []))
+    candidates += _collect_candidates_caldav(cal_cfg, now, tz_, index_offset=ics_count)
+
+  lines = _sort_and_format(candidates, now, tz_)
+
+  if not lines:
+    raise IntegrationDataUnavailableError('calendar: no events today')
+
+  return {'events': [lines]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.23.2"
+version = "0.24.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [
@@ -15,6 +15,9 @@ license-files = ["LICENSE.txt"]
 requires-python = ">=3.14"
 dependencies = [
     "apscheduler>=3.11.2",
+    "caldav>=1.4.0",
+    "icalendar>=7.0.0",
+    "recurring-ical-events>=3.8.0",
     "requests>=2.32.5",
 ]
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -41,7 +41,7 @@ from exceptions import IntegrationDataUnavailableError
 
 # Allowlist of valid integration names. Must be extended when a new integration
 # is added to integrations/.
-_KNOWN_INTEGRATIONS: frozenset[str] = frozenset({'bart', 'discogs', 'plex', 'trakt', 'weather'})
+_KNOWN_INTEGRATIONS: frozenset[str] = frozenset({'bart', 'calendar', 'discogs', 'plex', 'trakt', 'weather'})
 
 # Cache of loaded integration modules, keyed by name.
 _integrations: dict[str, Any] = {}

--- a/tests/core/test_calendar.py
+++ b/tests/core/test_calendar.py
@@ -1,0 +1,507 @@
+from datetime import datetime, timedelta, timezone
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+from icalendar import Calendar, Event
+
+import integrations.calendar as calendar
+from exceptions import IntegrationDataUnavailableError
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def reset_caches() -> Generator[None, None, None]:
+  """Reset module-level caches before each test."""
+  calendar._ics_cache.clear()
+  calendar._caldav_cache = None
+  yield
+  calendar._ics_cache.clear()
+  calendar._caldav_cache = None
+
+
+@pytest.fixture()
+def ical_config_ics(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Patch config with a minimal ICS-mode ical section."""
+  import config as _cfg
+
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {'calendar': {'urls': ['https://example.com/cal.ics']}, 'scheduler': {}},
+  )
+
+
+@pytest.fixture()
+def ical_config_ics_two_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Patch config with two ICS URLs, each with a color."""
+  import config as _cfg
+
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {
+      'calendar': {
+        'urls': ['https://example.com/cal1.ics', 'https://example.com/cal2.ics'],
+        'colors': ['B', 'G'],
+      },
+      'scheduler': {},
+    },
+  )
+
+
+# ── ICS builder helpers ────────────────────────────────────────────────────────
+
+_UTC = timezone.utc
+
+# Fixed reference time used by helpers and tests that patch _get_now.
+# Pinned to noon UTC so events ±3 hours are always within the same calendar day.
+_FIXED_NOW = datetime(2026, 1, 15, 12, 0, 0, tzinfo=_UTC)
+
+
+def _make_ics(events_data: list[dict]) -> bytes:
+  """Build raw ICS bytes from a list of event property dicts."""
+  cal = Calendar()
+  for ev_data in events_data:
+    ev = Event()
+    for key, val in ev_data.items():
+      ev.add(key, val)
+    cal.add_component(ev)
+  return cal.to_ical()
+
+
+def _make_ics_with_cal_color(events_data: list[dict], cal_color: str) -> bytes:
+  """Build raw ICS bytes with an X-APPLE-CALENDAR-COLOR property on the VCALENDAR."""
+  cal = Calendar()
+  cal.add('X-APPLE-CALENDAR-COLOR', cal_color)
+  for ev_data in events_data:
+    ev = Event()
+    for key, val in ev_data.items():
+      ev.add(key, val)
+    cal.add_component(ev)
+  return cal.to_ical()
+
+
+def _future_event(title: str = 'MEETING', hours_ahead: float = 2.0) -> dict:
+  start = _FIXED_NOW + timedelta(hours=hours_ahead)
+  end = start + timedelta(hours=1)
+  return {'SUMMARY': title, 'DTSTART': start, 'DTEND': end}
+
+
+def _past_event(title: str = 'OLD MEETING') -> dict:
+  start = _FIXED_NOW - timedelta(hours=3)
+  end = _FIXED_NOW - timedelta(hours=2)
+  return {'SUMMARY': title, 'DTSTART': start, 'DTEND': end}
+
+
+def _allday_event(title: str = 'HOLIDAY') -> dict:
+  return {'SUMMARY': title, 'DTSTART': _FIXED_NOW.date()}
+
+
+# ── Color helpers ──────────────────────────────────────────────────────────────
+
+
+def test_wrap_color_valid() -> None:
+  assert calendar._wrap_color('B') == '[B]'
+  assert calendar._wrap_color('b') == '[B]'  # case-insensitive
+  assert calendar._wrap_color('R') == '[R]'
+
+
+def test_wrap_color_invalid() -> None:
+  with pytest.raises(ValueError, match='Invalid calendar color'):
+    calendar._wrap_color('X')
+  with pytest.raises(ValueError, match='Invalid calendar color'):
+    calendar._wrap_color('purple')
+
+
+def test_nearest_color_tag_red() -> None:
+  # Apple red #FF2D30FF → nearest is R
+  assert calendar._nearest_color_tag('#FF2D30FF') == '[R]'
+
+
+def test_nearest_color_tag_blue() -> None:
+  assert calendar._nearest_color_tag('#007AFF') == '[B]'
+
+
+def test_nearest_color_tag_strips_alpha() -> None:
+  # With and without alpha should resolve to the same color
+  assert calendar._nearest_color_tag('#52C755FF') == calendar._nearest_color_tag('#52C755')
+
+
+def test_ics_calendar_color_parsed() -> None:
+  cal = Calendar()
+  cal.add('X-APPLE-CALENDAR-COLOR', '#007AFFFF')
+  result = calendar._ics_calendar_color(cal)
+  assert result == '[B]'
+
+
+def test_ics_calendar_color_absent() -> None:
+  cal = Calendar()
+  assert calendar._ics_calendar_color(cal) is None
+
+
+# ── ICS mode: basic ────────────────────────────────────────────────────────────
+
+
+def test_get_variables_returns_events_key(ical_config_ics: None) -> None:
+  ics = _make_ics([_future_event('TEAM MEETING')])
+  with patch('integrations.calendar._fetch_ics_bytes', return_value=ics):
+    with patch('integrations.calendar._display_tz', return_value=_UTC):
+      with patch('integrations.calendar._get_now', return_value=_FIXED_NOW):
+        result = calendar.get_variables()
+  assert 'events' in result
+  assert len(result['events']) == 1
+  assert len(result['events'][0]) >= 1
+
+
+def test_get_variables_24h_time_format(ical_config_ics: None) -> None:
+  # Event at 14:30 UTC on the same day as _FIXED_NOW (noon UTC).
+  start = _FIXED_NOW.replace(hour=14, minute=30, second=0, microsecond=0)
+  end = start + timedelta(hours=1)
+  ics = _make_ics([{'SUMMARY': 'DENTIST', 'DTSTART': start, 'DTEND': end}])
+
+  with patch('integrations.calendar._fetch_ics_bytes', return_value=ics):
+    with patch('integrations.calendar._display_tz', return_value=_UTC):
+      with patch('integrations.calendar._get_now', return_value=_FIXED_NOW):
+        result = calendar.get_variables()
+
+  lines = result['events'][0]
+  assert any('14:30' in line for line in lines), f'Expected 14:30 in lines: {lines}'
+  assert not any('AM' in line or 'PM' in line for line in lines)
+
+
+def test_get_variables_all_day_no_time_prefix(ical_config_ics: None) -> None:
+  ics = _make_ics([_allday_event('PROJECT DEADLINE')])
+  with patch('integrations.calendar._fetch_ics_bytes', return_value=ics):
+    with patch('integrations.calendar._display_tz', return_value=_UTC):
+      with patch('integrations.calendar._get_now', return_value=_FIXED_NOW):
+        result = calendar.get_variables()
+  lines = result['events'][0]
+  assert any('PROJECT DEADLINE' in line for line in lines)
+  # Should have no time component (no colon between two digits)
+  for line in lines:
+    if 'PROJECT DEADLINE' in line:
+      assert ':' not in line.split('PROJECT')[0] or not line.split('PROJECT')[0].strip()
+
+
+# ── ICS mode: color ────────────────────────────────────────────────────────────
+
+
+def test_get_variables_apple_color_auto_detected(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'calendar': {'urls': ['https://example.com/cal.ics']}, 'scheduler': {}})
+  ics = _make_ics_with_cal_color([_future_event('WORK MEETING')], '#007AFFFF')  # blue
+  with patch('integrations.calendar._fetch_ics_bytes', return_value=ics):
+    with patch('integrations.calendar._display_tz', return_value=_UTC):
+      with patch('integrations.calendar._get_now', return_value=_FIXED_NOW):
+        result = calendar.get_variables()
+  lines = result['events'][0]
+  assert any(line.startswith('[B]') for line in lines)
+
+
+def test_get_variables_configured_color_used(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {'calendar': {'urls': ['https://example.com/cal.ics'], 'colors': ['V']}, 'scheduler': {}},
+  )
+  ics = _make_ics([_future_event('PERSONAL EVENT')])
+  with patch('integrations.calendar._fetch_ics_bytes', return_value=ics):
+    with patch('integrations.calendar._display_tz', return_value=_UTC):
+      with patch('integrations.calendar._get_now', return_value=_FIXED_NOW):
+        result = calendar.get_variables()
+  lines = result['events'][0]
+  assert any(line.startswith('[V]') for line in lines)
+
+
+def test_get_variables_configured_color_overrides_apple(monkeypatch: pytest.MonkeyPatch) -> None:
+  """User-configured color takes precedence over auto-detected X-APPLE-CALENDAR-COLOR."""
+  import config as _cfg
+
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {'calendar': {'urls': ['https://example.com/cal.ics'], 'colors': ['G']}, 'scheduler': {}},
+  )
+  ics = _make_ics_with_cal_color([_future_event('MEETING')], '#FF2D30FF')  # red in ICS
+  with patch('integrations.calendar._fetch_ics_bytes', return_value=ics):
+    with patch('integrations.calendar._display_tz', return_value=_UTC):
+      with patch('integrations.calendar._get_now', return_value=_FIXED_NOW):
+        result = calendar.get_variables()
+  lines = result['events'][0]
+  assert any(line.startswith('[G]') for line in lines)
+
+
+# ── ICS mode: filtering ────────────────────────────────────────────────────────
+
+
+def test_get_variables_timed_event_ended_skipped(ical_config_ics: None) -> None:
+  ics = _make_ics([_past_event('FINISHED MEETING')])
+  with patch('integrations.calendar._fetch_ics_bytes', return_value=ics):
+    with patch('integrations.calendar._display_tz', return_value=_UTC):
+      with patch('integrations.calendar._get_now', return_value=_FIXED_NOW):
+        with pytest.raises(IntegrationDataUnavailableError):
+          calendar.get_variables()
+
+
+def test_get_variables_no_summary_skipped(ical_config_ics: None) -> None:
+  start = _FIXED_NOW + timedelta(hours=1)
+  end = _FIXED_NOW + timedelta(hours=2)
+  ics = _make_ics([{'DTSTART': start, 'DTEND': end}])
+  with patch('integrations.calendar._fetch_ics_bytes', return_value=ics):
+    with patch('integrations.calendar._display_tz', return_value=_UTC):
+      with patch('integrations.calendar._get_now', return_value=_FIXED_NOW):
+        with pytest.raises(IntegrationDataUnavailableError):
+          calendar.get_variables()
+
+
+def test_get_variables_cancelled_skipped(ical_config_ics: None) -> None:
+  ics = _make_ics(
+    [
+      {
+        'SUMMARY': 'CANCELLED MEETING',
+        'STATUS': 'CANCELLED',
+        'DTSTART': _FIXED_NOW + timedelta(hours=1),
+        'DTEND': _FIXED_NOW + timedelta(hours=2),
+      }
+    ]
+  )
+  with patch('integrations.calendar._fetch_ics_bytes', return_value=ics):
+    with patch('integrations.calendar._display_tz', return_value=_UTC):
+      with patch('integrations.calendar._get_now', return_value=_FIXED_NOW):
+        with pytest.raises(IntegrationDataUnavailableError):
+          calendar.get_variables()
+
+
+def test_get_variables_no_events_raises(ical_config_ics: None) -> None:
+  ics = _make_ics([])
+  with patch('integrations.calendar._fetch_ics_bytes', return_value=ics):
+    with patch('integrations.calendar._display_tz', return_value=_UTC):
+      with patch('integrations.calendar._get_now', return_value=_FIXED_NOW):
+        with pytest.raises(IntegrationDataUnavailableError, match='no events today'):
+          calendar.get_variables()
+
+
+# ── ICS mode: sort order ───────────────────────────────────────────────────────
+
+
+def test_get_variables_timed_before_allday(ical_config_ics: None) -> None:
+  ics = _make_ics([_allday_event('ALL DAY EVENT'), _future_event('TIMED EVENT')])
+  with patch('integrations.calendar._fetch_ics_bytes', return_value=ics):
+    with patch('integrations.calendar._display_tz', return_value=_UTC):
+      with patch('integrations.calendar._get_now', return_value=_FIXED_NOW):
+        result = calendar.get_variables()
+  lines = result['events'][0]
+  timed_idx = next(i for i, ln in enumerate(lines) if 'TIMED EVENT' in ln)
+  allday_idx = next(i for i, ln in enumerate(lines) if 'ALL DAY EVENT' in ln)
+  assert timed_idx < allday_idx
+
+
+def test_get_variables_url_order_tiebreaker(monkeypatch: pytest.MonkeyPatch) -> None:
+  """When two events have the same start time, the event from URL 0 comes first."""
+  import config as _cfg
+
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {'calendar': {'urls': ['https://example.com/a.ics', 'https://example.com/b.ics']}, 'scheduler': {}},
+  )
+  start = _FIXED_NOW + timedelta(hours=2)
+  end = start + timedelta(hours=1)
+  ics_a = _make_ics([{'SUMMARY': 'URL A EVENT', 'DTSTART': start, 'DTEND': end}])
+  ics_b = _make_ics([{'SUMMARY': 'URL B EVENT', 'DTSTART': start, 'DTEND': end}])
+
+  def fake_fetch(url: str) -> bytes:
+    return ics_a if 'a.ics' in url else ics_b
+
+  with patch('integrations.calendar._fetch_ics_bytes', side_effect=fake_fetch):
+    with patch('integrations.calendar._display_tz', return_value=_UTC):
+      with patch('integrations.calendar._get_now', return_value=_FIXED_NOW):
+        result = calendar.get_variables()
+  lines = result['events'][0]
+  a_idx = next(i for i, ln in enumerate(lines) if 'URL A EVENT' in ln)
+  b_idx = next(i for i, ln in enumerate(lines) if 'URL B EVENT' in ln)
+  assert a_idx < b_idx
+
+
+def test_get_variables_multiple_urls_merged(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {'calendar': {'urls': ['https://example.com/a.ics', 'https://example.com/b.ics']}, 'scheduler': {}},
+  )
+  ics_a = _make_ics([_future_event('EVENT FROM A')])
+  ics_b = _make_ics([_future_event('EVENT FROM B', hours_ahead=3)])
+
+  def fake_fetch(url: str) -> bytes:
+    return ics_a if 'a.ics' in url else ics_b
+
+  with patch('integrations.calendar._fetch_ics_bytes', side_effect=fake_fetch):
+    with patch('integrations.calendar._display_tz', return_value=_UTC):
+      with patch('integrations.calendar._get_now', return_value=_FIXED_NOW):
+        result = calendar.get_variables()
+  lines = result['events'][0]
+  assert any('EVENT FROM A' in ln for ln in lines)
+  assert any('EVENT FROM B' in ln for ln in lines)
+
+
+# ── ICS mode: failure handling ─────────────────────────────────────────────────
+
+
+def test_get_variables_one_url_fails_gracefully(monkeypatch: pytest.MonkeyPatch) -> None:
+  """If one URL fails with no cache, it is skipped; events from the other URL still show."""
+  import config as _cfg
+
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {'calendar': {'urls': ['https://example.com/fail.ics', 'https://example.com/ok.ics']}, 'scheduler': {}},
+  )
+  ics_ok = _make_ics([_future_event('OK EVENT')])
+
+  def fake_fetch(url: str) -> bytes:
+    if 'fail' in url:
+      raise IntegrationDataUnavailableError('fetch failed')
+    return ics_ok
+
+  with patch('integrations.calendar._fetch_ics_bytes', side_effect=fake_fetch):
+    with patch('integrations.calendar._display_tz', return_value=_UTC):
+      with patch('integrations.calendar._get_now', return_value=_FIXED_NOW):
+        result = calendar.get_variables()
+  lines = result['events'][0]
+  assert any('OK EVENT' in ln for ln in lines)
+
+
+def test_get_variables_cache_served_on_transient_failure(ical_config_ics: None) -> None:
+  """On fetch failure, stale cached bytes are served."""
+  ics = _make_ics([_future_event('CACHED EVENT')])
+  # Seed the cache with stale-but-valid data.
+  import time
+
+  calendar._ics_cache['https://example.com/cal.ics'] = (ics, time.monotonic() - 99999)
+
+  import requests as req
+
+  with patch('integrations.calendar._fetch_ics_bytes', side_effect=req.ConnectionError('down')):
+    with patch('integrations.calendar._display_tz', return_value=_UTC):
+      # fetch_ics_bytes handles the stale cache internally; get_variables should succeed
+      # by re-fetching from stale cache via the real function (not mocked here)
+      pass
+
+  # Call the real _fetch_ics_bytes to confirm stale cache is returned on error.
+  with patch('integrations.calendar.fetch_with_retry', side_effect=req.ConnectionError('down')):
+    data = calendar._fetch_ics_bytes('https://example.com/cal.ics')
+  assert data == ics
+
+
+def test_get_variables_raises_cold_start_failure(ical_config_ics: None) -> None:
+  """On fetch failure with no cache, IntegrationDataUnavailableError is raised."""
+  import requests as req
+
+  with patch('integrations.calendar.fetch_with_retry', side_effect=req.ConnectionError('down')):
+    with pytest.raises(IntegrationDataUnavailableError, match='fetch failed'):
+      calendar._fetch_ics_bytes('https://example.com/cal.ics')
+
+
+# ── CalDAV color ───────────────────────────────────────────────────────────────
+
+
+def test_nearest_color_tag_apple_red() -> None:
+  """Apple's default red #FF2D55FF maps to [R]."""
+  assert calendar._nearest_color_tag('#FF2D55FF') == '[R]'
+
+
+def test_nearest_color_tag_apple_green() -> None:
+  """Apple's default green #34C759FF maps to [G]."""
+  assert calendar._nearest_color_tag('#34C759FF') == '[G]'
+
+
+def test_nearest_color_tag_white() -> None:
+  assert calendar._nearest_color_tag('#FFFFFFFF') == '[W]'
+
+
+def test_nearest_color_tag_black() -> None:
+  assert calendar._nearest_color_tag('#000000FF') == '[K]'
+
+
+# ── Both modes simultaneously ──────────────────────────────────────────────────
+
+
+def test_get_variables_both_modes_merged(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Events from ICS and CalDAV are merged into a single sorted list."""
+  from unittest.mock import MagicMock
+
+  import config as _cfg
+
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {
+      'calendar': {
+        'urls': ['https://example.com/cal.ics'],
+        'caldav_url': 'https://caldav.icloud.com/',
+        'username': 'user@icloud.com',
+        'password': 'xxxx-xxxx-xxxx-xxxx',
+      },
+      'scheduler': {},
+    },
+  )
+
+  ics = _make_ics([_future_event('ICS EVENT', hours_ahead=1)])
+
+  # Build a fake CalDAV calendar that returns a CalDAV event.
+  caldav_event_ics = _make_ics([_future_event('CALDAV EVENT', hours_ahead=3)])
+  fake_cal_obj = MagicMock()
+  fake_cal_obj.icalendar_object = Calendar.from_ical(caldav_event_ics)
+  fake_caldav_cal = MagicMock()
+  fake_caldav_cal.events.return_value = [fake_cal_obj]
+
+  with patch('integrations.calendar._fetch_ics_bytes', return_value=ics):
+    with patch('integrations.calendar._get_caldav_calendars', return_value=[(fake_caldav_cal, '[G]')]):
+      with patch('integrations.calendar._display_tz', return_value=_UTC):
+        with patch('integrations.calendar._get_now', return_value=_FIXED_NOW):
+          result = calendar.get_variables()
+
+  lines = result['events'][0]
+  assert any('ICS EVENT' in ln for ln in lines), f'ICS event missing from: {lines}'
+  assert any('CALDAV EVENT' in ln for ln in lines), f'CalDAV event missing from: {lines}'
+  # ICS event is 1h ahead, CalDAV is 3h ahead → ICS should sort first.
+  ics_idx = next(i for i, ln in enumerate(lines) if 'ICS EVENT' in ln)
+  caldav_idx = next(i for i, ln in enumerate(lines) if 'CALDAV EVENT' in ln)
+  assert ics_idx < caldav_idx
+
+
+def test_get_variables_caldav_absent_does_not_block_ics(monkeypatch: pytest.MonkeyPatch) -> None:
+  """If CalDAV returns no calendars, ICS events still appear."""
+  import config as _cfg
+
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {
+      'calendar': {
+        'urls': ['https://example.com/cal.ics'],
+        'caldav_url': 'https://caldav.icloud.com/',
+        'username': 'user@icloud.com',
+        'password': 'xxxx-xxxx-xxxx-xxxx',
+      },
+      'scheduler': {},
+    },
+  )
+
+  ics = _make_ics([_future_event('ICS ONLY EVENT')])
+
+  with patch('integrations.calendar._fetch_ics_bytes', return_value=ics):
+    with patch('integrations.calendar._get_caldav_calendars', return_value=[]):
+      with patch('integrations.calendar._display_tz', return_value=_UTC):
+        with patch('integrations.calendar._get_now', return_value=_FIXED_NOW):
+          result = calendar.get_variables()
+
+  lines = result['events'][0]
+  assert any('ICS ONLY EVENT' in ln for ln in lines)

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -4,8 +4,12 @@ from pathlib import Path
 import pytest
 
 _INTEGRATION_VARS: list[tuple[str, str]] = [
-  ('BART_API_KEY', 'BART integration'),
   ('VESTABOARD_VIRTUAL_API_KEY', 'Vestaboard integration'),
+  ('CALENDAR_URL', 'Calendar integration (ICS mode)'),
+  ('CALENDAR_CALDAV_URL', 'Calendar integration (CalDAV mode)'),
+  ('CALENDAR_USERNAME', 'Calendar integration (CalDAV mode)'),
+  ('CALENDAR_PASSWORD', 'Calendar integration (CalDAV mode)'),
+  ('BART_API_KEY', 'BART integration'),
   ('TRAKT_CLIENT_ID', 'Trakt integration'),
   ('TRAKT_CLIENT_SECRET', 'Trakt integration'),
   ('TRAKT_ACCESS_TOKEN', 'Trakt integration'),

--- a/tests/integrations/test_calendar_integration.py
+++ b/tests/integrations/test_calendar_integration.py
@@ -1,0 +1,76 @@
+"""Integration tests for integrations/calendar.py — call real calendar feeds.
+
+Run with: uv run pytest -m integration
+
+Required env vars (at least one mode must be configured):
+  CALENDAR_URL             — public/secret-address .ics URL (ICS mode)
+  CALENDAR_CALDAV_URL      — CalDAV server URL (CalDAV mode)
+  CALENDAR_USERNAME        — CalDAV username / Apple ID
+  CALENDAR_PASSWORD        — CalDAV app-specific password
+"""
+
+import os
+from typing import Generator
+
+import pytest
+
+import config as _cfg
+import integrations.calendar as calendar
+from exceptions import IntegrationDataUnavailableError
+
+
+@pytest.fixture(autouse=True)
+def reset_caches() -> Generator[None, None, None]:
+  calendar._ics_cache.clear()
+  calendar._caldav_cache = None
+  yield
+  calendar._ics_cache.clear()
+  calendar._caldav_cache = None
+
+
+@pytest.mark.integration
+@pytest.mark.require_env('CALENDAR_URL')
+def test_ics_mode_real_feed(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+  """get_variables() returns valid events or raises cleanly from a real .ics feed."""
+  monkeypatch.setattr(_cfg, '_config', {'calendar': {'urls': [os.environ['CALENDAR_URL']]}, 'scheduler': {}})
+
+  try:
+    result = calendar.get_variables()
+  except IntegrationDataUnavailableError:
+    pytest.skip('no events today in the configured calendar — not a failure')
+
+  assert 'events' in result
+  assert len(result['events']) == 1
+  lines = result['events'][0]
+  assert lines, 'events list is empty'
+  for line in lines:
+    assert isinstance(line, str) and line.strip(), f'empty line in events: {lines!r}'
+
+
+@pytest.mark.integration
+@pytest.mark.require_env('CALENDAR_CALDAV_URL', 'CALENDAR_USERNAME', 'CALENDAR_PASSWORD')
+def test_caldav_mode_real_icloud(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+  """get_variables() connects to a real CalDAV server and returns valid events or raises cleanly."""
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {
+      'calendar': {
+        'caldav_url': os.environ['CALENDAR_CALDAV_URL'],
+        'username': os.environ['CALENDAR_USERNAME'],
+        'password': os.environ['CALENDAR_PASSWORD'],
+      },
+      'scheduler': {},
+    },
+  )
+
+  try:
+    result = calendar.get_variables()
+  except IntegrationDataUnavailableError:
+    pytest.skip('no events today in the CalDAV calendars — not a failure')
+
+  assert 'events' in result
+  lines = result['events'][0]
+  assert lines, 'events list is empty'
+  for line in lines:
+    assert isinstance(line, str) and line.strip(), f'empty line in events: {lines!r}'

--- a/uv.lock
+++ b/uv.lock
@@ -57,6 +57,25 @@ filecache = [
 ]
 
 [[package]]
+name = "caldav"
+version = "2.2.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "icalendar" },
+    { name = "icalendar-searcher" },
+    { name = "lxml" },
+    { name = "niquests" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "recurring-ical-events" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/c5/2938401bb7466148d048edb2471868689749844172a1eae34327fa405183/caldav-2.2.6.tar.gz", hash = "sha256:6ccde51de20114658a85be09ac4b4da2b51ea90c75c6f6c2c5c4d5efc61187fb", size = 10001239, upload-time = "2026-02-01T14:34:11.874Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/33/192fdedf457c57c0bb67938459d533e6e16a3b48836834fdd1eaa680a993/caldav-2.2.6-py2.py3-none-any.whl", hash = "sha256:d6f790163daf0b98dcbae6bb9fad303332b3c4e5a5d6df0461df0bb1ff0ac221", size = 121227, upload-time = "2026-02-01T14:34:07.186Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.11.12"
 source = { registry = "https://pypi.org/simple" }
@@ -97,6 +116,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
     { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
     { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]
@@ -142,11 +173,23 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "e-note-ion"
-version = "0.23.2"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },
+    { name = "caldav" },
+    { name = "icalendar" },
+    { name = "recurring-ical-events" },
     { name = "requests" },
 ]
 
@@ -163,6 +206,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "apscheduler", specifier = ">=3.11.2" },
+    { name = "caldav", specifier = ">=1.4.0" },
+    { name = "icalendar", specifier = ">=7.0.0" },
+    { name = "recurring-ical-events", specifier = ">=3.8.0" },
     { name = "requests", specifier = ">=2.32.5" },
 ]
 
@@ -183,6 +229,41 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/73/92/a8e2479937ff39185d20dd6a851c1a63e55849e447a55e798cc2e1f49c65/filelock-3.24.3.tar.gz", hash = "sha256:011a5644dc937c22699943ebbfc46e969cdde3e171470a6e40b9533e5a72affa", size = 37935, upload-time = "2026-02-19T00:48:20.543Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/0f/5d0c71a1aefeb08efff26272149e07ab922b64f46c63363756224bd6872e/filelock-3.24.3-py3-none-any.whl", hash = "sha256:426e9a4660391f7f8a810d71b0555bce9008b0a1cc342ab1f6947d37639e002d", size = 24331, upload-time = "2026-02-19T00:48:18.465Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "icalendar"
+version = "7.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/51/43458f01e229763b05dd937b5e9d41ef506b6eb8b4bf939f8ea34350b853/icalendar-7.0.2.tar.gz", hash = "sha256:de844ff5cde32f539bea7644e36d8494032a926b933bedb92621f2f239760806", size = 440039, upload-time = "2026-02-24T16:13:42.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/ab/e0d44b1de0beb703bbc507ca064300b34046f9f9628f052d1a97ffa61b95/icalendar-7.0.2-py3-none-any.whl", hash = "sha256:ad31a5825b39522a30b073c6ced3ffcdf6c02cbb7dab69ba2e4de32ddbf77cc9", size = 437913, upload-time = "2026-02-24T16:13:40.631Z" },
+]
+
+[[package]]
+name = "icalendar-searcher"
+version = "1.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "icalendar" },
+    { name = "recurring-ical-events" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/c3/56e751b7ae4f6ca61bf807e207c98e67756fc29134d219196806beb8957d/icalendar_searcher-1.0.5.tar.gz", hash = "sha256:abd99bf1ac9c9d675d84151101db4883a97e9958755708804c55abd30df58f6c", size = 68064, upload-time = "2026-02-25T09:10:17.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/b6/7ab1dfb1c5ba3ba394ff5ea285cbeb5db9f71ec5b3b906d01efd235f00d1/icalendar_searcher-1.0.5-py3-none-any.whl", hash = "sha256:66f6f5ece50041ceda5ea91995cd2ed80fa0b065a42b3b3f420f89343614b2a3", size = 37294, upload-time = "2026-02-25T09:10:16.61Z" },
 ]
 
 [[package]]
@@ -213,6 +294,45 @@ wheels = [
 ]
 
 [[package]]
+name = "jh2"
+version = "5.0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ed/466eb2a162d9cfaa8452e9a05d24b4fc11d4cf84cf27f5a71457dc590323/jh2-5.0.10.tar.gz", hash = "sha256:2c737a47bee50dc727f7a766185e110befdceba5efb1c4fa240b1e4399291487", size = 7301475, upload-time = "2025-10-05T06:18:59.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/2d/d1d5161adadacd04afb98016c86ca3c429e89ec5e46a93c1f9bd613d9e2e/jh2-5.0.10-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:e340215fa14b914096aa2e0960798603939f6bc85e9467057121c3aae4eadda1", size = 603721, upload-time = "2025-10-05T06:16:44.48Z" },
+    { url = "https://files.pythonhosted.org/packages/77/88/06dd26cfd8e47f8b573af4be09161d0b0b3a26357cb5224da4ceebbb9d11/jh2-5.0.10-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6124124ea77ba77b22cb1f66554eddd61b14a2ce0bb2bc2032d91c3a2b9cbfed", size = 379003, upload-time = "2025-10-05T06:16:46.185Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/37/e6abb173b034151eca851ad18908f97cb984bf657c744a4ee72bd4836862/jh2-5.0.10-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:db95f18b629f5dc914cf962725b7dfcb9673c4bb06e50d654426615c3d8d88d2", size = 389806, upload-time = "2025-10-05T06:16:47.759Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/aa/158f6ebafac187f80837d024b864e547ffe4a0ffa4df368c6b5d1dd20f49/jh2-5.0.10-cp314-cp314t-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:c16af652777ce4edc0627d037ac5195b921665b2e13e3547782116ce5a62cd5a", size = 528227, upload-time = "2025-10-05T06:16:48.98Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/26/4fe6ec57e9e6610443dea281a246b86438f9f6ea090adee4095ce3096f70/jh2-5.0.10-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0190daf5b65fbf52641ba761d1b895b74abcdb671ca1fb6cd138dd49050cfa8", size = 521170, upload-time = "2025-10-05T06:16:50.274Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/87/bbbaf7f146788544c5584142a7a4f5997147d65588ceed4a1ac769b7ab2d/jh2-5.0.10-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:578394d8a9409d540b45138cbecb9d611830ccce6c7f81157c96f2d8d54abd5a", size = 409999, upload-time = "2025-10-05T06:16:51.691Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/6f/ff1df3a83daa557e30ce0df48cf789a7faa0521ac56014e38fdd68457e79/jh2-5.0.10-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:108143494bba0b1bf5f8cd205f9c659667235e788d3e3f0f454ad8e52f2c8056", size = 386010, upload-time = "2025-10-05T06:16:53.256Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c7/e3ba47b2cc066b99084278fd77828a2689c59e443cdf8089bd3411deb2e7/jh2-5.0.10-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:85631d5b4d0e1eb9f9daacc43e6394efd8c65eb39c7a7e8458f0c3894108003c", size = 404137, upload-time = "2025-10-05T06:16:54.854Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/f8/b7ae14f5d3fc0e7c66b20c94d56fcf191cf588e33d0b653da022a31f32de/jh2-5.0.10-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a9aec4760a6545a654f503d709456c1d8afb63b0ee876a1e11090b75f2fd7488", size = 560449, upload-time = "2025-10-05T06:16:56.278Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6b/abc648a4149582733618e117d42e6b64d5f0885c4311b8108e2c2e667afc/jh2-5.0.10-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:028227ec9e44fb62e073b71ca391cb1f932c5c7da3981ccafff852df81d2b7f9", size = 653077, upload-time = "2025-10-05T06:16:57.903Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ec/8ccf1a7dbdabba5cdc27220507dd839e9bc36bdd4c2bf990334642ad6b8b/jh2-5.0.10-cp314-cp314t-musllinux_1_1_i686.whl", hash = "sha256:2c2ed55a32735b91a0683c7b995433e39325fdf42c6ffc8e87d56606ac6235bb", size = 580386, upload-time = "2025-10-05T06:16:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/57/50eab697d39b2a4d790355e304c79b3c2ab22f7a4889396155a946b8956a/jh2-5.0.10-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0075415d2a2dfdf3a8ddeaa51cf8d92fb3d7c90fa09cb9752c79ee54e960b9a8", size = 551533, upload-time = "2025-10-05T06:17:00.802Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f5/4f73015f4d65f1b3024043a2516062fd3f34846fe88433b3c3a0922ff5fd/jh2-5.0.10-cp314-cp314t-win32.whl", hash = "sha256:a8404e17a3d90c215e67be8a5ccb679eb9cf9bfeeec732521487b65ffaeac4a6", size = 234381, upload-time = "2025-10-05T06:17:02.558Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8d/61fcba06faeb9ab7d1ead7e2ef3db07264523f2d2fd463a4d2ec1780103a/jh2-5.0.10-cp314-cp314t-win_amd64.whl", hash = "sha256:5d664450ab1435f6a78c64e076c7ea22ffe779bafceb9c42600cce95ff20f927", size = 241614, upload-time = "2025-10-05T06:17:03.732Z" },
+    { url = "https://files.pythonhosted.org/packages/02/67/6641130f5f4f3e9e9254121267b0e7c2423863e8c1a46ee097098e7ede8f/jh2-5.0.10-cp314-cp314t-win_arm64.whl", hash = "sha256:ad6d18301f2162996d679be6759c6a120325b58a196231220b7a809e034280ed", size = 237355, upload-time = "2025-10-05T06:17:04.931Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8f/fe337b9104ab3a444a7b20baffc3dd54f3227a44f3037aba2a30bf36fefd/jh2-5.0.10-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7c2918379cce3352b6d40717ed3d5b06da6e6c17253317302cab2f0dbff62a5d", size = 622842, upload-time = "2025-10-05T06:17:06.121Z" },
+    { url = "https://files.pythonhosted.org/packages/63/37/f3c59f62e771755b31b6d1ce9124d4ab40bc3a2206116bfd879a33c1b02f/jh2-5.0.10-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd229bbe7dfdf499394fa8453c92e2ea19de47c80afc1efaec7f85704be97717", size = 385674, upload-time = "2025-10-05T06:17:07.369Z" },
+    { url = "https://files.pythonhosted.org/packages/03/9d/719cfd3afab6bb9115f574687fa24ea5731267ee9701439e30e06a45f468/jh2-5.0.10-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:36e9b5fb9cd8872846d031fae442df1b5c83f4dd29ef1dd1c3f70afd86fe8fc3", size = 396276, upload-time = "2025-10-05T06:17:08.933Z" },
+    { url = "https://files.pythonhosted.org/packages/22/63/1f36ff610684f2cb177218c700d3a3f4f87aad4d45a6e3f59feb360812c6/jh2-5.0.10-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:217af8256551627b9253737a866c05ce5f6c49f171c099260b76915239cfb13a", size = 532742, upload-time = "2025-10-05T06:17:10.396Z" },
+    { url = "https://files.pythonhosted.org/packages/59/c5/063fe0b930c0b15e8c0376d9d6cc20dcc3179823e6f456c1a571db1d27c4/jh2-5.0.10-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e20e3d747c4022d890865fb25f2e8b3ff6cbacf7556f29155dcfbff592d96202", size = 525320, upload-time = "2025-10-05T06:17:12.187Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/7a/c1f4a961554f6b521bfc75320264c0bde50210c11a206719e0c98c17e617/jh2-5.0.10-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6ea77b8b6b7defb67cbec69340e653495b36881671e9f0ac395cdd6b27144000", size = 416184, upload-time = "2025-10-05T06:17:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c9/75fdfd2ef673accba9b1ace28ffa2aaced23fba3209ac73521e441ae2265/jh2-5.0.10-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3fd6b5b2d4d38e089ac982ea341b36f2cb827c0765217e6b8f3e58a409290e6f", size = 394145, upload-time = "2025-10-05T06:17:14.673Z" },
+    { url = "https://files.pythonhosted.org/packages/52/5e/38b1b14182afcebf89d542b7a2e4cd4d7deaf9e4cae0a45b0a85115f0da7/jh2-5.0.10-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c3d38121a1ddc2ffc769f09aaaa4c7e67f89e25c578921326b515402176e7cf", size = 411333, upload-time = "2025-10-05T06:17:15.913Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/04/10383a467f24d2643013f784bca4ddb81dc9d0d81641a846b71bd0aa64e0/jh2-5.0.10-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:33e4ac058acf8f3f89ea1375deb33ac61713d60fb9e3333bd079f3602425739c", size = 565892, upload-time = "2025-10-05T06:17:17.517Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1a/b416bd65176593b405320bfd763ddc9cae3941fe96c7055ec1c46e081ebd/jh2-5.0.10-cp37-abi3-musllinux_1_1_armv7l.whl", hash = "sha256:86571f18274d7a5a7e6406e156a9f27fa1a72203a176921ea234c4a11fe0e105", size = 659878, upload-time = "2025-10-05T06:17:18.972Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/2d/e4c3b90585e92676777e9bcb9218ce97552f0c9797cec142d549904ca67b/jh2-5.0.10-cp37-abi3-musllinux_1_1_i686.whl", hash = "sha256:62f0842b5f8da463b6a548a8c2a7e69fa709888d03c997486390097341e88e09", size = 587129, upload-time = "2025-10-05T06:17:20.669Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d5/3e89d65bb6bbcdaa14236e9ec8f643cf77a5809d7315ce1208f0ef53927c/jh2-5.0.10-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f3b6401f089a65b87f2e5beffe81666a1c2ab1d90e8406cd49c756d66881bedc", size = 556811, upload-time = "2025-10-05T06:17:22.37Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8c/a05403065463ef759059d75e0862c94aa60d2019a7dcd41d716f6d8d6c32/jh2-5.0.10-cp37-abi3-win32.whl", hash = "sha256:7b79771bd366a11a36041f49cabc7876047cf1b99cee89df1333e6890f66d973", size = 239474, upload-time = "2025-10-05T06:17:23.637Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ac/92f97f07f748bdc9280c5d50e787773bef188c29c32f6804f2fc72cca725/jh2-5.0.10-cp37-abi3-win_amd64.whl", hash = "sha256:9c730e3f40f22bd4ff0ab63ee41d70ee22aa1cc54e5cb295ae0ac3b0a016af3e", size = 246320, upload-time = "2025-10-05T06:17:25.313Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ad/e9f4035ddd847efe26914da64f9d54198bf5b0bdcfd0e8bbcf6a328e1f7c/jh2-5.0.10-cp37-abi3-win_arm64.whl", hash = "sha256:d18eccec757374afca8de31bf012a888fb82903d5803e84f2e6f0b707478ced6", size = 241790, upload-time = "2025-10-05T06:17:26.488Z" },
+    { url = "https://files.pythonhosted.org/packages/93/57/d0fcb025736e24cb68c4e250cc4cf63a87b7e0bd7285e188c543018d05c1/jh2-5.0.10-py3-none-any.whl", hash = "sha256:1808c0e5d355c60485bb282b34c6aa3f15069b2634eb44779fb9f3bda0256ac0", size = 98099, upload-time = "2025-10-05T06:18:58.203Z" },
+]
+
+[[package]]
 name = "license-expression"
 version = "30.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -222,6 +342,50 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/88/262177de60548e5a2bfc46ad28232c9e9cbde697bd94132aeb80364675cb/lxml-6.0.2.tar.gz", hash = "sha256:cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62", size = 4073426, upload-time = "2025-09-22T04:04:59.287Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/d4a377b385ab693ce97b472fe0c77c2b16ec79590e688b3ccc71fba19884/lxml-6.0.2-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:b0c732aa23de8f8aec23f4b580d1e52905ef468afb4abeafd3fec77042abb6fe", size = 8659801, upload-time = "2025-09-22T04:02:30.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e8/c128e37589463668794d503afaeb003987373c5f94d667124ffd8078bbd9/lxml-6.0.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4468e3b83e10e0317a89a33d28f7aeba1caa4d1a6fd457d115dd4ffe90c5931d", size = 4659403, upload-time = "2025-09-22T04:02:32.119Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ce/74903904339decdf7da7847bb5741fc98a5451b42fc419a86c0c13d26fe2/lxml-6.0.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:abd44571493973bad4598a3be7e1d807ed45aa2adaf7ab92ab7c62609569b17d", size = 4966974, upload-time = "2025-09-22T04:02:34.155Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d3/131dec79ce61c5567fecf82515bd9bc36395df42501b50f7f7f3bd065df0/lxml-6.0.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:370cd78d5855cfbffd57c422851f7d3864e6ae72d0da615fca4dad8c45d375a5", size = 5102953, upload-time = "2025-09-22T04:02:36.054Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ea/a43ba9bb750d4ffdd885f2cd333572f5bb900cd2408b67fdda07e85978a0/lxml-6.0.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:901e3b4219fa04ef766885fb40fa516a71662a4c61b80c94d25336b4934b71c0", size = 5055054, upload-time = "2025-09-22T04:02:38.154Z" },
+    { url = "https://files.pythonhosted.org/packages/60/23/6885b451636ae286c34628f70a7ed1fcc759f8d9ad382d132e1c8d3d9bfd/lxml-6.0.2-cp314-cp314-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:a4bf42d2e4cf52c28cc1812d62426b9503cdb0c87a6de81442626aa7d69707ba", size = 5352421, upload-time = "2025-09-22T04:02:40.413Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5b/fc2ddfc94ddbe3eebb8e9af6e3fd65e2feba4967f6a4e9683875c394c2d8/lxml-6.0.2-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2c7fdaa4d7c3d886a42534adec7cfac73860b89b4e5298752f60aa5984641a0", size = 5673684, upload-time = "2025-09-22T04:02:42.288Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/47293c58cc91769130fbf85531280e8cc7868f7fbb6d92f4670071b9cb3e/lxml-6.0.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98a5e1660dc7de2200b00d53fa00bcd3c35a3608c305d45a7bbcaf29fa16e83d", size = 5252463, upload-time = "2025-09-22T04:02:44.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/da/ba6eceb830c762b48e711ded880d7e3e89fc6c7323e587c36540b6b23c6b/lxml-6.0.2-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:dc051506c30b609238d79eda75ee9cab3e520570ec8219844a72a46020901e37", size = 4698437, upload-time = "2025-09-22T04:02:46.524Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/24/7be3f82cb7990b89118d944b619e53c656c97dc89c28cfb143fdb7cd6f4d/lxml-6.0.2-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8799481bbdd212470d17513a54d568f44416db01250f49449647b5ab5b5dccb9", size = 5269890, upload-time = "2025-09-22T04:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/dcfb9ea1e16c665efd7538fc5d5c34071276ce9220e234217682e7d2c4a5/lxml-6.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9261bb77c2dab42f3ecd9103951aeca2c40277701eb7e912c545c1b16e0e4917", size = 5097185, upload-time = "2025-09-22T04:02:50.746Z" },
+    { url = "https://files.pythonhosted.org/packages/21/04/a60b0ff9314736316f28316b694bccbbabe100f8483ad83852d77fc7468e/lxml-6.0.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:65ac4a01aba353cfa6d5725b95d7aed6356ddc0a3cd734de00124d285b04b64f", size = 4745895, upload-time = "2025-09-22T04:02:52.968Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/bd/7d54bd1846e5a310d9c715921c5faa71cf5c0853372adf78aee70c8d7aa2/lxml-6.0.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:b22a07cbb82fea98f8a2fd814f3d1811ff9ed76d0fc6abc84eb21527596e7cc8", size = 5695246, upload-time = "2025-09-22T04:02:54.798Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/5643d6ab947bc371da21323acb2a6e603cedbe71cb4c99c8254289ab6f4e/lxml-6.0.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:d759cdd7f3e055d6bc8d9bec3ad905227b2e4c785dc16c372eb5b5e83123f48a", size = 5260797, upload-time = "2025-09-22T04:02:57.058Z" },
+    { url = "https://files.pythonhosted.org/packages/33/da/34c1ec4cff1eea7d0b4cd44af8411806ed943141804ac9c5d565302afb78/lxml-6.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:945da35a48d193d27c188037a05fec5492937f66fb1958c24fc761fb9d40d43c", size = 5277404, upload-time = "2025-09-22T04:02:58.966Z" },
+    { url = "https://files.pythonhosted.org/packages/82/57/4eca3e31e54dc89e2c3507e1cd411074a17565fa5ffc437c4ae0a00d439e/lxml-6.0.2-cp314-cp314-win32.whl", hash = "sha256:be3aaa60da67e6153eb15715cc2e19091af5dc75faef8b8a585aea372507384b", size = 3670072, upload-time = "2025-09-22T04:03:38.05Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/e0/c96cf13eccd20c9421ba910304dae0f619724dcf1702864fd59dd386404d/lxml-6.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:fa25afbadead523f7001caf0c2382afd272c315a033a7b06336da2637d92d6ed", size = 4080617, upload-time = "2025-09-22T04:03:39.835Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5d/b3f03e22b3d38d6f188ef044900a9b29b2fe0aebb94625ce9fe244011d34/lxml-6.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:063eccf89df5b24e361b123e257e437f9e9878f425ee9aae3144c77faf6da6d8", size = 3754930, upload-time = "2025-09-22T04:03:41.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/5c/42c2c4c03554580708fc738d13414801f340c04c3eff90d8d2d227145275/lxml-6.0.2-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6162a86d86893d63084faaf4ff937b3daea233e3682fb4474db07395794fa80d", size = 8910380, upload-time = "2025-09-22T04:03:01.645Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/4f/12df843e3e10d18d468a7557058f8d3733e8b6e12401f30b1ef29360740f/lxml-6.0.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:414aaa94e974e23a3e92e7ca5b97d10c0cf37b6481f50911032c69eeb3991bba", size = 4775632, upload-time = "2025-09-22T04:03:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0c/9dc31e6c2d0d418483cbcb469d1f5a582a1cd00a1f4081953d44051f3c50/lxml-6.0.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48461bd21625458dd01e14e2c38dd0aea69addc3c4f960c30d9f59d7f93be601", size = 4975171, upload-time = "2025-09-22T04:03:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2b/9b870c6ca24c841bdd887504808f0417aa9d8d564114689266f19ddf29c8/lxml-6.0.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25fcc59afc57d527cfc78a58f40ab4c9b8fd096a9a3f964d2781ffb6eb33f4ed", size = 5110109, upload-time = "2025-09-22T04:03:07.452Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/0c/4f5f2a4dd319a178912751564471355d9019e220c20d7db3fb8307ed8582/lxml-6.0.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5179c60288204e6ddde3f774a93350177e08876eaf3ab78aa3a3649d43eb7d37", size = 5041061, upload-time = "2025-09-22T04:03:09.297Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/554eed290365267671fe001a20d72d14f468ae4e6acef1e179b039436967/lxml-6.0.2-cp314-cp314t-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:967aab75434de148ec80597b75062d8123cadf2943fb4281f385141e18b21338", size = 5306233, upload-time = "2025-09-22T04:03:11.651Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/31/1d748aa275e71802ad9722df32a7a35034246b42c0ecdd8235412c3396ef/lxml-6.0.2-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d100fcc8930d697c6561156c6810ab4a508fb264c8b6779e6e61e2ed5e7558f9", size = 5604739, upload-time = "2025-09-22T04:03:13.592Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/41/2c11916bcac09ed561adccacceaedd2bf0e0b25b297ea92aab99fd03d0fa/lxml-6.0.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ca59e7e13e5981175b8b3e4ab84d7da57993eeff53c07764dcebda0d0e64ecd", size = 5225119, upload-time = "2025-09-22T04:03:15.408Z" },
+    { url = "https://files.pythonhosted.org/packages/99/05/4e5c2873d8f17aa018e6afde417c80cc5d0c33be4854cce3ef5670c49367/lxml-6.0.2-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:957448ac63a42e2e49531b9d6c0fa449a1970dbc32467aaad46f11545be9af1d", size = 4633665, upload-time = "2025-09-22T04:03:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c9/dcc2da1bebd6275cdc723b515f93edf548b82f36a5458cca3578bc899332/lxml-6.0.2-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b7fc49c37f1786284b12af63152fe1d0990722497e2d5817acfe7a877522f9a9", size = 5234997, upload-time = "2025-09-22T04:03:19.14Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e2/5172e4e7468afca64a37b81dba152fc5d90e30f9c83c7c3213d6a02a5ce4/lxml-6.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e19e0643cc936a22e837f79d01a550678da8377d7d801a14487c10c34ee49c7e", size = 5090957, upload-time = "2025-09-22T04:03:21.436Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b3/15461fd3e5cd4ddcb7938b87fc20b14ab113b92312fc97afe65cd7c85de1/lxml-6.0.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:1db01e5cf14345628e0cbe71067204db658e2fb8e51e7f33631f5f4735fefd8d", size = 4764372, upload-time = "2025-09-22T04:03:23.27Z" },
+    { url = "https://files.pythonhosted.org/packages/05/33/f310b987c8bf9e61c4dd8e8035c416bd3230098f5e3cfa69fc4232de7059/lxml-6.0.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:875c6b5ab39ad5291588aed6925fac99d0097af0dd62f33c7b43736043d4a2ec", size = 5634653, upload-time = "2025-09-22T04:03:25.767Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/51c80e75e0bc9382158133bdcf4e339b5886c6ee2418b5199b3f1a61ed6d/lxml-6.0.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:cdcbed9ad19da81c480dfd6dd161886db6096083c9938ead313d94b30aadf272", size = 5233795, upload-time = "2025-09-22T04:03:27.62Z" },
+    { url = "https://files.pythonhosted.org/packages/56/4d/4856e897df0d588789dd844dbed9d91782c4ef0b327f96ce53c807e13128/lxml-6.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:80dadc234ebc532e09be1975ff538d154a7fa61ea5031c03d25178855544728f", size = 5257023, upload-time = "2025-09-22T04:03:30.056Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/85/86766dfebfa87bea0ab78e9ff7a4b4b45225df4b4d3b8cc3c03c5cd68464/lxml-6.0.2-cp314-cp314t-win32.whl", hash = "sha256:da08e7bb297b04e893d91087df19638dc7a6bb858a954b0cc2b9f5053c922312", size = 3911420, upload-time = "2025-09-22T04:03:32.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1a/b248b355834c8e32614650b8008c69ffeb0ceb149c793961dd8c0b991bb3/lxml-6.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:252a22982dca42f6155125ac76d3432e548a7625d56f5a273ee78a5057216eca", size = 4406837, upload-time = "2025-09-22T04:03:34.027Z" },
+    { url = "https://files.pythonhosted.org/packages/92/aa/df863bcc39c5e0946263454aba394de8a9084dbaff8ad143846b0d844739/lxml-6.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:bb4c1847b303835d89d785a18801a883436cdfd5dc3d62947f9c49e24f0f5a2c", size = 3822205, upload-time = "2025-09-22T04:03:36.249Z" },
 ]
 
 [[package]]
@@ -269,6 +433,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
     { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
     { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
+]
+
+[[package]]
+name = "niquests"
+version = "3.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "urllib3-future" },
+    { name = "wassima" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/57/91fce2b91712cfce0fd6816d063f48770358d04b213eb947392ea371cbb6/niquests-3.17.0.tar.gz", hash = "sha256:1f4f337a973215c76f6f6471504fedab9dc6187203284146081e1bd3d2a311fc", size = 996883, upload-time = "2026-01-16T14:16:52.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/63/e13cff780ef2edbfcb81e3a714417822f4b967dac0bb0388ad3146f30a95/niquests-3.17.0-py3-none-any.whl", hash = "sha256:3930d94fce367385950dd545f913e7cfc6457feda76aecafeb324aae45da9fe1", size = 183429, upload-time = "2026-01-16T14:16:51.058Z" },
 ]
 
 [[package]]
@@ -447,6 +625,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -470,6 +660,59 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "qh3"
+version = "1.5.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/e4/6898c3c3c0d3a5ba62729599edf145acde478cd9d088e5dfd85e3866a610/qh3-1.5.6.tar.gz", hash = "sha256:5c7fb081a07512dcace9a49179a40dc00ad1f77b2779ee4bb7ca176f96552f66", size = 269753, upload-time = "2025-11-09T05:52:49.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/3a/6289b400c83aa0c17459f5abeea28e739a8c313ba6fb294b61c8596b2153/qh3-1.5.6-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:0875508e4b2b2ddc1c7a238eb999865ba8b0b4c0a0b9c9ce19a71f0c5d3c32b7", size = 4472098, upload-time = "2025-11-09T05:50:16.096Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/e2/706b906b909a0d4d2541bca437f09469f0806a1afaee7c66c4c70fc3f046/qh3-1.5.6-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e700c83ee03ca5ba32d1b489ea432daf999a54be9652edede03103aecac89d6", size = 2172734, upload-time = "2025-11-09T05:50:17.996Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/24/e79a38f72278a9352016ec4451af239304e63a7f9ebdb29ce2e0c8ad91e9/qh3-1.5.6-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:721bc54cce3d723af556d418827623b1a7cd34387e0f58123a48a313df17da1b", size = 1894861, upload-time = "2025-11-09T05:50:19.6Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c5/a6fc2cada12b55ed211aa14456a6dc8f30b17a4438d5ed11e3665bd2cc5a/qh3-1.5.6-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d96c704562ab6f1333a8d65c04c08a7d5e72d81cdcccbcf6dc71e63d1a65b10f", size = 2040805, upload-time = "2025-11-09T05:50:21.271Z" },
+    { url = "https://files.pythonhosted.org/packages/28/7a/56bc17e0c49c8ba4b224ae1767a57ee9561fdae93027fd1b4aa1a2987eff/qh3-1.5.6-cp314-cp314t-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:8781b7af3fc53a5cb9af3496f520d3dde767d1186412ff6def29d98b365e5bb4", size = 2025276, upload-time = "2025-11-09T05:50:23.081Z" },
+    { url = "https://files.pythonhosted.org/packages/99/4e/c2f136a4f72f8b33f928f6f7c3e04cb126e1538bcf3982770ca76984c380/qh3-1.5.6-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3927f4bca686e9ff03eaf6ef97af7682ed8206f345452febfdc76e82e65fc588", size = 2069548, upload-time = "2025-11-09T05:50:24.7Z" },
+    { url = "https://files.pythonhosted.org/packages/40/5b/d206ca53c2d90b4fa2f8e4b220acf93689c44d2d12ec37aebba391b06da8/qh3-1.5.6-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c51c5ee3fbdf62719538b987b31da86ff2e514b62f19cb785edc7b75a96f5ad5", size = 2090001, upload-time = "2025-11-09T05:50:26.355Z" },
+    { url = "https://files.pythonhosted.org/packages/01/1c/79f05139b566512fbeb5680044a6922eccdc16f638714db2cb5721b57be5/qh3-1.5.6-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e7fae38ff11f31ff58b7c73a8ffa195738b7593ad0780abbecb3fc73393f6bb", size = 2371051, upload-time = "2025-11-09T05:50:27.772Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/50/7a8465c965ca641e848ea7c3be743bf039b1551340997ed24ebbf768cbca/qh3-1.5.6-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:70d7ae5ed67531f5b71d86bccba114bb30174dbcea91385724762a7e4b368acb", size = 2033415, upload-time = "2025-11-09T05:50:29.432Z" },
+    { url = "https://files.pythonhosted.org/packages/95/e3/0bc5c1dacbd3572d18a71c4900c5f4a0dd3f9992a1cdd580ca6818c89037/qh3-1.5.6-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:bbdb7b6fc76f4af47769a03158ccb72d49a57a2e5ca445e6aa350e78b110fd31", size = 2368234, upload-time = "2025-11-09T05:50:31.153Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/71/c63fbc7f47c29f1a4e86fd74afb4bbd28b9dd197265c878c315ad76ce8e3/qh3-1.5.6-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:85fbee04e45e5cf1bb6ceffaf16fa48f6c6926a3e4a19061163c71a7c4ed0343", size = 2133163, upload-time = "2025-11-09T05:50:32.556Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/31/6af659f97c64990a23359bdbe62e5a14ab7894704ff6ad366320870c486a/qh3-1.5.6-cp314-cp314t-musllinux_1_1_i686.whl", hash = "sha256:b260308f9befd65172392ac8cbc3dff030be5b2ccea0ec4b78bf67e8bd51cccd", size = 2162641, upload-time = "2025-11-09T05:50:34.255Z" },
+    { url = "https://files.pythonhosted.org/packages/05/45/4d96516217340e8ed1c875b977298d33dc8bdccbdf38e6de25eb3ea8ca74/qh3-1.5.6-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:795581c480dfcf1849968d27975e7cc4bce25ba041f55773c1a1a6d159de3731", size = 2542760, upload-time = "2025-11-09T05:50:35.623Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/56/14705a0a1d3429133c411782203f16a205bbfa1bd8f71d40d69a58164b6a/qh3-1.5.6-cp314-cp314t-win32.whl", hash = "sha256:b3fa3c1a3759c9ac47f7fdc2322c2a3efcd820921296df85b6334aa144a36253", size = 1732911, upload-time = "2025-11-09T05:50:37.747Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c0/ae2a7a06399aae31ac68310732da71d724f9751e3a46d7f599a1abe70170/qh3-1.5.6-cp314-cp314t-win_amd64.whl", hash = "sha256:2b8fd3df8ccf8e10d8e11648f47dacf3bd763be1ac1734972d18565acb2b6a6d", size = 1985225, upload-time = "2025-11-09T05:50:39.032Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/5c/6c49f8d12da29eedd048039c1b3c33ffd4db8c2ed4c82afe91d31f00afc4/qh3-1.5.6-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:28b03fe0c7d8989c429426e0744d4eea1ffd976a8fe4e63a0164c2b56e8d4976", size = 4491221, upload-time = "2025-11-09T05:50:40.821Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/bc/5942a9189f1452744eeacff89ade2d58a312f11c5a1dd57c183bbd86c9c7/qh3-1.5.6-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1842aa5440b8c94a392202aa19e3593a597fe1e808950de00602bf7d46f6f8a3", size = 2177685, upload-time = "2025-11-09T05:50:42.182Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ab/1c7715bd18db347963bcda00768f387a3935c88d92ccd3292cbcd46edb26/qh3-1.5.6-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9804cf7329364c94075232ff0edaad86bc696c18a4ee6b46b4320b8716737b1a", size = 1898292, upload-time = "2025-11-09T05:50:44.223Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/1f8976a62f280fcd8520bfd627235a6241b30d380084ffa74bfd89530260/qh3-1.5.6-cp37-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3b64fd616d20028ed06450cf0a6743b739bc46500990003f9dfac7080b83466b", size = 2043209, upload-time = "2025-11-09T05:50:45.742Z" },
+    { url = "https://files.pythonhosted.org/packages/00/70/f350c4a61bbe1c3cfb719efef90ee1c609a8986637c1623abbdac00f837c/qh3-1.5.6-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:690bbf3075aa51999f61932da4ccee4f70645059a700da7025709867a39a0868", size = 2027699, upload-time = "2025-11-09T05:50:47.097Z" },
+    { url = "https://files.pythonhosted.org/packages/73/27/cea3edc242d65768dbccae3859a260b187e23f98dddf75cad5875cff9beb/qh3-1.5.6-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6987bedcdd8d5d156e21723c4d21575da4cdae31f8eb6b04b64796b68a43ad41", size = 2075827, upload-time = "2025-11-09T05:50:48.684Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/3e/8a90dd20618f408983aaff08e0ca9b343cc2b1f29d696827493be14f5c2e/qh3-1.5.6-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:11bcca3ffd03e6914f626bbe0f4392b89190ff4fd33a5bdc26b5b1fddae9ab9e", size = 2098224, upload-time = "2025-11-09T05:50:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/01/b8/41e849d7164b6ba1a61f66c6687008d750ee8b605a194a444197a7151d85/qh3-1.5.6-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:692722cd545bcc6c8d6de3ac58ea875f7f43e2cb014be64e267511e8d16bafcd", size = 2375936, upload-time = "2025-11-09T05:50:52.485Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ab/5a9a63901b3bb8a622db523ca785ac14b0e703d55f7796db860dfd671d0c/qh3-1.5.6-cp37-abi3-manylinux_2_39_riscv64.whl", hash = "sha256:91b523f9a7c4d083a831d89663d8aaf45128ad325f3049de4f48678d5e45b211", size = 2039073, upload-time = "2025-11-09T05:50:54.142Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d7/be9a2ef6da5da7e6be98a855cc133559bc88da7b5bb21d0c4dde5d71a0c6/qh3-1.5.6-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:2f6dd167e6458566825b371a27731092b15a0a527b32e831d21cd4ecb190566a", size = 2370983, upload-time = "2025-11-09T05:50:55.652Z" },
+    { url = "https://files.pythonhosted.org/packages/af/e3/ca1eccf6744b77aa744012c4c15350ee7f4e39818786c81ad4ee4a9f7564/qh3-1.5.6-cp37-abi3-musllinux_1_1_armv7l.whl", hash = "sha256:414ad77504a78c521d71ddb8a6d0a1230528ab64184a098424d2ec45c1b570ec", size = 2136965, upload-time = "2025-11-09T05:50:57.181Z" },
+    { url = "https://files.pythonhosted.org/packages/08/67/4caf81f598ce0a4a5dc029492ea9cf2c48c1c98921be8c42d8005768b6e2/qh3-1.5.6-cp37-abi3-musllinux_1_1_i686.whl", hash = "sha256:ef9bfaab22114f8fd36094246f774d8fc5bbc74421aebb742f392feaab04ecb3", size = 2166958, upload-time = "2025-11-09T05:50:58.633Z" },
+    { url = "https://files.pythonhosted.org/packages/22/51/196722ef0b0016968e2439720f4dce63ba7f641663cb61ad67bf089c6096/qh3-1.5.6-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:20686c57eb45087e644cd749cdd372e082af4845249eb946ffab9c4c3fb5b364", size = 2546184, upload-time = "2025-11-09T05:51:00.005Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e2/20c8c3e21b5465ed9373255216ad4657c58119eff45b99a5e4138c9caf68/qh3-1.5.6-cp37-abi3-win32.whl", hash = "sha256:deefa7d329df97fe4df7b5f2ce806378bb72c1b7b0329439dd8052e916679428", size = 1738876, upload-time = "2025-11-09T05:51:01.701Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b4/b67841c3442929caad6c65e937eefe5df7828427fad249e290d13b2df01a/qh3-1.5.6-cp37-abi3-win_amd64.whl", hash = "sha256:84992d0810cc53b33f122cd411be87d36c942e104aa6252d10ee03e1a6d6fb4d", size = 1991436, upload-time = "2025-11-09T05:51:03.438Z" },
+]
+
+[[package]]
+name = "recurring-ical-events"
+version = "3.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "icalendar" },
+    { name = "python-dateutil" },
+    { name = "tzdata" },
+    { name = "x-wr-timezone" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/d4/51c9361bb0efb2290dfd850c036b49acb502794e0fe9cc3520dbf60fd7db/recurring_ical_events-3.8.1.tar.gz", hash = "sha256:c3eb2490a00559fb963d2bdee39acf2f287c91c07dcea4ce80ade1c60a8c3acf", size = 603730, upload-time = "2026-02-18T11:45:53.272Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/67/4d4aead359164de68d30ee67efcdbe3784063cb21535c85b9a9a03dd2ebb/recurring_ical_events-3.8.1-py3-none-any.whl", hash = "sha256:3bb3aaa0c87a4d3ab5951360480686bd69f1512945f478be6a2c0f141da0bf78", size = 238286, upload-time = "2026-02-18T11:45:51.631Z" },
 ]
 
 [[package]]
@@ -523,6 +766,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/23/01/1c30526460f4d23222d0fabd5888868262fd0e2b71a00570ca26483cd993/ruff-0.15.2-py3-none-win32.whl", hash = "sha256:fd5ff9e5f519a7e1bd99cbe8daa324010a74f5e2ebc97c6242c08f26f3714f6f", size = 10507885, upload-time = "2026-02-19T22:32:15.635Z" },
     { url = "https://files.pythonhosted.org/packages/5c/10/3d18e3bbdf8fc50bbb4ac3cc45970aa5a9753c5cb51bf9ed9a3cd8b79fa3/ruff-0.15.2-py3-none-win_amd64.whl", hash = "sha256:d20014e3dfa400f3ff84830dfb5755ece2de45ab62ecea4af6b7262d0fb4f7c5", size = 11623725, upload-time = "2026-02-19T22:32:04.947Z" },
     { url = "https://files.pythonhosted.org/packages/6d/78/097c0798b1dab9f8affe73da9642bb4500e098cb27fd8dc9724816ac747b/ruff-0.15.2-py3-none-win_arm64.whl", hash = "sha256:cabddc5822acdc8f7b5527b36ceac55cc51eec7b1946e60181de8fe83ca8876e", size = 10941649, upload-time = "2026-02-19T22:32:18.108Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -619,6 +871,20 @@ wheels = [
 ]
 
 [[package]]
+name = "urllib3-future"
+version = "2.16.900"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "jh2" },
+    { name = "qh3", marker = "(platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'ARM64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'i686' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'ppc64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'ppc64le' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'riscv64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'riscv64gc' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 's390x' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'x86' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'ARM64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'i686' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'ppc64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'ppc64le' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'riscv64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'riscv64gc' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 's390x' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'ARM64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'i686' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'ppc64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'ppc64le' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'riscv64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'riscv64gc' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 's390x' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'x86' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/51/ad9202a73ed27e6d9643fab84856cef507c993941ea6ab9a00c0a6a1ee25/urllib3_future-2.16.900.tar.gz", hash = "sha256:aea8895b54c79fc67181efe0b473b4857927235bee6e54416688b2eb4a707abe", size = 1124153, upload-time = "2026-02-22T08:06:47.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/f8/d200701b30e0f3a5feb86668b5fe0c5f440ac896195f731c0a5e3ceacb4a/urllib3_future-2.16.900-py3-none-any.whl", hash = "sha256:d8b5fee7bd53f5ac5541ee02ff60331c8d410166cfa7d71412f256393d08da5a", size = 691731, upload-time = "2026-02-22T08:06:46.406Z" },
+]
+
+[[package]]
 name = "virtualenv"
 version = "20.38.0"
 source = { registry = "https://pypi.org/simple" }
@@ -630,4 +896,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d2/03/a94d404ca09a89a7301a7008467aed525d4cdeb9186d262154dd23208709/virtualenv-20.38.0.tar.gz", hash = "sha256:94f39b1abaea5185bf7ea5a46702b56f1d0c9aa2f41a6c2b8b0af4ddc74c10a7", size = 5864558, upload-time = "2026-02-19T07:48:02.385Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/d7/394801755d4c8684b655d35c665aea7836ec68320304f62ab3c94395b442/virtualenv-20.38.0-py3-none-any.whl", hash = "sha256:d6e78e5889de3a4742df2d3d44e779366325a90cf356f15621fddace82431794", size = 5837778, upload-time = "2026-02-19T07:47:59.778Z" },
+]
+
+[[package]]
+name = "wassima"
+version = "2.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/e6/4f9413cd115fe724fcc0ea83db1d43fdeb8dff59ea5d55e7788a946b0afd/wassima-2.0.5.tar.gz", hash = "sha256:91a0da50799d9b4ef7a85f23a37c9aabe629f75c2dd9616ee4abc1f4c17d10a7", size = 143472, upload-time = "2026-02-07T16:52:34.484Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/d9/e81c8de18b3edd22e1884ed6b8cfc2ce260addb110fd519781ea54274e38/wassima-2.0.5-py3-none-any.whl", hash = "sha256:e60b567b26b87c83ff310a191d9c584113f13c0bcea0564f92e7630b17da319b", size = 138778, upload-time = "2026-02-07T16:52:32.844Z" },
+]
+
+[[package]]
+name = "x-wr-timezone"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "icalendar" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/2b/8ae5f59ab852c8fe32dd37c1aa058eb98aca118fec2d3af5c3cd56fffb7b/x_wr_timezone-2.0.1.tar.gz", hash = "sha256:9166c40e6ffd4c0edebabc354e1a1e2cffc1bb473f88007694793757685cc8c3", size = 18212, upload-time = "2025-02-06T17:10:40.913Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/b7/4bac35b4079b76c07d8faddf89467e9891b1610cfe8d03b0ebb5610e4423/x_wr_timezone-2.0.1-py3-none-any.whl", hash = "sha256:e74a53b9f4f7def8138455c240e65e47c224778bce3c024fcd6da2cbe91ca038", size = 11102, upload-time = "2025-02-06T17:10:39.192Z" },
 ]


### PR DESCRIPTION
— *Claude Code*

## Summary

- Adds a `calendar` integration that fetches today's events from ICS feeds and/or private iCloud CalDAV — both modes can be active simultaneously, with events merged and sorted together
- ICS mode supports public/secret-address `.ics` feeds (Google Calendar, iCloud public link); colors auto-detected from `X-APPLE-CALENDAR-COLOR` or configured per-URL via `colors`
- CalDAV mode accesses private iCloud calendars via app-specific password; calendar colors read automatically from CalDAV properties
- Timed events sorted soonest-first; all-day events alphabetically; source index as tiebreaker (ICS URLs before CalDAV calendars)
- Ended timed events, cancelled events, and events with no summary silently skipped
- Per-URL ICS cache (30-minute TTL); stale cache served on transient fetch failures
- Recurring events fully expanded via `recurring-ical-events`
- Consolidates schedule override field docs in `config.example.toml` into a single block instead of repeating per-integration

Closes #165

## Test plan

- [ ] `uv run pytest` — 479 passed
- [ ] `uv run ruff check .` — clean
- [ ] `uv run ruff format --check .` — clean
- [ ] `uv run pyright` — 0 errors
- [ ] `uv run bandit -c pyproject.toml -r .` — no issues
- [ ] `uv run pip-audit` — no vulnerabilities
- [ ] `uv run pre-commit run pretty-format-json --all-files` — passed
- [ ] Integration tests: run `uv run pytest -m integration -v` locally with `CALENDAR_URL` and/or `CALENDAR_CALDAV_URL`/`CALENDAR_USERNAME`/`CALENDAR_PASSWORD` in `.env`
- [ ] Add GitHub environment secrets: `CALENDAR_URL`, `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD` to the `integration` environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
