### PR TITLE
feat(notion): add Notion webhook integration

### DIFF
--- a/content/README.md
+++ b/content/README.md
@@ -243,3 +243,4 @@ Don't inflate priority to "win" — see the priority guidelines above.
 | [`trakt.json`](contrib/trakt.md) | Trakt.tv upcoming calendar and now-playing |
 | [`morning_night.json`](contrib/morning_night.md) | Good morning and good night messages with moon phase visual |
 | [`plex.json`](contrib/plex.md) | Plex Media Server now-playing via webhook |
+| [`notion.json`](contrib/notion.md) | Notion automation notifications via webhook |

--- a/content/contrib/notion.json
+++ b/content/contrib/notion.json
@@ -1,0 +1,22 @@
+{
+  "templates": {
+    "notification": {
+      "webhook": true,
+      "schedule": {
+        "hold": 120,
+        "timeout": 120
+      },
+      "priority": 7,
+      "truncation": "word",
+      "integration": "notion",
+      "templates": [
+        {
+          "format": [
+            "[W] FROM NOTION",
+            "{message}"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/content/contrib/notion.md
+++ b/content/contrib/notion.md
@@ -1,0 +1,156 @@
+# notion.json
+
+Notion integration — displays automation-triggered notifications on the board
+via webhook. Each notification shows a `[W] FROM NOTION` header row followed
+by the message body.
+
+Unlike cron-scheduled templates, this template is triggered entirely by
+incoming webhook events from Notion automations. No content is shown when
+idle.
+
+## Requirements
+
+No Notion API key is needed — Notion automations send outbound HTTP requests
+directly to the webhook listener. You only need:
+
+- The webhook listener enabled in `config.toml` (see below)
+- A Notion automation with an **HTTP request** action
+
+## Configuration
+
+No `[notion]` section is needed in `config.toml`. Enable the webhook listener
+and the notion content:
+
+```toml
+[scheduler]
+content_enabled = ["notion"]
+
+[webhook]
+# secret is auto-generated on first start and saved to config.toml — check the log.
+```
+
+To override hold, timeout, or priority, add a section to `config.toml`:
+
+```toml
+[notion.schedules.notification]
+hold = 60
+timeout = 60
+priority = 8
+```
+
+| Override key | Default | Description |
+|---|---|---|
+| `hold` | `120` | Seconds to show the notification |
+| `timeout` | `120` | Seconds the message can wait in the queue before being discarded |
+| `priority` | `7` | Display priority (0–10) |
+
+## Webhook setup
+
+### 1. Enable the webhook listener
+
+Add the `[webhook]` block shown in Configuration above. On first start, a
+shared secret is auto-generated, printed to the log, and saved to
+`config.toml` — it persists across restarts:
+
+```
+Webhook secret generated and saved to config.toml:
+  <your-secret-here>
+Copy this into your webhook sender (Plex, Shortcuts, etc.).
+```
+
+### 2. Build the webhook URL
+
+```
+http://<host-ip>:<host-port>/webhook/notion
+```
+
+Pass the secret via the `X-Webhook-Secret` header (preferred) or the
+`?secret=` query parameter. Notion's HTTP request action supports custom
+headers, so the header approach is recommended:
+
+```
+X-Webhook-Secret: <your-secret-here>
+```
+
+### 3. Configure a Notion automation
+
+1. Open a Notion database → **Automations** → **New automation**
+2. Choose a trigger (e.g. "Status changed to Done", "Property edited")
+3. Add an action: **Send HTTP request**
+4. Set the request:
+   - **Method**: POST
+   - **URL**: your webhook URL from step 2
+   - **Headers**: `Content-Type: application/json`, `X-Webhook-Secret: <secret>`
+   - **Body** (JSON): see payload schema below
+
+## Payload schema
+
+```json
+{
+  "message": "required — body text displayed on the board",
+  "urgent": false,
+  "tag": "notion"
+}
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `message` | string | Yes | — | Body text. Newlines (`\n`) produce multiple display lines. |
+| `urgent` | boolean | No | `false` | If `true`, interrupt the current hold immediately. |
+| `tag` | string | No | `"notion"` | Deduplication key. A new notification replaces any queued message with the same tag. Set to `""` to disable superseding. |
+
+The `tag` value is automatically namespaced — a caller-supplied `"reminders"`
+becomes `"notion.reminders"` internally, preventing collisions with other
+integrations.
+
+### Example payloads
+
+Minimal:
+```json
+{ "message": "Task completed: Q1 planning" }
+```
+
+With newlines:
+```json
+{ "message": "Task completed\nQ1 planning doc" }
+```
+
+Urgent with a custom dedup tag:
+```json
+{
+  "message": "Deploy failed in production",
+  "urgent": true,
+  "tag": "deploy-alerts"
+}
+```
+
+## Display format
+
+**Note (3×15):**
+
+```
+[W] FROM NOTION
+TASK COMPLETED
+Q1 PLANNING DOC
+```
+
+**Flagship (6×22):**
+
+```
+[W] FROM NOTION
+TASK COMPLETED
+Q1 PLANNING DOC
+```
+
+- Row 1: `[W] FROM NOTION` (static header)
+- Rows 2+: message body, word-wrapped to board width; excess rows are dropped
+
+## Keeping data current
+
+### Notion automation HTTP request action
+
+Notion's automation HTTP action has been stable since launch. No hardcoded
+data in this integration. If Notion changes the outbound request format or
+adds authentication requirements, verify against:
+
+- [Notion help: Automation actions](https://www.notion.so/help/automation-actions)

--- a/integrations/notion.py
+++ b/integrations/notion.py
@@ -1,0 +1,108 @@
+# integrations/notion.py
+#
+# Notion webhook integration — displays automation-triggered notifications.
+#
+# Notion automations send an HTTP POST to the webhook endpoint with a
+# structured payload. This integration parses the payload and formats a
+# display message with a static "[W] FROM NOTION" header row.
+#
+# No config.toml keys are required for the integration itself. To override
+# hold/timeout/priority for the notification template, add a
+# [notion.schedules.notification] section to config.toml — the same override
+# syntax used for scheduled templates.
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from scheduler import WebhookMessage
+
+logger = logging.getLogger(__name__)
+
+_NOTION_JSON_PATH = Path(__file__).parent.parent / 'content' / 'contrib' / 'notion.json'
+
+
+def _load_template_config(template_name: str) -> dict[str, Any]:
+  """Return effective config for a webhook-only template from notion.json.
+
+  Applies any [notion.schedules.<template_name>] overrides from config.toml
+  on top of the JSON defaults, matching the behaviour of scheduled templates.
+  """
+  import config as _config_mod
+
+  with open(_NOTION_JSON_PATH) as f:
+    content = json.load(f)
+  template = content['templates'][template_name]
+  schedule = template['schedule']
+
+  effective: dict[str, Any] = {
+    'hold': schedule['hold'],
+    'timeout': schedule['timeout'],
+    'priority': template['priority'],
+    'truncation': template.get('truncation', 'hard'),
+    'templates': template.get('templates', []),
+  }
+
+  override = _config_mod.get_schedule_override(f'notion.{template_name}')
+  for field in ('hold', 'timeout'):
+    val = override.get(field)
+    if isinstance(val, int) and val >= 0:
+      effective[field] = val
+  priority_val = override.get('priority')
+  if isinstance(priority_val, int) and 0 <= priority_val <= 10:
+    effective['priority'] = priority_val
+
+  return effective
+
+
+def handle_webhook(payload: dict[str, Any]) -> WebhookMessage | None:
+  """Process a Notion webhook payload and return a WebhookMessage or None.
+
+  Expected payload fields:
+    message (str, required): body text; newlines produce multiple display lines.
+    urgent  (bool, optional, default false): if true, interrupt the current hold.
+    tag     (str, optional, default "notion"): deduplication key — queued messages
+            with the same namespaced tag are replaced by this one. Set to "" to
+            disable superseding entirely.
+
+  Returns None if message is missing or blank, or on any unexpected error.
+  """
+  try:
+    message = payload.get('message', '')
+    if not isinstance(message, str):
+      message = ''
+    message_lines = [line.strip().upper() for line in message.split('\n') if line.strip()]
+    if not message_lines:
+      logger.debug('notion: discarding: empty or missing message')
+      return None
+
+    urgent = bool(payload.get('urgent', False))
+
+    raw_tag = payload.get('tag')
+    if raw_tag is None:
+      supersede_tag = 'notion'
+    elif isinstance(raw_tag, str):
+      supersede_tag = f'notion.{raw_tag}' if raw_tag else ''
+    else:
+      logger.debug('notion: invalid tag type %r, using default', type(raw_tag).__name__)
+      supersede_tag = 'notion'
+
+    cfg = _load_template_config('notification')
+
+    logger.debug('notion: enqueueing notification (urgent=%s, tag=%r)', urgent, supersede_tag)
+    return WebhookMessage(
+      data={
+        'templates': cfg['templates'],
+        'variables': {'message': [message_lines]},
+        'truncation': cfg['truncation'],
+      },
+      priority=cfg['priority'],
+      hold=cfg['hold'],
+      timeout=cfg['timeout'],
+      interrupt=urgent,
+      supersede_tag=supersede_tag,
+    )
+  except Exception as e:  # noqa: BLE001
+    logger.error('Notion webhook error: %s', e)
+    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.27.0"
+version = "0.28.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -66,7 +66,7 @@ class _IndentedFormatter(logging.Formatter):
 # Allowlist of valid integration names. Must be extended when a new integration
 # is added to integrations/.
 _KNOWN_INTEGRATIONS: frozenset[str] = frozenset(
-  {'bart', 'calendar', 'discogs', 'moon', 'morning', 'plex', 'trakt', 'weather'}
+  {'bart', 'calendar', 'discogs', 'moon', 'morning', 'notion', 'plex', 'trakt', 'weather'}
 )
 
 # Cache of loaded integration modules, keyed by name.

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -1,0 +1,135 @@
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+
+import integrations.notion as notion
+from scheduler import WebhookMessage
+
+_TEMPLATE_CONFIG = {
+  'hold': 120,
+  'timeout': 120,
+  'priority': 7,
+  'truncation': 'word',
+  'templates': [{'format': ['[W] FROM NOTION', '{message}']}],
+}
+
+
+@pytest.fixture(autouse=True)
+def _mock_config() -> Generator[None, None, None]:
+  with patch('config.get_schedule_override', return_value={}):
+    yield
+
+
+# --- Message handling ---
+
+
+def test_valid_message_returns_webhook_message() -> None:
+  result = notion.handle_webhook({'message': 'task completed'})
+  assert isinstance(result, WebhookMessage)
+  assert result.data['variables'] == {'message': [['TASK COMPLETED']]}
+
+
+def test_message_uppercased() -> None:
+  result = notion.handle_webhook({'message': 'hello world'})
+  assert isinstance(result, WebhookMessage)
+  assert result.data['variables']['message'] == [['HELLO WORLD']]
+
+
+def test_multiline_message_splits_on_newlines() -> None:
+  result = notion.handle_webhook({'message': 'line one\nline two\nline three'})
+  assert isinstance(result, WebhookMessage)
+  assert result.data['variables']['message'] == [['LINE ONE', 'LINE TWO', 'LINE THREE']]
+
+
+def test_empty_message_returns_none() -> None:
+  assert notion.handle_webhook({'message': ''}) is None
+
+
+def test_blank_only_message_returns_none() -> None:
+  assert notion.handle_webhook({'message': '   \n  '}) is None
+
+
+def test_missing_message_returns_none() -> None:
+  assert notion.handle_webhook({}) is None
+
+
+def test_non_string_message_returns_none() -> None:
+  assert notion.handle_webhook({'message': 42}) is None
+
+
+# --- urgent field ---
+
+
+def test_urgent_false_by_default() -> None:
+  result = notion.handle_webhook({'message': 'hello'})
+  assert isinstance(result, WebhookMessage)
+  assert result.interrupt is False
+
+
+def test_urgent_true_sets_interrupt() -> None:
+  result = notion.handle_webhook({'message': 'hello', 'urgent': True})
+  assert isinstance(result, WebhookMessage)
+  assert result.interrupt is True
+
+
+def test_urgent_false_explicit() -> None:
+  result = notion.handle_webhook({'message': 'hello', 'urgent': False})
+  assert isinstance(result, WebhookMessage)
+  assert result.interrupt is False
+
+
+# --- tag / supersede_tag ---
+
+
+def test_default_tag_is_notion() -> None:
+  result = notion.handle_webhook({'message': 'hello'})
+  assert isinstance(result, WebhookMessage)
+  assert result.supersede_tag == 'notion'
+
+
+def test_custom_tag_is_namespaced() -> None:
+  result = notion.handle_webhook({'message': 'hello', 'tag': 'reminders'})
+  assert isinstance(result, WebhookMessage)
+  assert result.supersede_tag == 'notion.reminders'
+
+
+def test_empty_tag_disables_superseding() -> None:
+  result = notion.handle_webhook({'message': 'hello', 'tag': ''})
+  assert isinstance(result, WebhookMessage)
+  assert result.supersede_tag == ''
+
+
+def test_non_string_tag_falls_back_to_notion() -> None:
+  result = notion.handle_webhook({'message': 'hello', 'tag': 123})
+  assert isinstance(result, WebhookMessage)
+  assert result.supersede_tag == 'notion'
+
+
+# --- Config defaults ---
+
+
+def test_default_priority_and_hold() -> None:
+  result = notion.handle_webhook({'message': 'hello'})
+  assert isinstance(result, WebhookMessage)
+  assert result.priority == 7
+  assert result.hold == 120
+  assert result.timeout == 120
+
+
+def test_config_override_applied() -> None:
+  with patch('config.get_schedule_override', return_value={'hold': 60, 'priority': 9}):
+    result = notion.handle_webhook({'message': 'hello'})
+  assert isinstance(result, WebhookMessage)
+  assert result.hold == 60
+  assert result.priority == 9
+
+
+# --- Error handling ---
+
+
+def test_exception_returns_none(caplog: pytest.LogCaptureFixture) -> None:
+  with patch.object(notion, '_load_template_config', side_effect=RuntimeError('boom')):
+    result = notion.handle_webhook({'message': 'hello'})
+  assert result is None
+  assert 'Notion webhook error' in caplog.text

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.27.0"
+version = "0.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- Adds `integrations/notion.py` with `handle_webhook()` — processes Notion automation payloads and returns a `WebhookMessage` for display
- Static `[W] FROM NOTION` header row; message body word-wrapped to board width
- Payload supports `message` (required), `urgent` (interrupt current hold), and `tag` (dedup key, namespaced as `notion.<tag>` to prevent cross-integration collisions)
- Registers `'notion'` in `_KNOWN_INTEGRATIONS` in `scheduler.py`
- Adds `content/contrib/notion.json` and `content/contrib/notion.md` sidecar doc
- 17 unit tests; all checks pass

## Test plan

- [ ] All CI checks pass (ruff, pyright, bandit, pytest)
- [ ] `uv run pytest tests/test_notion.py -v` — 17 tests pass
- [ ] Manual: POST to `/webhook/notion` with `{"message": "hello"}` displays correctly
- [ ] Manual: `urgent: true` interrupts current hold
- [ ] Manual: `tag: "reminders"` and a second POST with same tag replaces the queued message

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)
