### PR TITLE
fix(bart): use named day_of_week to prevent Monday silent skip

### DIFF
--- a/content/README.md
+++ b/content/README.md
@@ -63,7 +63,7 @@ schedule and display settings.
 
 | Field | Description |
 |---|---|
-| `cron` | Standard 5-field cron expression |
+| `cron` | Standard 5-field cron expression. **Use named days for `day_of_week`** (e.g. `mon-fri`, not `1-5`): APScheduler numbers weekdays from Monday (0=Mon … 6=Sun), opposite to Unix cron (0=Sun). Numeric values will silently fire on the wrong days. |
 | `hold` | Seconds the message stays on display before the next update |
 | `timeout` | Seconds the message can wait in the queue before being discarded |
 | `priority` | Integer 0–10; higher number runs first when multiple messages are queued simultaneously |
@@ -148,7 +148,7 @@ Override schedule fields or visibility for any named template directly in
 
 ```toml
 [bart.schedules.departures]
-cron = "*/5 6-9 * * 1-5"  # extend window to start at 6am
+cron = "*/5 6-9 * * mon-fri"  # extend window to start at 6am
 hold = 180
 timeout = 90
 priority = 9

--- a/content/contrib/bart.json
+++ b/content/contrib/bart.json
@@ -2,7 +2,7 @@
   "templates": {
     "departures": {
       "schedule": {
-        "cron": "*/5 7-9 * * 1-5",
+        "cron": "*/5 7-9 * * mon-fri",
         "hold": 290,
         "timeout": 60,
         "refresh_interval": 60

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.25.8"
+version = "0.25.9"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.25.8"
+version = "0.25.9"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- `day_of_week='1-5'` in APScheduler means **Tuesday–Saturday** (0=Mon), not Monday–Friday as in Unix cron (0=Sun). BART was silently skipping all Mondays.
- Changed `bart.json` cron `day_of_week` from `1-5` to `mon-fri`, which APScheduler resolves unambiguously.
- Updated the schedule override example in `content/README.md` to match, and added a prominent warning to the `cron` field docs so future content authors know to use named days.

Closes #324

## Test plan

- [x] All 543 unit tests pass
- [x] `ruff`, `pyright`, `bandit`, `pip-audit`, `pre-commit` all clean
- [x] Verify in logs: BART should now appear in APScheduler's "Looking for jobs to run" output on Mondays

🤖 Generated with [Claude Code](https://claude.com/claude-code)
