### PR TITLE
fix(trakt): widen refresh window to 24h, add startup refresh, handle refresh failures

### DIFF
--- a/integrations/trakt.py
+++ b/integrations/trakt.py
@@ -5,7 +5,7 @@
 # Authentication uses the OAuth device code flow (no browser redirect). On
 # first use, the scheduler prints a short code and URL to stdout; the user
 # visits the URL, enters the code, and tokens are written to config.toml.
-# Access tokens expire every ~90 days; refresh happens automatically 1 hour
+# Access tokens expire every ~90 days; refresh happens automatically 24 hours
 # before expiry, rotating the refresh token as required by Trakt's API.
 #
 # Required config.toml keys ([trakt]):
@@ -109,10 +109,18 @@ def _refresh_token() -> None:
   logger.debug('Trakt: token refreshed successfully')
 
 
-def _get_token() -> str:
-  """Return a valid Trakt access token, refreshing if within 1 hour of expiry.
+def _clear_tokens() -> None:
+  """Clear stored tokens from config (in-memory and on disk)."""
+  import config as _config_mod
 
-  Raises IntegrationDataUnavailableError if auth is pending (no tokens yet).
+  _config_mod.write_section_values('trakt', {'access_token': '', 'refresh_token': '', 'expires_at': ''})  # nosec B105 — empty strings intentionally clear stored tokens
+
+
+def _get_token() -> str:
+  """Return a valid Trakt access token, refreshing if within 24 hours of expiry.
+
+  Raises IntegrationDataUnavailableError if auth is pending (no tokens yet) or
+  if a token refresh fails (tokens cleared; re-auth flow started).
   """
   import config as _config_mod
 
@@ -125,13 +133,26 @@ def _get_token() -> str:
   if expires_at_str:
     try:
       expires_at = int(expires_at_str)
-      secs_remaining = expires_at - time.time()
-      if secs_remaining < 3600:
-        logger.debug('Trakt: access token expires in %.0fs — triggering refresh', secs_remaining)
-        _refresh_token()
-        access_token = _config_mod.get_optional('trakt', 'access_token')
     except ValueError:
       pass  # malformed expires_at — proceed with current token
+    else:
+      secs_remaining = expires_at - time.time()
+      if secs_remaining < 86400:
+        logger.debug('Trakt: access token expires in %.0fs — triggering refresh', secs_remaining)
+        try:
+          _refresh_token()
+        except requests.HTTPError as e:
+          logger.warning(
+            'Trakt: token refresh failed (%s) — clearing tokens and re-starting '
+            'auth flow. Check logs for the new device code and URL.',
+            e,
+          )
+          _clear_tokens()
+          _ensure_authenticated()
+          raise IntegrationDataUnavailableError(
+            'Trakt auth pending — token refresh failed, re-authentication required'
+          ) from None
+        access_token = _config_mod.get_optional('trakt', 'access_token')
 
   return access_token
 
@@ -207,11 +228,33 @@ def _run_auth_flow() -> None:
 
 
 def preflight() -> None:
-  """Called at startup. Initiates the auth flow if tokens are absent."""
+  """Called at startup. Initiates the auth flow if tokens are absent.
+
+  Proactively refreshes near-expiry tokens before any poll fires, so a brief
+  scheduler restart near the expiry window doesn't cause the token to lapse.
+  """
   import config as _config_mod
 
-  if not _config_mod.get_optional('trakt', 'access_token'):
+  access_token = _config_mod.get_optional('trakt', 'access_token')
+  if not access_token:
     _ensure_authenticated()
+    return
+
+  expires_at_str = _config_mod.get_optional('trakt', 'expires_at')
+  if expires_at_str:
+    try:
+      expires_at = int(expires_at_str)
+    except ValueError:
+      return
+    secs_remaining = expires_at - time.time()
+    if secs_remaining < 86400:
+      logger.info('Trakt: access token expires in %.0fs — refreshing at startup', secs_remaining)
+      try:
+        _refresh_token()
+      except requests.HTTPError as e:
+        logger.warning('Trakt: startup token refresh failed (%s) — clearing tokens', e)
+        _clear_tokens()
+        _ensure_authenticated()
 
 
 def _ensure_authenticated() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.25.9"
+version = "0.25.10"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_trakt.py
+++ b/tests/core/test_trakt.py
@@ -34,7 +34,7 @@ def config_with_tokens(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     'client_secret = "test-secret"\n'
     'access_token = "test-access"\n'
     'refresh_token = "test-refresh"\n'
-    f'expires_at = {int(time.time()) + 10000}\n'
+    f'expires_at = {int(time.time()) + 200000}\n'  # well above 24h threshold
   )
   monkeypatch.setattr(
     _cfg,
@@ -45,7 +45,7 @@ def config_with_tokens(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         'client_secret': 'test-secret',
         'access_token': 'test-access',
         'refresh_token': 'test-refresh',
-        'expires_at': int(time.time()) + 10000,
+        'expires_at': int(time.time()) + 200000,
       }
     },
   )
@@ -74,8 +74,114 @@ def test_preflight_starts_auth_when_no_tokens(config_without_tokens: Path) -> No
 
 def test_preflight_skips_auth_when_tokens_present(config_with_tokens: Path) -> None:
   with patch.object(trakt, '_ensure_authenticated') as mock_auth:
-    trakt.preflight()
+    with patch.object(trakt, '_refresh_token'):  # tokens far-future; refresh not expected
+      trakt.preflight()
   mock_auth.assert_not_called()
+
+
+def test_preflight_refreshes_near_expiry_token_at_startup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+  """preflight() calls _refresh_token when token is within 24 hours of expiry."""
+  cfg_file = tmp_path / 'config.toml'
+  cfg_file.write_text(
+    '[trakt]\n'
+    'client_id = "test-id"\n'
+    'client_secret = "test-secret"\n'
+    'access_token = "old-access"\n'
+    'refresh_token = "test-refresh"\n'
+    f'expires_at = {int(time.time()) + 3600}\n'  # 1 hour — inside 24h window
+  )
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {
+      'trakt': {
+        'client_id': 'test-id',
+        'client_secret': 'test-secret',
+        'access_token': 'old-access',
+        'refresh_token': 'test-refresh',
+        'expires_at': int(time.time()) + 3600,
+      }
+    },
+  )
+  monkeypatch.chdir(tmp_path)
+
+  with patch.object(trakt, '_refresh_token') as mock_refresh:
+    trakt.preflight()
+
+  mock_refresh.assert_called_once()
+
+
+def test_preflight_no_refresh_when_token_far_from_expiry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+  """preflight() does not call _refresh_token when token expires far in the future."""
+  cfg_file = tmp_path / 'config.toml'
+  cfg_file.write_text(
+    '[trakt]\n'
+    'client_id = "test-id"\n'
+    'client_secret = "test-secret"\n'
+    'access_token = "old-access"\n'
+    'refresh_token = "test-refresh"\n'
+    f'expires_at = {int(time.time()) + 200000}\n'  # well outside 24h
+  )
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {
+      'trakt': {
+        'client_id': 'test-id',
+        'client_secret': 'test-secret',
+        'access_token': 'old-access',
+        'refresh_token': 'test-refresh',
+        'expires_at': int(time.time()) + 200000,
+      }
+    },
+  )
+  monkeypatch.chdir(tmp_path)
+
+  with patch.object(trakt, '_refresh_token') as mock_refresh:
+    trakt.preflight()
+
+  mock_refresh.assert_not_called()
+
+
+def test_preflight_refresh_failure_clears_tokens_and_triggers_reauth(
+  tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  """preflight() clears tokens and starts re-auth if startup refresh fails."""
+  cfg_file = tmp_path / 'config.toml'
+  cfg_file.write_text(
+    '[trakt]\n'
+    'client_id = "test-id"\n'
+    'client_secret = "test-secret"\n'
+    'access_token = "old-access"\n'
+    'refresh_token = "test-refresh"\n'
+    f'expires_at = {int(time.time()) + 3600}\n'
+  )
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {
+      'trakt': {
+        'client_id': 'test-id',
+        'client_secret': 'test-secret',
+        'access_token': 'old-access',
+        'refresh_token': 'test-refresh',
+        'expires_at': int(time.time()) + 3600,
+      }
+    },
+  )
+  monkeypatch.chdir(tmp_path)
+
+  mock_resp = MagicMock()
+  mock_resp.status_code = 400
+  mock_resp.reason = 'Bad Request'
+
+  with patch.object(trakt, '_refresh_token', side_effect=requests.HTTPError(response=mock_resp)):
+    with patch.object(trakt, '_ensure_authenticated') as mock_auth:
+      trakt.preflight()
+
+  mock_auth.assert_called_once()
+  assert _cfg._config['trakt']['access_token'] == ''
+  assert _cfg._config['trakt']['refresh_token'] == ''
 
 
 def test_get_token_returns_access_token(config_with_tokens: Path) -> None:
@@ -103,7 +209,7 @@ def test_token_refresh_called_when_near_expiry(tmp_path: Path, monkeypatch: pyte
     'client_secret = "test-secret"\n'
     'access_token = "old-access"\n'
     'refresh_token = "test-refresh"\n'
-    f'expires_at = {int(time.time()) + 100}\n'  # within 1-hour threshold
+    f'expires_at = {int(time.time()) + 100}\n'  # within 24-hour threshold
   )
   monkeypatch.setattr(
     _cfg,
@@ -128,6 +234,126 @@ def test_token_refresh_called_when_near_expiry(tmp_path: Path, monkeypatch: pyte
 
   mock_refresh.assert_called_once()
   assert token == 'new-access'
+
+
+def test_get_token_refresh_called_within_24h_window(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+  """Token with 20 hours remaining (outside old 1h window) should still trigger refresh."""
+  cfg_file = tmp_path / 'config.toml'
+  expires = int(time.time()) + 72000  # 20 hours — inside 24h, outside old 1h
+  cfg_file.write_text(
+    '[trakt]\n'
+    'client_id = "test-id"\n'
+    'client_secret = "test-secret"\n'
+    'access_token = "old-access"\n'
+    'refresh_token = "test-refresh"\n'
+    f'expires_at = {expires}\n'
+  )
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {
+      'trakt': {
+        'client_id': 'test-id',
+        'client_secret': 'test-secret',
+        'access_token': 'old-access',
+        'refresh_token': 'test-refresh',
+        'expires_at': expires,
+      }
+    },
+  )
+  monkeypatch.chdir(tmp_path)
+
+  with patch.object(trakt, '_refresh_token') as mock_refresh:
+    trakt._get_token()
+
+  mock_refresh.assert_called_once()
+
+
+def test_get_token_refresh_failure_clears_tokens_and_triggers_reauth(
+  tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  """HTTPError from _refresh_token clears tokens and starts re-auth."""
+  cfg_file = tmp_path / 'config.toml'
+  cfg_file.write_text(
+    '[trakt]\n'
+    'client_id = "test-id"\n'
+    'client_secret = "test-secret"\n'
+    'access_token = "old-access"\n'
+    'refresh_token = "test-refresh"\n'
+    f'expires_at = {int(time.time()) + 100}\n'
+  )
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {
+      'trakt': {
+        'client_id': 'test-id',
+        'client_secret': 'test-secret',
+        'access_token': 'old-access',
+        'refresh_token': 'test-refresh',
+        'expires_at': int(time.time()) + 100,
+      }
+    },
+  )
+  monkeypatch.chdir(tmp_path)
+
+  mock_resp = MagicMock()
+  mock_resp.status_code = 400
+  mock_resp.reason = 'Bad Request'
+
+  with patch.object(trakt, '_refresh_token', side_effect=requests.HTTPError(response=mock_resp)):
+    with patch.object(trakt, '_ensure_authenticated') as mock_auth:
+      with pytest.raises(IntegrationDataUnavailableError, match='re-authentication required'):
+        trakt._get_token()
+
+  mock_auth.assert_called_once()
+  assert _cfg._config['trakt']['access_token'] == ''
+  assert _cfg._config['trakt']['refresh_token'] == ''
+
+
+def test_get_token_refresh_failure_raises_unavailable_not_http_error(
+  tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  """Worker sees IntegrationDataUnavailableError (graceful skip), not raw HTTPError."""
+  cfg_file = tmp_path / 'config.toml'
+  cfg_file.write_text(
+    '[trakt]\n'
+    'client_id = "test-id"\n'
+    'client_secret = "test-secret"\n'
+    'access_token = "old-access"\n'
+    'refresh_token = "test-refresh"\n'
+    f'expires_at = {int(time.time()) + 100}\n'
+  )
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {
+      'trakt': {
+        'client_id': 'test-id',
+        'client_secret': 'test-secret',
+        'access_token': 'old-access',
+        'refresh_token': 'test-refresh',
+        'expires_at': int(time.time()) + 100,
+      }
+    },
+  )
+  monkeypatch.chdir(tmp_path)
+
+  mock_resp = MagicMock()
+  mock_resp.status_code = 400
+  mock_resp.reason = 'Bad Request'
+
+  with patch.object(trakt, '_refresh_token', side_effect=requests.HTTPError(response=mock_resp)):
+    with patch.object(trakt, '_ensure_authenticated'):
+      with pytest.raises(IntegrationDataUnavailableError):
+        trakt._get_token()
+      # confirm no HTTPError leaks out
+      try:
+        trakt._get_token()  # tokens now cleared → raises auth pending
+      except IntegrationDataUnavailableError:
+        pass
+      except requests.HTTPError:
+        pytest.fail('HTTPError leaked out of _get_token — worker would log ERROR instead of WARNING')
 
 
 # --- _write_tokens / _store_tokens ---

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.25.9"
+version = "0.25.10"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Closes #321.

## Summary

- **Widen refresh window to 24 hours** — was 1 hour, which meant a brief scheduler restart near expiry could silently miss the window and let both tokens expire simultaneously
- **Startup refresh in `preflight()`** — proactively refreshes near-expiry tokens when the scheduler starts, before any poll fires
- **Handle refresh failures gracefully** — `HTTPError` from `_refresh_token` now clears stored tokens, triggers the device-code re-auth flow, and raises `IntegrationDataUnavailableError` so the worker logs `WARNING` and skips the message instead of `ERROR` and crashing; previously the exception escaped uncaught and retried the doomed refresh on every subsequent poll indefinitely
- **`_clear_tokens()` helper** — DRYs up the clear-and-reauth pattern used in both `_get_token()` and `preflight()`
- 5 new tests covering the 24h window, failure recovery, and the no-refresh-when-fresh path

## Test plan

- [x] `uv run pytest` — 549 passed, 10 deselected
- [x] `uv run ruff check .` / `ruff format --check .`
- [x] `uv run pyright`
- [x] `uv run bandit -c pyproject.toml -r .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
