### PR TITLE
fix(color): detect achromatic art; substitute [K] with [W] on black board

### DIFF
--- a/integrations/color.py
+++ b/integrations/color.py
@@ -11,8 +11,12 @@
 #   2. Filter out near-white (all channels > 230) and near-black (all channels
 #      < 25) pixels — these are background/border artifacts that skew the result.
 #   3. Compute the arithmetic mean of the remaining pixels in RGB space.
-#   4. Find the nearest Vestaboard palette entry by Euclidean distance in RGB.
-#   5. Return the corresponding color tag string (e.g. '[R]').
+#   4. Check HSV saturation of the average color. If below _SATURATION_THRESHOLD
+#      the image is achromatic (grey/B&W); map directly to [W] or [K] by
+#      luminance rather than running palette matching (which would otherwise
+#      spuriously return [V] for mid-grey).
+#   5. For chromatic colors, find the nearest palette entry by Euclidean
+#      distance in RGB space and return its tag.
 #
 # If the image cannot be decoded, the request fails, or all pixels are filtered,
 # the caller-supplied fallback tag is returned instead.
@@ -47,6 +51,9 @@ _MAX_IMAGE_BYTES = 2 * 1024 * 1024  # 2 MB
 # Pixel brightness thresholds for background filtering.
 _NEAR_WHITE = 230  # all channels above this → skip
 _NEAR_BLACK = 25  # all channels below this → skip
+
+# HSV saturation below this threshold → treat as achromatic (grey/B&W).
+_SATURATION_THRESHOLD = 0.15
 
 # Known Discogs placeholder image indicators.
 _PLACEHOLDER_SUFFIXES = ('spacer.gif', 'placeholder.gif')
@@ -89,12 +96,22 @@ def dominant_color_tag(image_bytes: bytes, *, fallback: str = '[Y]') -> str:
   avg_g = sum(g for _, g, _ in filtered) // n
   avg_b = sum(b for _, _, b in filtered) // n
 
-  tag = min(
-    _PALETTE,
-    key=lambda entry: (entry[0] - avg_r) ** 2 + (entry[1] - avg_g) ** 2 + (entry[2] - avg_b) ** 2,
-  )[3]
+  # Compute HSV saturation to detect achromatic (grey/B&W) images.
+  max_c = max(avg_r, avg_g, avg_b)
+  min_c = min(avg_r, avg_g, avg_b)
+  saturation = (max_c - min_c) / max_c if max_c > 0 else 0.0
 
-  logger.debug('color: avg RGB (%d, %d, %d) → %s', avg_r, avg_g, avg_b, tag)
+  if saturation < _SATURATION_THRESHOLD:
+    # Achromatic: choose [W] or [K] by perceived luminance (ITU-R BT.601).
+    luminance = (avg_r * 299 + avg_g * 587 + avg_b * 114) // 1000
+    tag = '[W]' if luminance >= 128 else '[K]'
+  else:
+    tag = min(
+      _PALETTE,
+      key=lambda entry: (entry[0] - avg_r) ** 2 + (entry[1] - avg_g) ** 2 + (entry[2] - avg_b) ** 2,
+    )[3]
+
+  logger.debug('color: avg RGB (%d, %d, %d) sat=%.2f → %s', avg_r, avg_g, avg_b, saturation, tag)
   return tag
 
 
@@ -144,4 +161,14 @@ def fetch_cover_color(url: str, *, fallback: str = '[Y]') -> str:
     logger.debug('color: image fetch failed — %s', e)
     return fallback
 
-  return dominant_color_tag(image_bytes, fallback=fallback)
+  tag = dominant_color_tag(image_bytes, fallback=fallback)
+
+  # [K] (black) is invisible on a black board (the default). Substitute [W]
+  # so the color square is always visible. When board_color config is added
+  # (#287), read it here and skip this substitution for white boards (where
+  # [W] should instead be swapped to [K]).
+  if tag == '[K]':
+    logger.debug('color: substituting [K] → [W] for black board visibility')
+    tag = '[W]'
+
+  return tag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.26.0"
+version = "0.26.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_color.py
+++ b/tests/core/test_color.py
@@ -61,6 +61,27 @@ def test_dominant_color_tag_returns_string() -> None:
   assert tag.startswith('[') and tag.endswith(']')
 
 
+def test_dominant_color_tag_grey_maps_to_white() -> None:
+  # Mid-grey is achromatic with luminance >= 128 → [W], not [V].
+  tag = color_mod.dominant_color_tag(_png_bytes(128, 128, 128))
+  assert tag == '[W]'
+
+
+def test_dominant_color_tag_dark_grey_maps_to_black() -> None:
+  # Dark grey (passes near-black filter at 25) is achromatic with low luminance → [K].
+  tag = color_mod.dominant_color_tag(_png_bytes(60, 60, 60))
+  assert tag == '[K]'
+
+
+def test_dominant_color_tag_bw_image_maps_to_white_or_black() -> None:
+  # A B&W image (black silhouette on white bg): black pixels filtered,
+  # white pixels filtered, grey midtones (if any) map achromatic.
+  # Use a known mid-grey to confirm achromatic path, not [V].
+  tag = color_mod.dominant_color_tag(_png_bytes(150, 150, 150))
+  assert tag in ('[W]', '[K]')
+  assert tag != '[V]'
+
+
 # --- fetch_cover_color ---
 
 
@@ -132,3 +153,11 @@ def test_fetch_cover_color_custom_fallback() -> None:
   with patch('integrations.color.fetch_with_retry', side_effect=requests.Timeout()):
     tag = color_mod.fetch_cover_color('https://example.com/cover.jpg', fallback='[G]')
   assert tag == '[G]'
+
+
+def test_fetch_cover_color_substitutes_black_with_white() -> None:
+  # [K] returned by dominant_color_tag must be swapped to [W] for black board visibility.
+  png = _png_bytes(60, 60, 60)  # dark grey → dominant_color_tag returns [K]
+  with patch('integrations.color.fetch_with_retry', return_value=_mock_response(png)):
+    tag = color_mod.fetch_cover_color('https://example.com/cover.jpg')
+  assert tag == '[W]'

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.26.0"
+version = "0.26.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- Adds saturation check (HSV) to `dominant_color_tag`: if saturation < 0.15, the image is treated as achromatic and mapped to `[W]`/`[K]` by perceived luminance (ITU-R BT.601) instead of running Euclidean palette matching — which was incorrectly returning `[V]` for mid-grey
- `fetch_cover_color` now substitutes `[K]` → `[W]` so dark-dominant covers produce a visible tile on black boards (the default); the substitution site is commented with a `#287` marker for when white board support inverts the logic
- 4 new tests; 581 total passing

Closes #334

🤖 — *Claude Code*
