### PR TITLE
fix(notion): parse nested Notion automation webhook payload

### DIFF
--- a/integrations/notion.py
+++ b/integrations/notion.py
@@ -59,33 +59,43 @@ def _load_template_config(template_name: str) -> dict[str, Any]:
 def handle_webhook(payload: dict[str, Any]) -> WebhookMessage | None:
   """Process a Notion webhook payload and return a WebhookMessage or None.
 
-  Expected payload fields:
-    message (str, required): body text; newlines produce multiple display lines.
-    urgent  (bool, optional, default false): if true, interrupt the current hold.
-    tag     (str, optional, default "notion"): deduplication key — queued messages
+  Expects the Notion automation webhook format, where page data is nested under
+  payload["data"]["properties"]. The integration reads three page properties:
+    message (title, required): body text; newlines produce multiple display lines.
+    urgent  (checkbox, optional, default false): if true, interrupt the current hold.
+    tag     (select, optional, default "notion"): deduplication key — queued messages
             with the same namespaced tag are replaced by this one. Set to "" to
             disable superseding entirely.
 
   Returns None if message is missing or blank, or on any unexpected error.
   """
   try:
-    message = payload.get('message', '')
-    if not isinstance(message, str):
-      message = ''
+    data = payload.get('data')
+    if not isinstance(data, dict):
+      logger.debug('notion: discarding: missing or invalid data key')
+      return None
+    properties = data.get('properties')
+    if not isinstance(properties, dict):
+      logger.debug('notion: discarding: missing or invalid properties key')
+      return None
+
+    title_items = properties.get('message', {}).get('title', [])
+    message = ''.join(item.get('plain_text', '') for item in title_items if isinstance(item, dict))
     message_lines = [line.strip().upper() for line in message.split('\n') if line.strip()]
     if not message_lines:
       logger.debug('notion: discarding: empty or missing message')
       return None
 
-    urgent = bool(payload.get('urgent', False))
+    urgent = bool(properties.get('urgent', {}).get('checkbox', False))
 
-    raw_tag = payload.get('tag')
-    if raw_tag is None:
+    select = properties.get('tag', {}).get('select')
+    if select is None:
       supersede_tag = 'notion'
-    elif isinstance(raw_tag, str):
+    elif isinstance(select, dict):
+      raw_tag = select.get('name', '')
       supersede_tag = f'notion.{raw_tag}' if raw_tag else ''
     else:
-      logger.debug('notion: invalid tag type %r, using default', type(raw_tag).__name__)
+      logger.debug('notion: invalid tag select type %r, using default', type(select).__name__)
       supersede_tag = 'notion'
 
     cfg = _load_template_config('notification')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.28.0"
+version = "0.28.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from typing import Any, Generator
 from unittest.mock import patch
 
 import pytest
@@ -15,6 +15,28 @@ _TEMPLATE_CONFIG = {
 }
 
 
+def _make_payload(
+  message: str = 'task completed',
+  urgent: bool = False,
+  tag_select: dict[str, Any] | None = None,
+  tag_missing: bool = False,
+) -> dict[str, Any]:
+  """Return a minimal Notion automation webhook payload."""
+  properties: dict[str, Any] = {
+    'message': {
+      'type': 'title',
+      'title': [{'type': 'text', 'plain_text': message}],
+    },
+    'urgent': {'type': 'checkbox', 'checkbox': urgent},
+  }
+  if not tag_missing:
+    properties['tag'] = {'type': 'select', 'select': tag_select}
+  return {
+    'source': {'type': 'automation'},
+    'data': {'object': 'page', 'properties': properties},
+  }
+
+
 @pytest.fixture(autouse=True)
 def _mock_config() -> Generator[None, None, None]:
   with patch('config.get_schedule_override', return_value={}):
@@ -25,56 +47,64 @@ def _mock_config() -> Generator[None, None, None]:
 
 
 def test_valid_message_returns_webhook_message() -> None:
-  result = notion.handle_webhook({'message': 'task completed'})
+  result = notion.handle_webhook(_make_payload('task completed'))
   assert isinstance(result, WebhookMessage)
   assert result.data['variables'] == {'message': [['TASK COMPLETED']]}
 
 
 def test_message_uppercased() -> None:
-  result = notion.handle_webhook({'message': 'hello world'})
+  result = notion.handle_webhook(_make_payload('hello world'))
   assert isinstance(result, WebhookMessage)
   assert result.data['variables']['message'] == [['HELLO WORLD']]
 
 
 def test_multiline_message_splits_on_newlines() -> None:
-  result = notion.handle_webhook({'message': 'line one\nline two\nline three'})
+  result = notion.handle_webhook(_make_payload('line one\nline two\nline three'))
   assert isinstance(result, WebhookMessage)
   assert result.data['variables']['message'] == [['LINE ONE', 'LINE TWO', 'LINE THREE']]
 
 
 def test_empty_message_returns_none() -> None:
-  assert notion.handle_webhook({'message': ''}) is None
+  payload = _make_payload()
+  payload['data']['properties']['message']['title'] = [{'plain_text': ''}]
+  assert notion.handle_webhook(payload) is None
 
 
 def test_blank_only_message_returns_none() -> None:
-  assert notion.handle_webhook({'message': '   \n  '}) is None
+  assert notion.handle_webhook(_make_payload('   \n  ')) is None
 
 
 def test_missing_message_returns_none() -> None:
-  assert notion.handle_webhook({}) is None
+  payload = _make_payload()
+  payload['data']['properties']['message']['title'] = []
+  assert notion.handle_webhook(payload) is None
 
 
-def test_non_string_message_returns_none() -> None:
-  assert notion.handle_webhook({'message': 42}) is None
+def test_missing_data_key_returns_none() -> None:
+  assert notion.handle_webhook({'source': {'type': 'automation'}}) is None
+
+
+def test_missing_properties_key_returns_none() -> None:
+  assert notion.handle_webhook({'data': {'object': 'page'}}) is None
 
 
 # --- urgent field ---
 
 
 def test_urgent_false_by_default() -> None:
-  result = notion.handle_webhook({'message': 'hello'})
+  result = notion.handle_webhook(_make_payload(urgent=False))
   assert isinstance(result, WebhookMessage)
   assert result.interrupt is False
 
 
 def test_urgent_true_sets_interrupt() -> None:
-  result = notion.handle_webhook({'message': 'hello', 'urgent': True})
+  result = notion.handle_webhook(_make_payload(urgent=True))
   assert isinstance(result, WebhookMessage)
   assert result.interrupt is True
 
 
 def test_urgent_false_explicit() -> None:
-  result = notion.handle_webhook({'message': 'hello', 'urgent': False})
+  result = notion.handle_webhook(_make_payload(urgent=False))
   assert isinstance(result, WebhookMessage)
   assert result.interrupt is False
 
@@ -83,34 +113,34 @@ def test_urgent_false_explicit() -> None:
 
 
 def test_default_tag_is_notion() -> None:
-  result = notion.handle_webhook({'message': 'hello'})
+  result = notion.handle_webhook(_make_payload(tag_select=None))
+  assert isinstance(result, WebhookMessage)
+  assert result.supersede_tag == 'notion'
+
+
+def test_tag_missing_from_properties_uses_default() -> None:
+  result = notion.handle_webhook(_make_payload(tag_missing=True))
   assert isinstance(result, WebhookMessage)
   assert result.supersede_tag == 'notion'
 
 
 def test_custom_tag_is_namespaced() -> None:
-  result = notion.handle_webhook({'message': 'hello', 'tag': 'reminders'})
+  result = notion.handle_webhook(_make_payload(tag_select={'name': 'reminders'}))
   assert isinstance(result, WebhookMessage)
   assert result.supersede_tag == 'notion.reminders'
 
 
 def test_empty_tag_disables_superseding() -> None:
-  result = notion.handle_webhook({'message': 'hello', 'tag': ''})
+  result = notion.handle_webhook(_make_payload(tag_select={'name': ''}))
   assert isinstance(result, WebhookMessage)
   assert result.supersede_tag == ''
-
-
-def test_non_string_tag_falls_back_to_notion() -> None:
-  result = notion.handle_webhook({'message': 'hello', 'tag': 123})
-  assert isinstance(result, WebhookMessage)
-  assert result.supersede_tag == 'notion'
 
 
 # --- Config defaults ---
 
 
 def test_default_priority_and_hold() -> None:
-  result = notion.handle_webhook({'message': 'hello'})
+  result = notion.handle_webhook(_make_payload())
   assert isinstance(result, WebhookMessage)
   assert result.priority == 7
   assert result.hold == 120
@@ -119,7 +149,7 @@ def test_default_priority_and_hold() -> None:
 
 def test_config_override_applied() -> None:
   with patch('config.get_schedule_override', return_value={'hold': 60, 'priority': 9}):
-    result = notion.handle_webhook({'message': 'hello'})
+    result = notion.handle_webhook(_make_payload())
   assert isinstance(result, WebhookMessage)
   assert result.hold == 60
   assert result.priority == 9
@@ -130,6 +160,6 @@ def test_config_override_applied() -> None:
 
 def test_exception_returns_none(caplog: pytest.LogCaptureFixture) -> None:
   with patch.object(notion, '_load_template_config', side_effect=RuntimeError('boom')):
-    result = notion.handle_webhook({'message': 'hello'})
+    result = notion.handle_webhook(_make_payload())
   assert result is None
   assert 'Notion webhook error' in caplog.text

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.28.0"
+version = "0.28.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Fixes #345.

Notion automation webhooks nest page data under `data.properties` rather than the payload top level. The previous implementation read `message`, `urgent`, and `tag` directly from the payload root, so every incoming webhook was silently discarded.

## Changes

- `integrations/notion.py` — `handle_webhook` now navigates `payload["data"]["properties"]` and extracts:
  - `message` by joining `plain_text` across all `title` items
  - `urgent` from the `checkbox` property value
  - `tag` from the `select` property (`null` → default `'notion'` tag; dict with `name` → `'notion.<name>'`; blank name → `''` to disable superseding)
- `tests/test_notion.py` — updated all existing tests to use the nested Notion automation payload format; added coverage for missing `data`, missing `properties`, and `tag` absent from properties

## Test plan

- [x] `uv run pytest` — 636 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run pyright` — clean
- [x] `uv run bandit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
