### PR TITLE
chore(logging): indent continuation lines in multi-line log messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.25.11"
+version = "0.25.12"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -52,6 +52,17 @@ if __name__ == '__main__':
 
 logger = logging.getLogger('scheduler')
 
+
+class _IndentedFormatter(logging.Formatter):
+  # Prefix width for 'HH:MM:SS LEVELNAM ' (asctime=8, space=1, levelname-8=8, space=1)
+  _PREFIX_WIDTH = 18
+
+  def format(self, record: logging.LogRecord) -> str:
+    msg = super().format(record)
+    indent = ' ' * self._PREFIX_WIDTH
+    return msg.replace('\n', '\n' + indent)
+
+
 # Allowlist of valid integration names. Must be extended when a new integration
 # is added to integrations/.
 _KNOWN_INTEGRATIONS: frozenset[str] = frozenset({'bart', 'calendar', 'discogs', 'moon', 'plex', 'trakt', 'weather'})
@@ -950,11 +961,14 @@ def _validate_startup() -> None:
 
 
 def main() -> None:
-  logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s %(levelname)-8s %(message)s',
-    datefmt='%H:%M:%S',
+  _handler = logging.StreamHandler()
+  _handler.setFormatter(
+    _IndentedFormatter(
+      fmt='%(asctime)s %(levelname)-8s %(message)s',
+      datefmt='%H:%M:%S',
+    )
   )
+  logging.basicConfig(level=logging.INFO, handlers=[_handler])
   _validate_startup()
   _config_mod.load_config()
 

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.25.11"
+version = "0.25.12"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

Adds `_IndentedFormatter`, a `logging.Formatter` subclass that pads continuation lines with 18 spaces (matching the `HH:MM:SS LEVELNAM ` prefix width), so multi-line board previews align cleanly in the log output.

Before:
```
01:40:36 INFO     ┌─────────────────┐
│ SANTA CLARA     │
│ ▉ OVERCAST      │
│ 55F H:63 L:50   │
└─────────────────┘
```

After:
```
01:40:36 INFO     ┌─────────────────┐
                  │ SANTA CLARA     │
                  │ ▉ OVERCAST      │
                  │ 55F H:63 L:50   │
                  └─────────────────┘
```

`render_grid()` output is unchanged — the indentation is applied only at the formatter level.

Closes #323
