### PR TITLE
fix(plex): pause/stop board displacement check never passed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.25.0"
+version = "0.25.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- **Missing `global` declaration in `worker()`**: `_current_hold_supersede_tag` and `_current_hold_priority` were assigned without `global`, creating local variables. The module-level globals read by `current_hold_tag()` were never updated, so the board displacement check in `plex.py` always saw `tag=''` and silently dropped every pause/stop event.
- **Tag set too late**: even after adding `global`, a ~1–2s race window existed during `vestaboard.set_state()` where concurrent pause/stop events still saw the old tag. Moving the assignment before `set_state()` closes this window.
- **Interrupt cleared before it could fire**: `_hold_interrupt.clear()` was called after `set_state()`, discarding any interrupt set by a pause event that arrived during the API call. Now re-fires the interrupt when a same-tag message is already queued.

Closes #312.

## Test plan

- [ ] 5 new regression tests in `test_scheduler.py` cover all fixed paths
- [ ] Full CI suite passes
- [ ] Manually trigger `media.play` then `media.pause` on Plex — board transitions to PAUSED
- [ ] `media.stop` — board transitions to stopped card

🤖 Generated with [Claude Code](https://claude.com/claude-code)
