### PR TITLE
feat(scheduler): warn when content file is missing, malformed, or has unknown integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.24.3"
+version = "0.24.4"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.24.3"
+version = "0.24.4"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Closes #305.

— *Claude Code*

## Summary

- `load_content()` wraps each `_load_file()` call in try/except — malformed JSON, invalid templates, or any other parse error now prints `Warning: failed to load <path>: <reason>` and continues rather than crashing startup
- After scanning both directories, warns on any stem in `[scheduler] enabled` that wasn't found in either location
- Warns when the same stem exists in both `content/user/` and `content/contrib/` (both still load; operator can rename to resolve)
- `_load_file()` now calls `_get_integration()` at parse time for templates with `"integration"` — unknown names and missing dependencies print a `Warning: skipping template` and skip that template rather than registering a job guaranteed to fail at runtime
- Bumps patch version to 0.24.4

## Test plan

- [ ] `uv run pytest` passes (489 tests)
- [ ] New tests: malformed JSON warning, unknown stem warning, `'*'` no-warning, duplicate-stem warning (both still loaded), unknown integration skipped
- [ ] CI `check` and `docker` jobs pass
