### PR TITLE
chore(docs): health review — fix stale refs, add missing docs, fix CI env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,12 @@ jobs:
         run: uv run pytest -m integration -v
         env:
           BART_API_KEY: ${{ secrets.BART_API_KEY }}
-          VESTABOARD_VIRTUAL_API_KEY: ${{ secrets.VESTABOARD_VIRTUAL_API_KEY }}
+          CALENDAR_URL: ${{ secrets.CALENDAR_URL }}
+          CALENDAR_CALDAV_URL: ${{ secrets.CALENDAR_CALDAV_URL }}
+          CALENDAR_USERNAME: ${{ secrets.CALENDAR_USERNAME }}
+          CALENDAR_PASSWORD: ${{ secrets.CALENDAR_PASSWORD }}
+          DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN }}
           TRAKT_CLIENT_ID: ${{ vars.TRAKT_CLIENT_ID }}
           TRAKT_CLIENT_SECRET: ${{ secrets.TRAKT_CLIENT_SECRET }}
           TRAKT_ACCESS_TOKEN: ${{ secrets.TRAKT_ACCESS_TOKEN }}
-          DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN }}
+          VESTABOARD_VIRTUAL_API_KEY: ${{ secrets.VESTABOARD_VIRTUAL_API_KEY }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,10 @@ integrations/discogs.py     # Daily vinyl suggestion from Discogs collection
 integrations/trakt.py       # Trakt.tv calendar and now-playing (OAuth device flow)
 integrations/plex.py        # Plex Media Server now-playing via webhook
 content/
+  README.md                 # Content author reference: JSON format, priority, schedule coordination
+  DESIGN.md                 # Visual/design conventions: layout, color, tone, character set
   contrib/                  # Bundled community content (disabled by default)
+    TEMPLATE.md             # Sidecar doc template for new integrations
     weather.json            # Current weather conditions
     weather.md              # Sidecar doc: configuration and data sources
     calendar.json           # Today's calendar events (ICS and iCloud CalDAV)
@@ -86,6 +89,8 @@ content/
     plex.json               # Plex Media Server now-playing (webhook-only)
     plex.md                 # Sidecar doc: Plex Pass requirement and webhook setup
   user/                     # Personal content (always loaded, git-ignored)
+docs/
+  webhook-reverse-proxy.md  # Webhook TLS setup guide (Tailscale Funnel, reverse proxy)
 .env.example                # Template for local integration test secrets (copy to .env, fill in, git-ignored)
 Dockerfile                  # Single-stage image using ghcr.io/astral-sh/uv
 .github/workflows/
@@ -167,6 +172,11 @@ static `variables` dict. When the job fires, the worker calls
 dynamic data (e.g. real-time API responses) to populate `{variable}`
 placeholders in the format. The `variables` key is optional when an
 integration is present.
+
+Add `"integration_fn": "<function_name>"` to call a function other than
+`get_variables` on the integration module. This lets a single integration
+expose multiple data sources (e.g. Trakt's `get_variables_calendar` and
+`get_variables_watching`).
 
 Color squares can be embedded in format strings and integration output using
 short tags: `[R]` `[O]` `[Y]` `[G]` `[B]` `[V]` `[W]` `[K]` (red, orange,

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ uv run pyright
 uv run bandit -c pyproject.toml -r .
 uv run pip-audit
 uv run pre-commit run pretty-format-json --all-files
+uv run pytest
 ```
 
 All checks are also enforced as pre-commit hooks.

--- a/config.example.toml
+++ b/config.example.toml
@@ -119,7 +119,7 @@ token = "your-discogs-personal-access-token"
 # folder_id = "0"
 
 # [discogs.schedules.morning_spin]
-# cron = "0 9 * * *"
+# cron = "30 8 * * *"
 # hold = 600
 # timeout = 3600
 # priority = 5

--- a/content/README.md
+++ b/content/README.md
@@ -115,6 +115,11 @@ fetch current variable values:
 }
 ```
 
+By default the worker calls `get_variables()` on the integration module. To
+call a different function, add `"integration_fn": "<function_name>"` to the
+template — useful when one integration exposes multiple data sources (e.g.
+Trakt's `get_variables_calendar` and `get_variables_watching`).
+
 ### Priority guidelines
 
 Priority determines which message is shown first when multiple jobs fire at

--- a/content/contrib/plex.md
+++ b/content/contrib/plex.md
@@ -1,8 +1,9 @@
 # plex.json
 
 Plex Media Server integration — shows what you are currently watching on the
-board using Plex webhooks. Displays "NOW PLAYING" when playback starts or
-resumes, "PAUSED" when playback is paused, and clears when playback stops.
+board using Plex webhooks. Shows "NOW PLAYING" when playback starts, resumes,
+pauses, or stops — the color square signals the state (green for playing,
+yellow for paused, red for stopped).
 
 Unlike cron-scheduled templates, these templates are triggered entirely by
 incoming Plex webhook events. No content is shown when Plex is idle.
@@ -123,15 +124,31 @@ Only video media is displayed — music and photo events return no message.
 **Note (3×15):**
 
 ```
-[O] NOW PLAYING
+[G] NOW PLAYING        ← playing (green)
+SHOW NAME
+S3E3 EPISODE TITLE
+
+[Y] NOW PLAYING        ← paused (yellow)
+SHOW NAME
+S3E3 EPISODE TITLE
+
+[R] NOW PLAYING        ← stopped (red, brief 60s card)
 SHOW NAME
 S3E3 EPISODE TITLE
 ```
 
-- Row 1: `[O]` (orange, Plex brand color) + mode label
+- Row 1: color square (data-driven, see below) + `NOW PLAYING`
 - Row 2: Show name (for episodes) or movie title (for movies)
 - Row 3: Season/episode reference + episode title (e.g. `S3E3 BEEF`), truncated
   with ellipsis if too long. For movies, row 3 is blank.
+
+Color indicates playback state:
+
+| State | Color | Hold |
+|---|---|---|
+| Playing | `[G]` green | Indefinite (until paused/stopped) |
+| Paused | `[Y]` yellow | Indefinite (until resumed/stopped) |
+| Stopped | `[R]` red | 60 seconds |
 
 Leading articles are stripped from episode titles only. Show names and
 movie titles are preserved as-is: "THE BEAR" stays "THE BEAR", but the


### PR DESCRIPTION
— *Claude Code*

## Summary

Health review across all project docs, CI, content JSON, and agent instructions.

**Fixes found and applied:**

- **CI missing calendar env vars**: `CALENDAR_URL`, `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD` were documented in AGENTS.md and conftest.py but never passed to the integration test job — calendar tests always skipped in CI. Added and alphabetized env vars.
- **plex.md display format wrong**: doc showed `[O] NOW PLAYING` (orange) for all states and claimed "PAUSED" text; actual JSON uses data-driven colors (`[G]` playing, `[Y]` paused, `[R]` stopped) with "NOW PLAYING" text throughout. Updated with per-state format examples and color table.
- **config.example.toml stale discogs cron**: showed `"0 9 * * *"` but actual default in discogs.json is `"30 8 * * *"`. Fixed.
- **`integration_fn` undocumented**: field used in trakt.json and supported in scheduler.py but never documented. Added to both AGENTS.md and content/README.md.
- **AGENTS.md project structure incomplete**: missing `content/README.md`, `content/DESIGN.md`, `content/contrib/TEMPLATE.md`, `docs/webhook-reverse-proxy.md`. Added.
- **README.md check suite missing pytest**: `uv run pytest` was in AGENTS.md and CI but not in the README Development section. Added.

**Also fixed (no PR needed):**

- Added missing labels to issues #222 (`enhancement`), #223 (`chore`), #227 (`enhancement`), #228 (`enhancement`)

**Checked and clean:**

- All checks pass (ruff, pyright, bandit, pip-audit, pytest 479/479, JSON format)
- No CodeQL or Dependabot alerts
- No stale TODO/FIXME in source
- Branch ruleset required checks match CI job names
- All recent CI runs on main green
- All open issues have milestones and assignees
- Content JSON schedules match slot documentation in content/README.md
- Sidecar docs consistent with JSON defaults (after plex.md fix)
- No significant token-optimization opportunities — docs are already concise

## Test plan

- [ ] CI integration job picks up calendar env vars on next main push
- [ ] Verify no doc regressions by reading updated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
