### PR TITLE
chore(docs): doc review — fix stale refs, sort by usage, add missing entries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,17 +64,27 @@ exceptions.py               # Custom exception types (IntegrationDataUnavailable
 config.toml                 # Runtime config with API keys (git-ignored; copy from config.example.toml)
 config.example.toml         # Config template committed to the repo
 integrations/vestaboard.py  # Vestaboard API client (get_state, set_state)
+integrations/http.py        # Shared HTTP helper with retry logic
+integrations/weather.py     # Current weather via Open-Meteo (no API key required)
+integrations/calendar.py    # Today's calendar events (ICS feeds + iCloud CalDAV)
 integrations/bart.py        # BART real-time departures integration
-integrations/plex.py        # Plex Media Server now-playing via webhook
+integrations/discogs.py     # Daily vinyl suggestion from Discogs collection
 integrations/trakt.py       # Trakt.tv calendar and now-playing (OAuth device flow)
+integrations/plex.py        # Plex Media Server now-playing via webhook
 content/
   contrib/                  # Bundled community content (disabled by default)
+    weather.json            # Current weather conditions
+    weather.md              # Sidecar doc: configuration and data sources
+    calendar.json           # Today's calendar events (ICS and iCloud CalDAV)
+    calendar.md             # Sidecar doc: ICS and CalDAV configuration
     bart.json               # BART real-time departure board
     bart.md                 # Sidecar doc: configuration and data sources
-    plex.json               # Plex Media Server now-playing (webhook-only)
-    plex.md                 # Sidecar doc: Plex Pass requirement and webhook setup
+    discogs.json            # Daily vinyl suggestion from Discogs collection
+    discogs.md              # Sidecar doc: configuration and API details
     trakt.json              # Trakt.tv calendar and now-playing
     trakt.md                # Sidecar doc: OAuth setup and data sources
+    plex.json               # Plex Media Server now-playing (webhook-only)
+    plex.md                 # Sidecar doc: Plex Pass requirement and webhook setup
   user/                     # Personal content (always loaded, git-ignored)
 .env.example                # Template for local integration test secrets (copy to .env, fill in, git-ignored)
 Dockerfile                  # Single-stage image using ghcr.io/astral-sh/uv
@@ -332,7 +342,7 @@ prevention here — not just a one-off fix. See #65 for extended notes.
    ```
    gh api repos/JasonPuglisi/e-note-ion/rulesets/13082160 --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
    ```
-9. **Integration test hygiene** — advisory CI job passing on `main`; GitHub environment secrets/vars present (`BART_API_KEY`, `VESTABOARD_VIRTUAL_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `DISCOGS_TOKEN`, `ICAL_URL`, `ICAL_CALDAV_URL`, `ICAL_USERNAME`, `ICAL_PASSWORD` as secrets; `TRAKT_CLIENT_ID` as a variable); new integrations have `test_<name>_integration.py` and env vars in `tests/integrations/conftest.py`
+9. **Integration test hygiene** — advisory CI job passing on `main`; GitHub environment secrets/vars present (`VESTABOARD_VIRTUAL_API_KEY`, `CALENDAR_URL`, `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `DISCOGS_TOKEN` as secrets; `TRAKT_CLIENT_ID` as a variable); new integrations have `test_<name>_integration.py` and env vars in `tests/integrations/conftest.py`
 10. **Issue/milestone hygiene**:
     - Every open issue has a milestone (no orphans); scope is right-sized
     - Blocking relationships explicit ("Blocked by #X" in body)

--- a/README.md
+++ b/README.md
@@ -222,7 +222,12 @@ Required keys:
 | Key | Where to get it |
 |---|---|
 | `VESTABOARD_VIRTUAL_API_KEY` | [web.vestaboard.com](https://web.vestaboard.com) → Developer → Virtual Boards |
+| `CALENDAR_URL` | Google/iCloud: secret-address `.ics` URL (see `content/contrib/calendar.md`) |
+| `CALENDAR_CALDAV_URL` | `https://caldav.icloud.com/` for iCloud CalDAV |
+| `CALENDAR_USERNAME` | Apple ID email address |
+| `CALENDAR_PASSWORD` | App-specific password from [appleid.apple.com](https://appleid.apple.com) |
 | `BART_API_KEY` | [api.bart.gov/api/register.aspx](https://api.bart.gov/api/register.aspx) |
+| `DISCOGS_TOKEN` | [discogs.com/settings/developers](https://www.discogs.com/settings/developers) |
 | `TRAKT_CLIENT_ID` | [trakt.tv/oauth/applications](https://trakt.tv/oauth/applications) → your app |
 | `TRAKT_CLIENT_SECRET` | same app page |
 | `TRAKT_ACCESS_TOKEN` | run Trakt auth flow once and copy from `config.toml` |

--- a/content/README.md
+++ b/content/README.md
@@ -167,7 +167,7 @@ template to keep everything playing nicely together.
 
 | Slot | What fires | Notes |
 |---|---|---|
-| `:00` every hour | `weather` (priority 5, hold 600s) | Plus `trakt.calendar` every 4h (priority 4) and `aria` at 8am/8pm (priority 9) |
+| `:00` every hour | `weather` (priority 5, hold 600s) | Plus `trakt.calendar` every 4h (priority 4) |
 | `:30` every hour | `calendar` (priority 5, hold 300s) | Plus `discogs` at 8:30am (priority 5) |
 
 **New templates that fire hourly should pick `:00` or `:30` and check what
@@ -200,9 +200,9 @@ Don't inflate priority to "win" — see the priority guidelines above.
 
 | File | Description |
 |---|---|
+| [`weather.json`](contrib/weather.md) | Current weather conditions via Open-Meteo |
+| [`calendar.json`](contrib/calendar.md) | Today's calendar events (ICS and iCloud CalDAV) |
 | [`bart.json`](contrib/bart.md) | BART real-time departure board |
 | [`discogs.json`](contrib/discogs.md) | Daily vinyl suggestion from your Discogs collection |
-| [`calendar.json`](contrib/calendar.md) | Today's calendar events (ICS and iCloud CalDAV) |
-| [`plex.json`](contrib/plex.md) | Plex Media Server now-playing via webhook |
 | [`trakt.json`](contrib/trakt.md) | Trakt.tv upcoming calendar and now-playing |
-| [`weather.json`](contrib/weather.md) | Current weather conditions via Open-Meteo |
+| [`plex.json`](contrib/plex.md) | Plex Media Server now-playing via webhook |

--- a/content/contrib/discogs.md
+++ b/content/contrib/discogs.md
@@ -1,7 +1,7 @@
 # discogs.json
 
 Daily vinyl suggestion from your Discogs collection. Picks a random record
-each morning at 8am and displays the album title and artist.
+each morning at 8:30am and displays the album title and artist.
 
 ## Configuration
 


### PR DESCRIPTION
— *Claude Code*

## Summary

- **AGENTS.md**: Add missing integrations (`http`, `weather`, `calendar`, `discogs`) and `content/contrib/` entries (`weather`, `calendar`, `discogs`) to Project Structure; sort both by usage order (weather → calendar → bart → discogs → trakt → plex); fix item 9 health checklist `ICAL_*` → `CALENDAR_*`
- **README.md**: Add `CALENDAR_*` and `DISCOGS_TOKEN` to integration tests table; sort by usage (Vestaboard, Calendar, BART, Discogs, Trakt)
- **content/README.md**: Remove personal `aria` template reference from schedule coordination table (personal content that leaked into committed docs); sort contrib integrations table by usage order
- **content/contrib/discogs.md**: Fix "8am" → "8:30am" (stale since #290 rescheduled it)

## Test plan

- [ ] No code changes — docs only; CI lint/check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
