### PR TITLE
feat(vestaboard): retry on 429 with exponential backoff

### DIFF
--- a/integrations/vestaboard.py
+++ b/integrations/vestaboard.py
@@ -15,6 +15,7 @@ import json
 import logging
 import random
 import re
+import time
 import unicodedata
 from enum import Enum
 from typing import Literal
@@ -472,6 +473,9 @@ def _build_grid(lines: list[str]) -> list[list[int]]:
 
 # --- Writing ---
 
+_RATE_LIMIT_RETRIES = 3  # retries after the initial attempt (4 total)
+_RATE_LIMIT_BACKOFF = 5.0  # base delay in seconds; doubles each attempt
+
 
 class BoardLockedError(Exception):
   """Raised when the Vestaboard returns 423 (rate-limited or quiet hours)."""
@@ -503,12 +507,29 @@ def set_state(
   lines = _wrap_lines(lines, truncation)
   grid = _build_grid(lines)
   logger.debug(render_grid(grid))
-  r = requests.post(_HOST, json=grid, headers=_get_headers(), timeout=10)
-  if r.status_code == 409:
-    raise DuplicateContentError('board already shows this content')
-  if r.status_code == 423:
-    raise BoardLockedError('board is locked (rate-limited or quiet hours)')
-  try:
-    r.raise_for_status()
-  except requests.HTTPError as e:
-    raise requests.HTTPError(f'Vestaboard API error: {e.response.status_code} {e.response.reason}') from None
+  for attempt in range(1 + _RATE_LIMIT_RETRIES):
+    r = requests.post(_HOST, json=grid, headers=_get_headers(), timeout=10)
+    if r.status_code == 409:
+      raise DuplicateContentError('board already shows this content')
+    if r.status_code == 423:
+      raise BoardLockedError('board is locked (rate-limited or quiet hours)')
+    if r.status_code == 429:
+      if attempt < _RATE_LIMIT_RETRIES:
+        delay = _RATE_LIMIT_BACKOFF * 2**attempt
+        logger.warning(
+          'Rate limited (429); retrying in %.0fs (attempt %d/%d)',
+          delay,
+          attempt + 1,
+          _RATE_LIMIT_RETRIES,
+        )
+        time.sleep(delay)
+        continue
+      raise requests.HTTPError(
+        f'Vestaboard API error: 429 Too Many Requests (exhausted {_RATE_LIMIT_RETRIES} retries)',
+        response=r,
+      )
+    try:
+      r.raise_for_status()
+    except requests.HTTPError as e:
+      raise requests.HTTPError(f'Vestaboard API error: {e.response.status_code} {e.response.reason}') from None
+    return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.25.12"
+version = "0.25.13"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_vestaboard.py
+++ b/tests/core/test_vestaboard.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -514,6 +515,57 @@ def test_set_state_passes_auth_header(monkeypatch: pytest.MonkeyPatch) -> None:
     vb.set_state([{'format': ['HELLO']}], {})
   _, kwargs = mock_post.call_args
   assert kwargs['headers']['X-Vestaboard-Read-Write-Key'] == 'sentinel-key'
+
+
+def test_set_state_retries_on_429_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
+  rate_limited = MagicMock()
+  rate_limited.status_code = 429
+  ok = MagicMock()
+  ok.status_code = 200
+  ok.raise_for_status.return_value = None
+  with (
+    patch('integrations.vestaboard.requests.post', side_effect=[rate_limited, ok]) as mock_post,
+    patch('integrations.vestaboard.time.sleep') as mock_sleep,
+  ):
+    vb.set_state([{'format': ['HELLO']}], {})
+  assert mock_post.call_count == 2
+  mock_sleep.assert_called_once_with(vb._RATE_LIMIT_BACKOFF)  # noqa: SLF001
+
+
+def test_set_state_raises_after_exhausted_429_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
+  rate_limited = MagicMock()
+  rate_limited.status_code = 429
+  with (
+    patch('integrations.vestaboard.requests.post', return_value=rate_limited) as mock_post,
+    patch('integrations.vestaboard.time.sleep'),
+  ):
+    with pytest.raises(requests.HTTPError, match='429 Too Many Requests'):
+      vb.set_state([{'format': ['HELLO']}], {})
+  assert mock_post.call_count == vb._RATE_LIMIT_RETRIES + 1  # noqa: SLF001
+
+
+def test_set_state_logs_warning_on_429_retry(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
+  rate_limited = MagicMock()
+  rate_limited.status_code = 429
+  ok = MagicMock()
+  ok.status_code = 200
+  ok.raise_for_status.return_value = None
+  with (
+    patch('integrations.vestaboard.requests.post', side_effect=[rate_limited, ok]),
+    patch('integrations.vestaboard.time.sleep'),
+    caplog.at_level(logging.WARNING, logger='integrations.vestaboard'),
+  ):
+    vb.set_state([{'format': ['HELLO']}], {})
+  assert any('Rate limited' in r.message for r in caplog.records)
 
 
 # --- _expand_format (random selection) ---

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.25.12"
+version = "0.25.13"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- Adds exponential backoff retry logic to `set_state()` in `integrations/vestaboard.py` for HTTP 429 responses
- 3 retries after the initial attempt (4 total), with delays of 5s, 10s, 20s
- Logs a warning on each retry; raises `HTTPError` after retries are exhausted (worker then logs and skips the message)
- Transparent to the worker — no scheduler changes needed
- Bumps to v0.25.13

Closes #322

## Test plan

- [x] `test_set_state_retries_on_429_then_succeeds` — 429 then 200: verifies 2 POST calls, no exception
- [x] `test_set_state_raises_after_exhausted_429_retries` — all 429s: verifies HTTPError raised after `_RATE_LIMIT_RETRIES + 1` calls
- [x] `test_set_state_logs_warning_on_429_retry` — verifies "Rate limited" warning logged on retry
- [x] Full suite: 557 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
