### PR TITLE
fix(vestaboard): strip unsupported characters before word-wrap

### DIFF
--- a/integrations/vestaboard.py
+++ b/integrations/vestaboard.py
@@ -286,6 +286,30 @@ def _encode_char(ch: str) -> int:
   return _CHAR_CODES.get((normalized or ch).upper(), 0)
 
 
+def _strip_unsupported(text: str) -> str:
+  """Remove characters that have no Vestaboard display mapping.
+
+  Characters that NFKD-normalize to nothing and are not in _CHAR_CODES
+  (e.g. hiragana, katakana, CJK, other non-Latin scripts) are dropped.
+  Spaces, color tags ([R] etc.), and ❤️ are always preserved.
+  Multiple spaces produced by stripping are collapsed to one, and
+  leading/trailing whitespace is removed.
+  """
+  tokens: list[str] = []
+  i = 0
+  while i < len(text):
+    tok, consumed = _next_token(text, i)
+    i += consumed
+    if tok in (' ', '❤️') or tok in _COLOR_TAGS or len(tok) == 5:  # space, emoji, color tag, escaped tag
+      tokens.append(tok)
+    else:
+      normalized = unicodedata.normalize('NFKD', tok).encode('ascii', 'ignore').decode('ascii')
+      if (normalized or tok).upper() in _CHAR_CODES:
+        tokens.append(tok)
+      # else: drop — no mapping exists (hiragana, katakana, CJK, etc.)
+  return re.sub(r' +', ' ', ''.join(tokens)).strip()
+
+
 def _encode_line(text: str) -> list[int]:
   """Encode a text string into a row of model.cols integer character codes.
 
@@ -425,6 +449,7 @@ def _wrap_lines(
   cols = model.cols
   result: list[str] = []
   for line in lines:
+    line = _strip_unsupported(line)
     if display_len(line) <= cols:
       result.append(line)
       continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.26.5"
+version = "0.26.6"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_vestaboard.py
+++ b/tests/core/test_vestaboard.py
@@ -213,6 +213,39 @@ def test_wrap_lines_ellipsis_preserves_fixed_layout() -> None:
   assert result[2] == 'TEAM CHERRY'
 
 
+# --- _strip_unsupported ---
+
+
+def test_strip_unsupported_removes_hiragana() -> None:
+  # Japanese hiragana has no Vestaboard mapping and must be dropped.
+  result = vb._strip_unsupported('あつまれ ANIMAL CROSSING')  # noqa: SLF001
+  assert result == 'ANIMAL CROSSING'
+
+
+def test_strip_unsupported_collapses_spaces() -> None:
+  # Stripping characters that were surrounded by spaces must not leave double spaces.
+  result = vb._strip_unsupported('HELLO あ WORLD')  # noqa: SLF001
+  assert result == 'HELLO WORLD'
+
+
+def test_strip_unsupported_preserves_color_tags() -> None:
+  result = vb._strip_unsupported('[R] MORNING SPIN')  # noqa: SLF001
+  assert result == '[R] MORNING SPIN'
+
+
+def test_strip_unsupported_preserves_ascii() -> None:
+  result = vb._strip_unsupported('ANIMAL CROSSING: NEW HORIZONS')  # noqa: SLF001
+  assert result == 'ANIMAL CROSSING: NEW HORIZONS'
+
+
+def test_wrap_lines_strips_unsupported_before_wrap() -> None:
+  # Japanese prefix + English suffix: unsupported chars stripped, English visible.
+  lines = ['あつまれ どうぶつの森 = ANIMAL CROSSING']
+  result = vb._wrap_lines(lines, truncation='ellipsis')  # noqa: SLF001
+  assert result[0].startswith('= ANIMAL')
+  assert 'あ' not in result[0]
+
+
 # --- _expand_format ---
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.26.5"
+version = "0.26.6"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Problem

Characters with no Vestaboard display mapping (hiragana, katakana, CJK, etc.) were silently encoded as blank cells (code 0 = space), consuming column space during `display_len` measurement and word-wrapping. The readable content that followed was displaced off the display.

Observed: `あつまれ どうぶつの森 とたけけミュージック = ANIMAL CROSSING: NEW HORIZONS...` rendered as a screen of blank cells with the English portion never visible.

## Fix

Add `_strip_unsupported()` which processes tokens via `_next_token`, drops any character whose NFKD normalization produces nothing and which has no `_CHAR_CODES` entry, collapses resulting double-spaces, and strips leading/trailing whitespace. Spaces, color tags, and ❤️ are always preserved.

Called at the start of `_wrap_lines` so all lines are cleaned before `display_len` and truncation run.

Result: `"あつまれ どうぶつの森 = ANIMAL CROSSING..."` → `"= ANIMAL CRO..."` (correctly ellipsized to fit the display).

## Tests

- `test_strip_unsupported_removes_hiragana`
- `test_strip_unsupported_collapses_spaces`
- `test_strip_unsupported_preserves_color_tags`
- `test_strip_unsupported_preserves_ascii`
- `test_wrap_lines_strips_unsupported_before_wrap`