### PR TITLE
fix(scheduler): alias __main__ → scheduler to prevent double-import of module globals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.25.4"
+version = "0.25.5"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -39,6 +39,16 @@ import config as _config_mod
 import integrations.vestaboard as vestaboard
 from exceptions import IntegrationDataUnavailableError
 
+# When run via `python scheduler.py` or the `e-note-ion` entry point, Python
+# loads this module as __main__. Integrations that do `import scheduler` (e.g.
+# plex.py) would otherwise trigger a *second* import, producing a separate
+# module object with its own copies of module-level globals such as
+# _current_hold_supersede_tag. This line aliases __main__ → scheduler so that
+# all imports share a single module object. No-op when scheduler is already
+# imported normally (e.g. in tests or when imported by another module).
+if __name__ == '__main__':
+  sys.modules.setdefault('scheduler', sys.modules['__main__'])
+
 # Allowlist of valid integration names. Must be extended when a new integration
 # is added to integrations/.
 _KNOWN_INTEGRATIONS: frozenset[str] = frozenset({'bart', 'calendar', 'discogs', 'plex', 'trakt', 'weather'})
@@ -217,8 +227,6 @@ def current_hold_tag() -> str:
   """Return the supersede_tag of the message currently being held, or ''."""
   with _current_hold_lock:
     tag = _current_hold_supersede_tag
-  ts = datetime.now().strftime('%H:%M:%S.%f')[:-3]
-  print(f'[{ts}] [tag] current_hold_tag()={tag!r} pri={_current_hold_priority!r}')
   return tag
 
 
@@ -352,10 +360,6 @@ def worker() -> None:
     with _current_hold_lock:
       _current_hold_supersede_tag = message.supersede_tag
       _current_hold_priority = message.priority
-    print(
-      f'[{datetime.now().strftime("%H:%M:%S.%f")[:-3]}] [tag] set tag={message.supersede_tag!r}'
-      f' priority={message.priority!r}'
-    )
 
     try:
       variables = message.data['variables']
@@ -371,7 +375,6 @@ def worker() -> None:
       with _current_hold_lock:
         _current_hold_supersede_tag = ''
         _current_hold_priority = None
-      print(f'[{datetime.now().strftime("%H:%M:%S.%f")[:-3]}] [tag] cleared (IntegrationDataUnavailableError)')
       print(f'[{datetime.now().strftime("%H:%M:%S")}] Skipping {message.name}: {e}')
       continue
     except vestaboard.DuplicateContentError:
@@ -382,7 +385,6 @@ def worker() -> None:
       with _current_hold_lock:
         _current_hold_supersede_tag = ''
         _current_hold_priority = None
-      print(f'[{datetime.now().strftime("%H:%M:%S.%f")[:-3]}] [tag] cleared (BoardLockedError)')
       print(f'Board locked: {e}. Retrying in {_LOCK_RETRY_DELAY}s.')
       time.sleep(_LOCK_RETRY_DELAY)
       # Re-enqueue if the message hasn't exceeded its timeout.
@@ -393,7 +395,6 @@ def worker() -> None:
       with _current_hold_lock:
         _current_hold_supersede_tag = ''
         _current_hold_priority = None
-      print(f'[{datetime.now().strftime("%H:%M:%S.%f")[:-3]}] [tag] cleared (Exception: {type(e).__name__})')
       print(f'Error sending to board: {e}')
       continue
 

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.25.4"
+version = "0.25.5"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Root cause

`scheduler.py` runs as `__main__`. When `plex.py` executes `import scheduler as _sched` inside `handle_webhook`, Python performs a **second import** — loading `scheduler.py` again as a separate module object with its own copy of `_current_hold_supersede_tag = ''`. The worker thread writes to `__main__._current_hold_supersede_tag`, but plex's board displacement check reads from `scheduler._current_hold_supersede_tag` (always `''`).

```
[tag] set tag='plex' priority=8           ← worker writes __main__ global
[tag] current_hold_tag()='' pri=None      ← plex reads scheduler global (always '')
[tag] current_hold_tag()='plex' pri=8     ← webhook handler reads __main__ global (correct)
```

Every `media.pause` and `media.stop` event was discarded at:
```python
if hold_tag != 'plex':  # hold_tag was always '' from the shadow module
    _log(f'discarding {event}: board tag={hold_tag!r}, expected "plex"')
    return None
```

## Fix

Register `__main__` under `'scheduler'` in `sys.modules` before any integration can trigger the double-import. This is a single line, added at module level, guarded by `if __name__ == '__main__':`:

```python
if __name__ == '__main__':
    sys.modules.setdefault('scheduler', sys.modules['__main__'])
```

`setdefault` is safe: if `scheduler` is already in `sys.modules` (e.g. loaded by tests), it does nothing.

Also removes the `[tag]` diagnostic print statements added during root-cause investigation (PRs #314–#316); keeps the `[hold]` and `[webhook]` operational logs.

Closes #312.

## Test plan

- [x] All 510 unit tests pass
- [ ] CI passes
- [ ] Manually trigger play → pause → stop on Plex — board shows PAUSED, then stopped card

🤖 Generated with [Claude Code](https://claude.com/claude-code)
