### PR TITLE
fix(ci): only count setup-phase skips toward integration exit code 5

### DIFF
--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -55,9 +55,13 @@ def _integration_env_summary() -> None:
 
 
 def pytest_runtest_logreport(report: pytest.TestReport) -> None:
-  """Track integration tests skipped due to missing env vars."""
+  """Track integration tests skipped due to missing env vars.
+
+  Only setup-phase skips (from the require_env fixture) are counted — call-phase
+  skips (e.g. "no events today") are intentional and must not trigger exit code 5.
+  """
   global _skipped
-  if report.skipped and report.when in ('setup', 'call'):
+  if report.skipped and report.when == 'setup':
     _skipped += 1
 
 


### PR DESCRIPTION
— *Claude Code*

## Summary

- The integration conftest was counting **all** skips (setup and call phase) toward the exit-code-5 trigger, which surfaces as an advisory failure
- Calendar tests legitimately skip during the call phase when there are no events today (e.g. "no events today in the configured calendar — not a failure") — this is not a missing env var and should not fail the job
- Fix: only count `setup`-phase skips from the `require_env` fixture, which are the genuine "env var missing" cases worth surfacing

## Root cause

`CALENDAR_URL` was set correctly in the GitHub environment, but today (Feb 28) has no US holidays. The test fetched the feed, found no events, and called `pytest.skip('no events today')` from the test body (call phase). The conftest counted it the same as a missing-env-var skip.

## Test plan

- Confirmed locally: `test_ics_mode_real_feed` skips with "no events today" (call phase, not counted); `test_caldav_mode_real_icloud` skips with "CALENDAR_CALDAV_URL not set" (setup phase, counted) — exit 5 locally because CalDAV vars aren't in `.env`
- In CI where all env vars are set, all tests run; "no events today" call-phase skips will no longer trigger exit code 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
