### PR TITLE
feat(trakt): add on-deck template showing next unwatched episode

### DIFF
--- a/content/contrib/trakt.json
+++ b/content/contrib/trakt.json
@@ -2,7 +2,7 @@
   "templates": {
     "calendar": {
       "schedule": {
-        "cron": "0 */4 * * *",
+        "cron": "0 0,8,16 * * *",
         "hold": 1200,
         "timeout": 1800
       },
@@ -17,6 +17,27 @@
             "[V] NEXT AIRING",
             "{show_name}",
             "{episode_ref} {air_day} {air_time}"
+          ]
+        }
+      ]
+    },
+    "next_up": {
+      "schedule": {
+        "cron": "0 4,12,20 * * *",
+        "hold": 1200,
+        "timeout": 1800
+      },
+      "priority": 4,
+      "private": true,
+      "truncation": "ellipsis",
+      "integration": "trakt",
+      "integration_fn": "get_variables_next_up",
+      "templates": [
+        {
+          "format": [
+            "[V] ON DECK",
+            "{show_name}",
+            "{episode_ref} {episode_title}"
           ]
         }
       ]

--- a/content/contrib/trakt.md
+++ b/content/contrib/trakt.md
@@ -1,8 +1,10 @@
 # trakt.json
 
-Trakt.tv integration — shows the next upcoming episode from your calendar and
-what you are currently watching. Calendar updates every 4 hours; now-playing
-polls every 3 minutes and only shows when something is actively playing.
+Trakt.tv integration — shows the next upcoming episode from your calendar,
+the next unwatched episode for your most recently watched show, and what you
+are currently watching. Calendar and on-deck alternate every 4 hours (3 fires
+each per day); now-playing polls every 3 minutes and only shows when something
+is actively playing.
 
 ## Configuration
 
@@ -106,8 +108,10 @@ review new discussions periodically for anything that may affect this integratio
 
 This integration uses:
 - `GET /calendars/my/shows/{date}/{days}` — episodes airing in the next N days
+- `GET /users/me/watched/shows` — shows sorted by most recently watched
+- `GET /shows/{trakt_id}/progress/watched` — next unwatched episode for a show
 - `GET /users/me/watching` — currently playing episode or movie
 
-Both endpoints are available on all Trakt accounts (no VIP required).
+All endpoints are available on all Trakt accounts (no VIP required).
 
 Authoritative API docs: https://trakt.docs.apiary.io

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.24.5"
+version = "0.25.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/integrations/test_trakt_integration.py
+++ b/tests/integrations/test_trakt_integration.py
@@ -72,3 +72,24 @@ def test_get_variables_watching_live(require_env: None, monkeypatch: pytest.Monk
     assert 'episode_title' in result
   except IntegrationDataUnavailableError:
     pass  # nothing playing — valid outcome
+
+
+@pytest.mark.integration
+@pytest.mark.require_env('TRAKT_CLIENT_ID', 'TRAKT_CLIENT_SECRET', 'TRAKT_ACCESS_TOKEN')
+def test_get_variables_next_up_live(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+  """get_variables_next_up() returns valid vars or raises DataUnavailable — both are correct."""
+  _patch_config(monkeypatch)
+  trakt._auth_started = False
+  trakt._next_up_cache = None
+
+  try:
+    result = trakt.get_variables_next_up()
+    assert 'show_name' in result
+    assert 'episode_ref' in result
+    assert 'episode_title' in result
+    for key in result:
+      assert len(result[key]) == 1
+      assert len(result[key][0]) == 1
+      assert isinstance(result[key][0][0], str)
+  except IntegrationDataUnavailableError:
+    pass  # user may have no shows in progress — valid outcome

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.24.5"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Implements the `next_up` (On Deck) template for the Trakt integration, as planned in #188.

## Changes

- **`integrations/trakt.py`**: Add `get_variables_next_up()` — fetches the user's most recently watched shows (`/users/me/watched/shows`), then probes `/shows/{id}/progress/watched` for each (up to 5) until one has a non-null `next_episode`. Returns `show_name`, `episode_ref`, `episode_title`. 1-hour cache with stale fallback on transient API failures.
- **`content/contrib/trakt.json`**: Add `next_up` template (`[V] ON DECK`). Adjust `calendar` cron from `0 */4 * * *` → `0 0,8,16 * * *`; `next_up` runs at `0 4,12,20 * * *` — same total Trakt frequency, interleaved every 4 hours.
- **`content/contrib/trakt.md`**: Document the new template and the two new API endpoints.
- **`tests/core/test_trakt.py`**: 10 new unit tests covering happy path, skip-completed, all-completed, empty list, API errors (watched + progress), long show name, credential non-leakage, cache hit, cache expiry.
- **`tests/integrations/test_trakt_integration.py`**: `test_get_variables_next_up_live` — real API call; accepts result or `IntegrationDataUnavailableError`.

## Version bump

`0.24.5` → `0.25.0` (minor — new feature)

Closes #188

---
— *Claude Code*
