### PR TITLE
fix(trakt): auto-recover from invalid token via 401-triggered refresh and re-auth

### DIFF
--- a/integrations/trakt.py
+++ b/integrations/trakt.py
@@ -166,6 +166,31 @@ def _request_headers(access_token: str, client_id: str) -> dict[str, str]:
   }
 
 
+def _handle_api_401() -> str:
+  """Called when a Trakt API request returns 401.
+
+  Attempts a token refresh. If the refresh succeeds, returns the new access
+  token so the caller can retry the request. If the refresh fails (e.g. token
+  revoked), clears stored tokens, starts re-auth, and raises
+  IntegrationDataUnavailableError so the worker skips this cycle gracefully.
+  """
+  import config as _config_mod
+
+  logger.warning('Trakt: received 401 — attempting token refresh')
+  try:
+    _refresh_token()
+  except requests.HTTPError as e:
+    logger.warning('Trakt: token refresh after 401 failed (%s) — clearing tokens and re-starting auth flow', e)
+    _clear_tokens()
+    _ensure_authenticated()
+    raise IntegrationDataUnavailableError('Trakt auth pending — token invalid, re-authentication required') from None
+  new_token = _config_mod.get_optional('trakt', 'access_token')
+  if not new_token:
+    raise IntegrationDataUnavailableError('Trakt auth pending — token unavailable after refresh')
+  logger.debug('Trakt: token refreshed after 401 — retrying request')
+  return new_token
+
+
 # --- OAuth device code flow ---
 
 
@@ -310,13 +335,12 @@ def get_variables_calendar() -> dict[str, list[list[str]]]:
   global _calendar_cache
 
   today = datetime.now().strftime('%Y-%m-%d')
+  url = f'{_TRAKT_API_BASE}/calendars/my/shows/{today}/{days}'
   try:
-    r = fetch_with_retry(
-      'GET',
-      f'{_TRAKT_API_BASE}/calendars/my/shows/{today}/{days}',
-      headers=_request_headers(token, client_id),
-      timeout=10,
-    )
+    r = fetch_with_retry('GET', url, headers=_request_headers(token, client_id), timeout=10)
+    if r.status_code == 401:
+      token = _handle_api_401()
+      r = fetch_with_retry('GET', url, headers=_request_headers(token, client_id), timeout=10)
     r.raise_for_status()
   except requests.RequestException as e:
     if isinstance(e, requests.HTTPError):
@@ -399,13 +423,12 @@ def get_variables_watching() -> dict[str, list[list[str]]]:
   token = _get_token()
   client_id = _config_mod.get('trakt', 'client_id')
 
+  url = f'{_TRAKT_API_BASE}/users/me/watching'
   try:
-    r = fetch_with_retry(
-      'GET',
-      f'{_TRAKT_API_BASE}/users/me/watching',
-      headers=_request_headers(token, client_id),
-      timeout=10,
-    )
+    r = fetch_with_retry('GET', url, headers=_request_headers(token, client_id), timeout=10)
+    if r.status_code == 401:
+      token = _handle_api_401()
+      r = fetch_with_retry('GET', url, headers=_request_headers(token, client_id), timeout=10)
   except requests.RequestException as e:
     raise IntegrationDataUnavailableError(f'Trakt: watching request failed — {e}') from None
 
@@ -485,13 +508,12 @@ def get_variables_next_up() -> dict[str, list[list[str]]]:
   token = _get_token()
   client_id = _config_mod.get('trakt', 'client_id')
 
+  watched_url = f'{_TRAKT_API_BASE}/users/me/watched/shows'
   try:
-    r = fetch_with_retry(
-      'GET',
-      f'{_TRAKT_API_BASE}/users/me/watched/shows',
-      headers=_request_headers(token, client_id),
-      timeout=10,
-    )
+    r = fetch_with_retry('GET', watched_url, headers=_request_headers(token, client_id), timeout=10)
+    if r.status_code == 401:
+      token = _handle_api_401()
+      r = fetch_with_retry('GET', watched_url, headers=_request_headers(token, client_id), timeout=10)
     r.raise_for_status()
   except requests.RequestException as e:
     if isinstance(e, requests.HTTPError):
@@ -509,13 +531,12 @@ def get_variables_next_up() -> dict[str, list[list[str]]]:
 
   for entry in shows:
     trakt_id = entry['show']['ids']['trakt']
+    progress_url = f'{_TRAKT_API_BASE}/shows/{trakt_id}/progress/watched'
     try:
-      r2 = fetch_with_retry(
-        'GET',
-        f'{_TRAKT_API_BASE}/shows/{trakt_id}/progress/watched',
-        headers=_request_headers(token, client_id),
-        timeout=10,
-      )
+      r2 = fetch_with_retry('GET', progress_url, headers=_request_headers(token, client_id), timeout=10)
+      if r2.status_code == 401:
+        token = _handle_api_401()
+        r2 = fetch_with_retry('GET', progress_url, headers=_request_headers(token, client_id), timeout=10)
       r2.raise_for_status()
     except requests.RequestException as e:
       if isinstance(e, requests.HTTPError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.25.10"
+version = "0.25.11"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_trakt.py
+++ b/tests/core/test_trakt.py
@@ -356,6 +356,102 @@ def test_get_token_refresh_failure_raises_unavailable_not_http_error(
         pytest.fail('HTTPError leaked out of _get_token — worker would log ERROR instead of WARNING')
 
 
+# --- _handle_api_401 ---
+
+
+def test_handle_api_401_refreshes_and_returns_new_token(
+  config_with_tokens: Path,
+) -> None:
+  """_handle_api_401 calls _refresh_token and returns the updated access token."""
+
+  def fake_refresh() -> None:
+    _cfg._config['trakt']['access_token'] = 'refreshed-token'
+
+  with patch.object(trakt, '_refresh_token', side_effect=fake_refresh):
+    token = trakt._handle_api_401()
+
+  assert token == 'refreshed-token'
+
+
+def test_handle_api_401_refresh_failure_clears_tokens_and_triggers_reauth(
+  config_with_tokens: Path,
+) -> None:
+  """_handle_api_401 clears tokens and starts re-auth when refresh fails."""
+  mock_resp = MagicMock()
+  mock_resp.status_code = 400
+  mock_resp.reason = 'Bad Request'
+
+  with patch.object(trakt, '_refresh_token', side_effect=requests.HTTPError(response=mock_resp)):
+    with patch.object(trakt, '_ensure_authenticated') as mock_auth:
+      with pytest.raises(IntegrationDataUnavailableError, match='re-authentication required'):
+        trakt._handle_api_401()
+
+  mock_auth.assert_called_once()
+  assert _cfg._config['trakt']['access_token'] == ''
+
+
+def test_get_variables_calendar_401_retries_with_refreshed_token(config_with_tokens: Path) -> None:
+  """A 401 from the calendar endpoint triggers a token refresh and retries."""
+  unauth = MagicMock()
+  unauth.status_code = 401
+
+  ok = MagicMock()
+  ok.status_code = 200
+  ok.raise_for_status.return_value = None
+  ok.json.return_value = _CALENDAR_RESPONSE
+
+  def fake_refresh() -> None:
+    _cfg._config['trakt']['access_token'] = 'new-token'
+
+  with patch.object(trakt, '_refresh_token', side_effect=fake_refresh):
+    with patch('integrations.trakt.fetch_with_retry', side_effect=[unauth, ok]):
+      result = trakt.get_variables_calendar()
+
+  assert result['show_name'] == [['GREAT SHOW']]
+
+
+def test_get_variables_watching_401_retries_with_refreshed_token(config_with_tokens: Path) -> None:
+  """A 401 from the watching endpoint triggers a token refresh and retries."""
+  unauth = MagicMock()
+  unauth.status_code = 401
+
+  ok = MagicMock()
+  ok.status_code = 200
+  ok.raise_for_status.return_value = None
+  ok.json.return_value = {
+    'type': 'episode',
+    'show': {'title': 'My Show'},
+    'episode': {'season': 1, 'number': 1, 'title': 'Pilot'},
+  }
+
+  def fake_refresh() -> None:
+    _cfg._config['trakt']['access_token'] = 'new-token'
+
+  with patch.object(trakt, '_refresh_token', side_effect=fake_refresh):
+    with patch('integrations.trakt.fetch_with_retry', side_effect=[unauth, ok]):
+      result = trakt.get_variables_watching()
+
+  assert result['show_name'] == [['MY SHOW']]
+
+
+def test_get_variables_next_up_401_retries_with_refreshed_token(config_with_tokens: Path) -> None:
+  """A 401 from the watched/shows endpoint triggers a token refresh and retries."""
+  unauth = MagicMock()
+  unauth.status_code = 401
+
+  watched = _mock_watched_ok([_WATCHED_SHOWS_RESPONSE[0]])
+  progress = _mock_progress_ok(_PROGRESS_WITH_NEXT)
+
+  def fake_refresh() -> None:
+    _cfg._config['trakt']['access_token'] = 'new-token'
+
+  with patch.object(trakt, '_refresh_token', side_effect=fake_refresh):
+    with patch('integrations.trakt.fetch_with_retry', side_effect=[unauth, watched, progress]):
+      result = trakt.get_variables_next_up()
+
+  assert result['show_name'] == [['BREAKING BAD']]
+
+
 # --- _write_tokens / _store_tokens ---
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.25.10"
+version = "0.25.11"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Closes #327. Depends on #326.

## Summary

- Adds `_handle_api_401()` helper: on a 401 response, attempts a token refresh; on success returns the new token for a single retry; on `HTTPError` clears tokens, starts device-code re-auth, and raises `IntegrationDataUnavailableError`
- Wires 401 handling into `get_variables_calendar()`, `get_variables_watching()`, and `get_variables_next_up()` — each checks for 401 before `raise_for_status()` and retries once with the refreshed token
- 5 new tests: helper success/failure paths, and retry behaviour in all three API functions

## Test plan

- [x] `uv run pytest` — 554 passed, 10 deselected
- [x] `uv run ruff check .` / `ruff format --check .`
- [x] `uv run pyright`
- [x] `uv run bandit -c pyproject.toml -r .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
