### PR TITLE
fix(discogs): prefer anv over canonical name for artist display

### DIFF
--- a/integrations/discogs.py
+++ b/integrations/discogs.py
@@ -104,7 +104,10 @@ def _format_artist(release: dict[str, Any]) -> str:
   artists = release.get('basic_information', {}).get('artists', [])
   if not artists:
     return 'UNKNOWN ARTIST'
-  name = artists[0].get('name', '').strip()
+  artist = artists[0]
+  # Prefer anv (name as credited on this release) over the canonical Discogs
+  # name — e.g. 'Nayeon' (anv) vs 'Na Yeon' (canonical name).
+  name = (artist.get('anv') or artist.get('name', '')).strip()
   # Strip Discogs disambiguator suffixes e.g. 'David Bowie (2)' → 'David Bowie'
   if ' (' in name:
     name = name[: name.rfind(' (')]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.26.3"
+version = "0.26.4"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_discogs.py
+++ b/tests/core/test_discogs.py
@@ -120,6 +120,45 @@ def test_identity_failure_raises_unavailable(discogs_config: None) -> None:
       discogs.get_variables()
 
 
+# --- artist anv ---
+
+
+def test_artist_uses_anv_when_present(discogs_config: None) -> None:
+  """anv (release-credited name) is preferred over canonical Discogs name."""
+  release: dict[str, Any] = {
+    'basic_information': {
+      'title': 'Im Nayeon',
+      'artists': [{'name': 'Na Yeon', 'anv': 'Nayeon'}],
+      'cover_image': '',
+    }
+  }
+  with patch('integrations.discogs.random.randint', return_value=0):
+    with patch(
+      'integrations.discogs.fetch_with_retry',
+      side_effect=[_mock_identity(), _mock_page([release], total=1)],
+    ):
+      result = discogs.get_variables()
+  assert result['artist'][0][0] == 'NAYEON'
+
+
+def test_artist_falls_back_to_name_when_anv_empty(discogs_config: None) -> None:
+  """Empty anv falls back to canonical name."""
+  release: dict[str, Any] = {
+    'basic_information': {
+      'title': 'Some Album',
+      'artists': [{'name': 'Some Artist', 'anv': ''}],
+      'cover_image': '',
+    }
+  }
+  with patch('integrations.discogs.random.randint', return_value=0):
+    with patch(
+      'integrations.discogs.fetch_with_retry',
+      side_effect=[_mock_identity(), _mock_page([release], total=1)],
+    ):
+      result = discogs.get_variables()
+  assert result['artist'][0][0] == 'SOME ARTIST'
+
+
 # --- artist formatting ---
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.26.3"
+version = "0.26.4"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

Discogs stores a canonical artist name (e.g. "Na Yeon") separately from the name as credited on a specific release via the `anv` field (e.g. "Nayeon"). `_format_artist` now uses `anv` when non-empty, falling back to `name` — so the display matches what's printed on the sleeve rather than the Discogs database entry.

Discovered while testing the morning spin integration: IM NAYEON by Nayeon was displaying "NA YEON" because the canonical Discogs name for the artist is stored as "Na Yeon".

Adds 2 new tests; 588 pass.

🤖 — *Claude Code*