### PR TITLE
chore(content): refine good morning quips

### DIFF
--- a/content/contrib/morning_night.json
+++ b/content/contrib/morning_night.json
@@ -11,49 +11,63 @@
         {
           "format": [
             "[Y] GOOD MORNING",
-            "HAVE A GREAT DAY"
-          ]
-        },
-        {
-          "format": [
-            "[Y] GOOD MORNING",
-            "YOU GOT THIS"
-          ]
-        },
-        {
-          "format": [
-            "[Y] GOOD MORNING",
-            "MAKE IT COUNT"
-          ]
-        },
-        {
-          "format": [
-            "[Y] GOOD MORNING",
             "RISE AND SHINE"
           ]
         },
         {
           "format": [
             "[Y] GOOD MORNING",
-            "HAPPY TO SEE YOU"
+            "LET'S DO THIS"
           ]
         },
         {
           "format": [
             "[Y] GOOD MORNING",
-            "LETS DO THIS"
+            "HAPPY TO",
+            "SEE YOU"
           ]
         },
         {
           "format": [
             "[Y] GOOD MORNING",
-            "A BRAND NEW DAY"
+            "LOOK ALIVE"
           ]
         },
         {
           "format": [
             "[Y] GOOD MORNING",
-            "THE WORLD IS YOURS"
+            "HERE COMES",
+            "THE SUN"
+          ]
+        },
+        {
+          "format": [
+            "[Y] GOOD MORNING",
+            "EYES OPEN"
+          ]
+        },
+        {
+          "format": [
+            "[Y] GOOD MORNING",
+            "OFF WE GO"
+          ]
+        },
+        {
+          "format": [
+            "[Y] GOOD MORNING",
+            "UP AND AT 'EM"
+          ]
+        },
+        {
+          "format": [
+            "[Y] GOOD MORNING",
+            "HERE WE GO"
+          ]
+        },
+        {
+          "format": [
+            "[Y] GOOD MORNING",
+            "STEPPING IN"
           ]
         }
       ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.25.13"
+version = "0.25.14"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.25.13"
+version = "0.25.14"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

Closes #329

Collaboratively reviewed and refined the good morning quip list in `content/contrib/morning_night.json`.

**Removed** (cheesy / motivational-poster tone):
- HAVE A GREAT DAY
- YOU GOT THIS
- MAKE IT COUNT
- A BRAND NEW DAY
- THE WORLD IS YOURS

**Kept / fixed:**
- RISE AND SHINE — earned its place
- LET'S DO THIS — fix missing apostrophe
- HAPPY TO / SEE YOU — rebalanced across two rows (was wrapping 12/3)

**Added:**
- LOOK ALIVE
- HERE COMES / THE SUN — Beatles reference, morning-perfect
- EYES OPEN
- OFF WE GO
- UP AND AT 'EM
- HERE WE GO
- STEPPING IN — Above & Beyond reference
