### PR TITLE
fix(color): filter dark shadow pixels via luminance floor

### DIFF
--- a/integrations/color.py
+++ b/integrations/color.py
@@ -61,6 +61,7 @@ _MAX_IMAGE_BYTES = 2 * 1024 * 1024  # 2 MB
 # Pixel brightness thresholds for background filtering.
 _NEAR_WHITE = 230  # all channels above this → skip
 _NEAR_BLACK = 25  # all channels below this → skip
+_DARK_LUM_FLOOR = 40  # ITU-R BT.601 luminance below this → skip (dark shadows pass per-channel but read as black)
 
 # HSV saturation below this threshold → treat as achromatic (grey/B&W).
 _SATURATION_THRESHOLD = 0.15
@@ -169,12 +170,16 @@ def dominant_color_tag(image_bytes: bytes, *, fallback: str = '[Y]') -> str:
   # RGB: 3 bytes per pixel; tobytes() always returns int values.
   pixels = [(raw[i], raw[i + 1], raw[i + 2]) for i in range(0, len(raw), 3)]
 
-  # Filter near-white and near-black pixels.
+  # Filter near-white, near-black, and dark shadow pixels.
+  # The luminance floor catches dark pixels (e.g. face shadows on a black cover)
+  # that pass the per-channel near-black check but are visually indistinguishable
+  # from black and skew hue detection with their slight warm undertones.
   filtered = [
     (r, g, b)
     for r, g, b in pixels
     if not (r > _NEAR_WHITE and g > _NEAR_WHITE and b > _NEAR_WHITE)
     and not (r < _NEAR_BLACK and g < _NEAR_BLACK and b < _NEAR_BLACK)
+    and (r * 299 + g * 587 + b * 114) // 1000 >= _DARK_LUM_FLOOR
   ]
 
   if not filtered:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.26.4"
+version = "0.26.5"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_color.py
+++ b/tests/core/test_color.py
@@ -91,6 +91,14 @@ def test_dominant_color_tag_dark_grey_maps_to_black() -> None:
   assert tag == '[K]'
 
 
+def test_dominant_color_tag_dark_warm_shadow_maps_to_achromatic() -> None:
+  # Dark shadow pixels (e.g. face on a black album cover): lum ~36, passes per-channel
+  # near-black filter but is visually black. Slight warm R>G>B bias must not map to [O].
+  # These are filtered by the luminance floor — fallback [Y] is returned.
+  tag = color_mod.dominant_color_tag(_png_bytes(40, 35, 32))
+  assert tag == '[Y]'  # all pixels filtered → fallback
+
+
 def test_dominant_color_tag_bw_image_maps_to_white_or_black() -> None:
   # A B&W image (black silhouette on white bg): black pixels filtered,
   # white pixels filtered, grey midtones (if any) map achromatic.

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.26.4"
+version = "0.26.5"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Problem

Dark pixels on predominantly-black album covers (e.g. face/figure shadows) pass the per-channel near-black filter (`all channels < 25`) but carry a slight warm R>G>B bias. After filtering true blacks, these shadow pixels become the dominant cluster and hue-match to `[O]` or `[R]` instead of the expected achromatic result.

Observed: *That's the Spirit* (Bring Me the Horizon) → `[O]`. The cover is visually solid black but 23% of pixels are dark shadow with avg RGB (40, 35, 32), saturation 0.20, hue ~22°.

## Fix

Add a luminance floor (`_DARK_LUM_FLOOR = 40`, ITU-R BT.601) to the pixel filter in `dominant_color_tag`. Pixels below this threshold are visually indistinguishable from black and should not influence color detection.

After applying the floor, the remaining pixels on the BMTH cover have avg RGB (66, 62, 58), saturation 0.12 → routes correctly to achromatic → `[K]` → `[W]`.

## Tests

- `test_dominant_color_tag_dark_warm_shadow_maps_to_achromatic`: solid (40, 35, 32) image → all pixels filtered by lum floor → fallback `[Y]`
- All 589 existing tests pass