### PR TITLE
chore(plex): add diagnostic logging to handle_webhook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.25.1"
+version = "0.25.2"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.25.1"
+version = "0.25.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Adds `[plex]` prefixed log lines to `handle_webhook` at every decision point that can return `None`, so it's possible to diagnose pause/stop drops without adding temporary print statements
- Each log line shows: timestamp, event name, current state machine state, and the specific discard reason when applicable

## Log output after this change

Play event (normal path):
```
[12:01:00] [plex] media.play (state=idle)
[12:01:00] Sending webhook.plex | ...
```

Pause discarded — state machine (e.g. pause arrives before any play):
```
[12:05:00] [plex] media.pause (state=idle)
[12:05:00] [plex] discarding media.pause: state=idle, expected playing
```

Pause discarded — board displacement (tag not yet set):
```
[12:05:00] [plex] media.pause (state=playing)
[12:05:00] [plex] discarding media.pause: board tag='', expected "plex"
```

Pause enqueued (normal path):
```
[12:05:00] [plex] media.pause (state=playing)
[12:05:00] [plex] enqueueing paused: 'SHOW NAME'
[12:05:00] Sending webhook.plex | ...
```

## Test plan

- [ ] CI passes
- [ ] Trigger play → pause → stop sequence on Plex, check scheduler logs to confirm each event is logged and which path it takes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
