### PR TITLE
chore(docs): fix public/private description and stale env var in SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Key `[scheduler]` settings:
 | Key | Default | Description |
 |---|---|---|
 | `model` | `"note"` | Display model: `"note"` (3×15) or `"flagship"` (6×22) |
-| `public` | `false` | Skip templates marked `public = false` (for shared spaces) |
+| `public` | `false` | When `true`, skip templates marked `private = true` (for shared/guest-visible spaces) |
 | `content_enabled` | _(absent)_ | Content filter for both `user/` and `contrib/`: absent = all user loads, no contrib; `["*"]` = all user + all contrib; `["bart", "my_quotes"]` = only matching stems from either directory |
 | `timezone` | system TZ | IANA timezone for cron job scheduling (e.g. `"America/Los_Angeles"`) |
 | `min_hold` | `60` | Minimum seconds any message stays on display before a high-priority (≥8) queued message can interrupt it. Set to `0` to disable (not recommended for physical displays). |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,8 +10,8 @@ steps to reproduce, and any potential impact.
 
 ## API Key Handling
 
-This project requires a Vestaboard Read/Write API key via the `VESTABOARD_API_KEY`
-environment variable. Keep this key out of version control and never include it
-in content JSON files or Docker image builds. When running with Docker, pass it
-at runtime via `-e VESTABOARD_API_KEY=...` or an env file, not in the `Dockerfile`
-or image layers.
+This project stores secrets (Vestaboard API key, integration credentials) in
+`config.toml`, which is git-ignored. Never commit `config.toml` or include
+secrets in content JSON files or Docker image builds. When running with Docker,
+mount `config.toml` at runtime via `-v /path/to/config.toml:/app/config.toml`,
+not baked into the image.


### PR DESCRIPTION
— *Claude Code*

## Summary

- **README.md**: Fix `public` setting description — it was incorrectly describing templates as having a `public` field. Templates have a `private` field; `[scheduler] public = true` skips templates marked `private = true`
- **SECURITY.md**: Remove stale `VESTABOARD_API_KEY` environment variable reference — secrets live in `config.toml`, which is mounted at runtime in Docker, not passed as env vars

## Test plan

- [ ] Docs only — CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
