### PR TITLE
chore(plex): add hold-lifecycle logging to diagnose premature hold exit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.25.2"
+version = "0.25.3"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -279,11 +279,19 @@ def _do_hold(
     interrupted = _hold_interrupt.wait(timeout=next_wake)
     _hold_interrupt.clear()
     if interrupted:
+      print(
+        f'[{datetime.now().strftime("%H:%M:%S")}] [hold] {message.name}'
+        f' interrupted at {time.monotonic() - hold_start:.1f}s'
+      )
       break
 
     if message.priority < _INTERRUPT_PRIORITY_THRESHOLD and elapsed >= min_hold:
       with _queue.mutex:
         if _queue.queue and _queue.queue[0].priority >= _INTERRUPT_PRIORITY_THRESHOLD:
+          print(
+            f'[{datetime.now().strftime("%H:%M:%S")}] [hold] {message.name}'
+            f' preempted by higher-priority message at {time.monotonic() - hold_start:.1f}s'
+          )
           break
 
     if refresh_fn and refresh_interval:
@@ -415,11 +423,16 @@ def worker() -> None:
     if message.supersede_tag:
       with _queue.mutex:
         if any(m.supersede_tag == message.supersede_tag for m in _queue.queue):
+          print(
+            f'[{datetime.now().strftime("%H:%M:%S")}] [hold] {message.name}'
+            f' re-firing interrupt: same-tag message queued during set_state'
+          )
           _hold_interrupt.set()
     _do_hold(message, _get_min_hold(), refresh_fn=_refresh_fn, refresh_interval=refresh_interval)
     with _current_hold_lock:
       _current_hold_supersede_tag = ''
       _current_hold_priority = None
+    print(f'[{datetime.now().strftime("%H:%M:%S")}] [hold] {message.name} hold ended, tag cleared')
 
     # Hold expired — if this was a refresh-capable integration message, transfer
     # the refresh fn to idle state so the display keeps updating while the queue
@@ -528,6 +541,10 @@ def _make_webhook_handler(secret: str) -> type:
 
       if result.interrupt_only:
         if _current_hold_is_interruptible():
+          print(
+            f'[{datetime.now().strftime("%H:%M:%S")}] [webhook] {integration_name}'
+            f' interrupt_only — firing hold interrupt'
+          )
           _hold_interrupt.set()
         self._respond(200, 'Interrupted')
         return
@@ -547,6 +564,11 @@ def _make_webhook_handler(secret: str) -> type:
         # cut through the prior hold from that same source.
         same_tag = bool(result.supersede_tag) and result.supersede_tag == current_hold_tag()
         if same_tag or _current_hold_is_interruptible():
+          reason = 'same-tag' if same_tag else 'interruptible hold'
+          print(
+            f'[{datetime.now().strftime("%H:%M:%S")}] [webhook] {integration_name}'
+            f' interrupt ({reason}) — firing hold interrupt'
+          )
           _hold_interrupt.set()
 
       self._respond(200, 'Enqueued')

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.25.2"
+version = "0.25.3"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

Adds `[hold]` and `[webhook]` prefixed log lines to diagnose why `current_hold_tag()` returns `''` within 5–6 seconds of a Plex `now_playing` hold starting, causing every subsequent `media.pause` and `media.stop` to be silently discarded.

### New log lines

**In `_do_hold`** — fires when the hold exits early:
```
[HH:MM:SS] [hold] webhook.plex interrupted at 1.0s
[HH:MM:SS] [hold] webhook.plex preempted by higher-priority message at 62.3s
```

**In `worker()`** — fires when the pre-hold re-fire check triggers:
```
[HH:MM:SS] [hold] webhook.plex re-firing interrupt: same-tag message queued during set_state
```

**In `worker()`** — fires when the hold ends normally and the tag is cleared:
```
[HH:MM:SS] [hold] webhook.plex hold ended, tag cleared
```

**In the webhook handler** — fires when `_hold_interrupt.set()` is called:
```
[HH:MM:SS] [webhook] plex interrupt (same-tag) — firing hold interrupt
[HH:MM:SS] [webhook] plex interrupt (interruptible hold) — firing hold interrupt
[HH:MM:SS] [webhook] plex interrupt_only — firing hold interrupt
```

## Test plan

- [ ] CI passes
- [ ] Trigger play → pause sequence; check logs to see which `[hold]` or `[webhook]` line fires before the `[plex] discarding media.pause` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)
