### PR TITLE
feat(morning): replace quips with weather-based visual grid

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ config.example.toml         # Config template committed to the repo
 integrations/vestaboard.py  # Vestaboard API client (get_state, set_state)
 integrations/http.py        # Shared HTTP helper with retry logic
 integrations/weather.py     # Current weather via Open-Meteo (no API key required)
+integrations/morning.py     # Morning weather visual grid (optional; falls back to sunrise)
 integrations/calendar.py    # Today's calendar events (ICS feeds + iCloud CalDAV)
 integrations/bart.py        # BART real-time departures integration
 integrations/discogs.py     # Daily vinyl suggestion from Discogs collection

--- a/content/contrib/morning_night.json
+++ b/content/contrib/morning_night.json
@@ -7,67 +7,13 @@
         "timeout": 3600
       },
       "priority": 3,
+      "integration": "morning",
       "templates": [
         {
           "format": [
-            "[Y] GOOD MORNING",
-            "RISE AND SHINE"
-          ]
-        },
-        {
-          "format": [
-            "[Y] GOOD MORNING",
-            "LET'S DO THIS"
-          ]
-        },
-        {
-          "format": [
-            "[Y] GOOD MORNING",
-            "HAPPY TO",
-            "SEE YOU"
-          ]
-        },
-        {
-          "format": [
-            "[Y] GOOD MORNING",
-            "LOOK ALIVE"
-          ]
-        },
-        {
-          "format": [
-            "[Y] GOOD MORNING",
-            "HERE COMES",
-            "THE SUN"
-          ]
-        },
-        {
-          "format": [
-            "[Y] GOOD MORNING",
-            "EYES OPEN"
-          ]
-        },
-        {
-          "format": [
-            "[Y] GOOD MORNING",
-            "OFF WE GO"
-          ]
-        },
-        {
-          "format": [
-            "[Y] GOOD MORNING",
-            "UP AND AT 'EM"
-          ]
-        },
-        {
-          "format": [
-            "[Y] GOOD MORNING",
-            "HERE WE GO"
-          ]
-        },
-        {
-          "format": [
-            "[Y] GOOD MORNING",
-            "STEPPING IN"
+            "{morning_r1} GOOD",
+            "{morning_r2} MORNING",
+            "{morning_r3}"
           ]
         }
       ]

--- a/content/contrib/morning_night.md
+++ b/content/contrib/morning_night.md
@@ -1,14 +1,23 @@
 # morning_night.json
 
-Good morning and good night messages. Good morning fires at 7:00 AM with
-rotating greetings. Good night fires at 9:00 PM with the current moon phase
-displayed as a visual grid. September 21st gets a special Earth, Wind & Fire
-themed morning message.
+Good morning and good night messages. Good morning fires at 7:00 AM with a
+weather-based color visual. Good night fires at 9:00 PM with the current moon
+phase displayed as a visual grid. September 21st gets a special Earth, Wind &
+Fire themed morning message.
 
 ## Configuration
 
-No configuration required. The moon phase is calculated locally using a
-pure-math formula — no API key or network access needed.
+No configuration required for the moon phase (calculated locally, no API key
+needed). The morning visual uses weather data when available:
+
+```toml
+[weather]
+city = "San Francisco, CA"
+units = "imperial"
+```
+
+If `[weather]` is not configured, or if the weather fetch fails, the morning
+visual falls back to a default sunrise grid.
 
 Align the cron expressions to your board's hardware-configured quiet hours.
 The defaults (`0 7 * * *` and `0 21 * * *`) can be overridden per-template
@@ -24,6 +33,26 @@ cron = "15 6 21 9 *"
 [morning_night.schedules.good_night]
 cron = "30 21 * * *"
 ```
+
+## Morning weather visual
+
+The good morning template displays a 7×3 color grid on the left, with `GOOD`
+and `MORNING` anchored to the right on rows 1 and 2 — mirroring the good night
+layout. The visual adapts to current conditions:
+
+| Condition | Visual |
+|---|---|
+| Clear / mostly clear | Orange/yellow sunrise arc |
+| Partly cloudy | Sunrise arc with white cloud patches |
+| Overcast / fog | White cloud fill |
+| Light drizzle / rain | Sparse blue rain-drop columns |
+| Moderate–heavy rain | Denser blue rain columns |
+| Snow | White dot scatter on black |
+| Thunderstorm | Red fill with dark gaps |
+
+Weather data is fetched via the Open-Meteo API (same source as `weather.json`)
+and shares the weather integration's process-level forecast cache — at most one
+API call between them regardless of order.
 
 ## Moon phase visual
 

--- a/integrations/morning.py
+++ b/integrations/morning.py
@@ -1,0 +1,123 @@
+# integrations/morning.py
+#
+# Morning visual integration — weather-based 7×3 color grid.
+#
+# Returns a 7-cell-wide color grid for each of the 3 display rows,
+# reflecting current weather conditions when the weather integration is
+# configured. Falls back to a default sunrise visual when weather is
+# unavailable or not configured.
+#
+# The grid occupies the left 7 columns across all 3 rows, matching the
+# good_night moon layout convention (visual left, text right).
+#
+# No config.toml keys required. When [weather] is present, the current
+# WMO weather code drives the visual; otherwise the sunrise grid is used.
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# 7×3 [color] grids for each weather condition group.
+# Each entry is (r1, r2, r3) — three 7-cell color-tag strings.
+_GRIDS: dict[str, tuple[str, str, str]] = {
+  'CLEAR': (
+    '[K][K][K][Y][K][K][K]',
+    '[K][O][Y][Y][Y][O][K]',
+    '[O][Y][Y][Y][Y][Y][O]',
+  ),
+  'PARTLY': (
+    '[W][W][K][K][K][W][W]',
+    '[K][O][Y][Y][Y][O][K]',
+    '[O][Y][Y][Y][Y][Y][O]',
+  ),
+  'CLOUDY': (
+    '[K][W][W][W][W][W][K]',
+    '[W][W][W][W][W][W][W]',
+    '[W][W][W][W][W][W][W]',
+  ),
+  'RAIN_LIGHT': (
+    '[B][K][B][K][B][K][B]',
+    '[K][B][K][B][K][B][K]',
+    '[B][K][B][K][B][K][B]',
+  ),
+  'RAIN_HEAVY': (
+    '[B][B][K][B][B][K][B]',
+    '[B][K][B][B][K][B][B]',
+    '[K][B][B][K][B][B][K]',
+  ),
+  'SNOW': (
+    '[W][K][W][K][W][K][W]',
+    '[K][W][K][W][K][W][K]',
+    '[W][K][W][K][W][K][W]',
+  ),
+  'STORM': (
+    '[R][R][K][R][K][R][R]',
+    '[R][K][R][R][R][K][R]',
+    '[K][R][R][K][R][R][K]',
+  ),
+}
+
+_DEFAULT = 'CLEAR'
+
+# Maps condition strings (as returned by integrations.weather._WMO_CONDITIONS)
+# to grid keys. Covers all known WMO condition strings.
+_CONDITION_MAP: dict[str, str] = {
+  'CLEAR': 'CLEAR',
+  'MOSTLY CLEAR': 'CLEAR',
+  'PARTLY CLOUDY': 'PARTLY',
+  'OVERCAST': 'CLOUDY',
+  'FOG': 'CLOUDY',
+  'RIME FOG': 'CLOUDY',
+  'LIGHT DRIZZLE': 'RAIN_LIGHT',
+  'DRIZZLE': 'RAIN_LIGHT',
+  'HEAVY DRIZZLE': 'RAIN_HEAVY',
+  'FRZ DRIZZLE': 'RAIN_LIGHT',
+  'HVY FRZ DRZL': 'RAIN_HEAVY',
+  'LIGHT RAIN': 'RAIN_LIGHT',
+  'RAIN': 'RAIN_HEAVY',
+  'HEAVY RAIN': 'RAIN_HEAVY',
+  'FRZ RAIN': 'RAIN_LIGHT',
+  'HVY FRZ RAIN': 'RAIN_HEAVY',
+  'LIGHT SNOW': 'SNOW',
+  'SNOW': 'SNOW',
+  'HEAVY SNOW': 'SNOW',
+  'SNOW GRAINS': 'SNOW',
+  'LIGHT SHOWERS': 'RAIN_LIGHT',
+  'SHOWERS': 'RAIN_HEAVY',
+  'HEAVY SHOWERS': 'RAIN_HEAVY',
+  'SNOW SHOWERS': 'SNOW',
+  'HVY SNOW SHWR': 'SNOW',
+  'THUNDERSTORM': 'STORM',
+  'STORM + HAIL': 'STORM',
+}
+
+
+def _grid_key_from_weather() -> str:
+  """Return a grid key derived from the current weather condition.
+
+  Imports and calls integrations.weather.get_variables() at call time so
+  the weather module's process-level forecast cache is reused if already
+  populated. Returns _DEFAULT on any failure (unavailable data, missing
+  config section, import error).
+  """
+  try:
+    import integrations.weather as weather_mod
+
+    variables = weather_mod.get_variables()
+    condition = variables['condition'][0][0]  # e.g. '[Y] CLEAR'
+    # Strip the 3-char color tag and the following space: '[Y] CLEAR' → 'CLEAR'
+    condition_str = condition[4:] if len(condition) > 4 else ''
+    return _CONDITION_MAP.get(condition_str, _DEFAULT)
+  except Exception:
+    logger.debug('Morning: weather unavailable, using sunrise fallback')
+    return _DEFAULT
+
+
+def get_variables() -> dict[str, list[list[str]]]:
+  key = _grid_key_from_weather()
+  r1, r2, r3 = _GRIDS[key]
+  return {
+    'morning_r1': [[r1]],
+    'morning_r2': [[r2]],
+    'morning_r3': [[r3]],
+  }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.26.6"
+version = "0.27.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -65,7 +65,9 @@ class _IndentedFormatter(logging.Formatter):
 
 # Allowlist of valid integration names. Must be extended when a new integration
 # is added to integrations/.
-_KNOWN_INTEGRATIONS: frozenset[str] = frozenset({'bart', 'calendar', 'discogs', 'moon', 'plex', 'trakt', 'weather'})
+_KNOWN_INTEGRATIONS: frozenset[str] = frozenset(
+  {'bart', 'calendar', 'discogs', 'moon', 'morning', 'plex', 'trakt', 'weather'}
+)
 
 # Cache of loaded integration modules, keyed by name.
 _integrations: dict[str, Any] = {}

--- a/tests/integrations/test_morning_integration.py
+++ b/tests/integrations/test_morning_integration.py
@@ -1,0 +1,48 @@
+"""Integration tests for integrations/morning.py — calls the real Open-Meteo API
+via the weather integration.
+
+Run with: uv run pytest -m integration
+
+No API key required. Open-Meteo is free for non-commercial use.
+The morning integration has no env vars of its own; it reuses [weather] config.
+"""
+
+import pytest
+
+import config as _cfg
+import integrations.morning as morning
+import integrations.weather as weather
+
+_COLOR_TAGS = {'[W]', '[K]', '[R]', '[O]', '[Y]', '[G]', '[B]', '[V]'}
+_TAG_LEN = 3
+
+
+def _count_visual_width(row: str) -> int:
+  count = 0
+  i = 0
+  while i < len(row):
+    if row[i] == '[' and row[i : i + _TAG_LEN] in _COLOR_TAGS:
+      count += 1
+      i += _TAG_LEN
+    else:
+      i += 1
+  return count
+
+
+@pytest.mark.integration
+def test_get_variables_live(monkeypatch: pytest.MonkeyPatch) -> None:
+  """get_variables() returns a valid 7-wide visual using live Open-Meteo data."""
+  monkeypatch.setattr(_cfg, '_config', {'weather': {'city': 'San Francisco', 'units': 'imperial'}})
+  weather._geocode_cache = None
+  weather._forecast_cache = None
+
+  result = morning.get_variables()
+
+  assert set(result.keys()) == {'morning_r1', 'morning_r2', 'morning_r3'}
+  for key in ('morning_r1', 'morning_r2', 'morning_r3'):
+    assert len(result[key]) == 1
+    assert len(result[key][0]) == 1
+    row = result[key][0][0]
+    assert isinstance(row, str)
+    width = _count_visual_width(row)
+    assert width == 7, f'{key}: expected 7-wide row, got {row!r}'

--- a/tests/test_morning.py
+++ b/tests/test_morning.py
@@ -1,0 +1,106 @@
+from unittest.mock import patch
+
+import pytest
+
+import integrations.weather as weather_mod
+from exceptions import IntegrationDataUnavailableError
+from integrations.morning import _CONDITION_MAP, _DEFAULT, _GRIDS, _grid_key_from_weather, get_variables
+
+_COLOR_TAGS = {'[W]', '[K]', '[R]', '[O]', '[Y]', '[G]', '[B]', '[V]'}
+_TAG_LEN = 3
+
+
+def _count_visual_width(row: str) -> int:
+  count = 0
+  i = 0
+  while i < len(row):
+    if row[i] == '[' and row[i : i + _TAG_LEN] in _COLOR_TAGS:
+      count += 1
+      i += _TAG_LEN
+    else:
+      i += 1
+  return count
+
+
+# --- Grid shape ---
+
+
+def test_all_grids_are_seven_wide() -> None:
+  for key, (r1, r2, r3) in _GRIDS.items():
+    for row in (r1, r2, r3):
+      width = _count_visual_width(row)
+      assert width == 7, f'{key}: row {row!r} has width {width}, expected 7'
+
+
+def test_default_grid_exists() -> None:
+  assert _DEFAULT in _GRIDS
+
+
+def test_all_condition_map_values_are_valid_grid_keys() -> None:
+  for condition, key in _CONDITION_MAP.items():
+    assert key in _GRIDS, f'{condition!r} maps to unknown grid key {key!r}'
+
+
+# --- Condition mapping ---
+
+
+@pytest.mark.parametrize(
+  'condition,expected_key',
+  [
+    ('[Y] CLEAR', 'CLEAR'),
+    ('[Y] MOSTLY CLEAR', 'CLEAR'),
+    ('[O] PARTLY CLOUDY', 'PARTLY'),
+    ('[W] OVERCAST', 'CLOUDY'),
+    ('[W] FOG', 'CLOUDY'),
+    ('[W] RIME FOG', 'CLOUDY'),
+    ('[B] LIGHT DRIZZLE', 'RAIN_LIGHT'),
+    ('[B] DRIZZLE', 'RAIN_LIGHT'),
+    ('[B] LIGHT RAIN', 'RAIN_LIGHT'),
+    ('[B] RAIN', 'RAIN_HEAVY'),
+    ('[B] HEAVY RAIN', 'RAIN_HEAVY'),
+    ('[W] LIGHT SNOW', 'SNOW'),
+    ('[W] SNOW', 'SNOW'),
+    ('[W] HEAVY SNOW', 'SNOW'),
+    ('[R] THUNDERSTORM', 'STORM'),
+    ('[R] STORM + HAIL', 'STORM'),
+  ],
+)
+def test_grid_key_from_weather_conditions(condition: str, expected_key: str) -> None:
+  with patch.object(weather_mod, 'get_variables', return_value={'condition': [[condition]]}):
+    assert _grid_key_from_weather() == expected_key
+
+
+def test_grid_key_fallback_on_data_unavailable() -> None:
+  with patch.object(weather_mod, 'get_variables', side_effect=IntegrationDataUnavailableError('no data')):
+    assert _grid_key_from_weather() == _DEFAULT
+
+
+def test_grid_key_fallback_on_general_exception() -> None:
+  with patch.object(weather_mod, 'get_variables', side_effect=Exception('config missing')):
+    assert _grid_key_from_weather() == _DEFAULT
+
+
+def test_grid_key_fallback_on_unknown_condition() -> None:
+  with patch.object(weather_mod, 'get_variables', return_value={'condition': [['[K] UNKNOWN CONDITION']]}):
+    assert _grid_key_from_weather() == _DEFAULT
+
+
+# --- get_variables shape ---
+
+
+def test_get_variables_shape() -> None:
+  result = get_variables()
+  assert set(result.keys()) == {'morning_r1', 'morning_r2', 'morning_r3'}
+  for key in ('morning_r1', 'morning_r2', 'morning_r3'):
+    assert isinstance(result[key], list)
+    assert len(result[key]) == 1
+    assert len(result[key][0]) == 1
+    assert isinstance(result[key][0][0], str)
+
+
+def test_get_variables_rows_are_seven_wide() -> None:
+  result = get_variables()
+  for key in ('morning_r1', 'morning_r2', 'morning_r3'):
+    row = result[key][0][0]
+    width = _count_visual_width(row)
+    assert width == 7, f'{key}: expected 7-wide row, got {row!r}'

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.26.6"
+version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

Closes #342.

## Summary

- Adds `integrations/morning.py` with a 7×3 weather-based color grid for the good morning display, mirroring the good night moon layout (visual left, text right)
- Replaces the ten rotating quips in `good_morning` with a single integration-backed template: `{morning_r1} GOOD` / `{morning_r2} MORNING` / `{morning_r3}`
- Falls back silently to a default sunrise grid when `[weather]` is not configured or the fetch fails
- Reuses the weather integration's process-level forecast cache — at most one Open-Meteo API call regardless of invocation order

## Visuals

| Condition | Visual |
|---|---|
| Clear / mostly clear | Orange/yellow sunrise arc |
| Partly cloudy | Sunrise arc with white cloud patches |
| Overcast / fog | White cloud fill |
| Light rain / drizzle | Sparse blue rain-drop columns |
| Heavy rain | Denser blue rain columns |
| Snow | White dot scatter on black |
| Thunderstorm | Red fill with dark gaps |

## Test plan

- [ ] Unit tests: `uv run pytest tests/test_morning.py -v` — 24 tests covering all WMO condition groups and both fallback paths
- [ ] Full suite: `uv run pytest` — 618 passed
- [ ] Integration test (live API): `uv run pytest -m integration tests/integrations/test_morning_integration.py -v`
