### PR TITLE
fix(plex): same-tag supersede always interrupts indefinite hold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.24.0"
+version = "0.24.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.24.0"
+version = "0.24.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- All three Plex webhook templates use `priority: 8`, which equals `_INTERRUPT_PRIORITY_THRESHOLD`
- The interruptibility check uses strict less-than (`8 < 8 → False`), so the indefinite `now_playing` hold could never be interrupted by incoming `paused` or `stopped` events — the board got stuck on "NOW PLAYING" forever
- Fix adds a same-tag bypass: when the incoming `supersede_tag` matches the current hold's tag, `_hold_interrupt.set()` fires unconditionally; cross-source messages still respect the threshold as before

## Test plan

- `test_interrupt_bypasses_threshold_when_same_supersede_tag` — same-tag at priority 8 now fires interrupt
- `test_interrupt_blocked_for_different_tag_high_priority_hold` — different-tag at priority 8 still blocked
- Updated `test_interrupt_blocked_when_current_hold_is_high_priority` to explicitly set a different source tag, making the scenario unambiguous
- All 481 existing tests continue to pass

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)
