### PR TITLE
chore(plex): instrument current_hold_tag and tag writes for deep diagnostics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.25.3"
+version = "0.25.4"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -216,7 +216,10 @@ _current_hold_priority: int | None = None
 def current_hold_tag() -> str:
   """Return the supersede_tag of the message currently being held, or ''."""
   with _current_hold_lock:
-    return _current_hold_supersede_tag
+    tag = _current_hold_supersede_tag
+  ts = datetime.now().strftime('%H:%M:%S.%f')[:-3]
+  print(f'[{ts}] [tag] current_hold_tag()={tag!r} pri={_current_hold_priority!r}')
+  return tag
 
 
 def _current_hold_is_interruptible() -> bool:
@@ -349,6 +352,10 @@ def worker() -> None:
     with _current_hold_lock:
       _current_hold_supersede_tag = message.supersede_tag
       _current_hold_priority = message.priority
+    print(
+      f'[{datetime.now().strftime("%H:%M:%S.%f")[:-3]}] [tag] set tag={message.supersede_tag!r}'
+      f' priority={message.priority!r}'
+    )
 
     try:
       variables = message.data['variables']
@@ -364,6 +371,7 @@ def worker() -> None:
       with _current_hold_lock:
         _current_hold_supersede_tag = ''
         _current_hold_priority = None
+      print(f'[{datetime.now().strftime("%H:%M:%S.%f")[:-3]}] [tag] cleared (IntegrationDataUnavailableError)')
       print(f'[{datetime.now().strftime("%H:%M:%S")}] Skipping {message.name}: {e}')
       continue
     except vestaboard.DuplicateContentError:
@@ -374,6 +382,7 @@ def worker() -> None:
       with _current_hold_lock:
         _current_hold_supersede_tag = ''
         _current_hold_priority = None
+      print(f'[{datetime.now().strftime("%H:%M:%S.%f")[:-3]}] [tag] cleared (BoardLockedError)')
       print(f'Board locked: {e}. Retrying in {_LOCK_RETRY_DELAY}s.')
       time.sleep(_LOCK_RETRY_DELAY)
       # Re-enqueue if the message hasn't exceeded its timeout.
@@ -384,6 +393,7 @@ def worker() -> None:
       with _current_hold_lock:
         _current_hold_supersede_tag = ''
         _current_hold_priority = None
+      print(f'[{datetime.now().strftime("%H:%M:%S.%f")[:-3]}] [tag] cleared (Exception: {type(e).__name__})')
       print(f'Error sending to board: {e}')
       continue
 

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.25.3"
+version = "0.25.4"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

Adds millisecond-precision `[tag]` log lines at every point where `_current_hold_supersede_tag` is written or read, to resolve a deep diagnostic contradiction:

- `current_hold_tag()` returns `''` when `media.pause` arrives 7 seconds into the hold
- `current_hold_tag()` returns `'plex'` when `media.resume` arrives 14 seconds into the same hold
- No `[hold]` lines appear between those two events, so the hold is still running

These lines will reveal exactly when the tag becomes `''` and what kind of clear (exception path or other) causes it.

### New log lines

```
[HH:MM:SS.mmm] [tag] set tag='plex' priority=8
[HH:MM:SS.mmm] [tag] current_hold_tag()='plex' pri=8
[HH:MM:SS.mmm] [tag] cleared (IntegrationDataUnavailableError)
[HH:MM:SS.mmm] [tag] cleared (BoardLockedError)
[HH:MM:SS.mmm] [tag] cleared (Exception: SomeType)
```

## Test plan

- [ ] CI passes
- [ ] Trigger play → pause sequence; look for `[tag]` lines to see where the clear happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
