### PR TITLE
fix(vestaboard): ellipsis truncation uses hard cut to fill maximum columns

### DIFF
--- a/content/DESIGN.md
+++ b/content/DESIGN.md
@@ -215,7 +215,7 @@ Use the `truncation` field to control overflow:
 
 | Mode | Use when |
 |---|---|
-| `ellipsis` | Live API data — the user should know content was cut |
+| `ellipsis` | Live API data — fills to the column limit, then appends `...` so the user knows content was cut |
 | `word` | Hand-written static content with natural word boundaries |
 | `hard` | Output is pre-fitted and overflow is impossible or intentional |
 

--- a/content/README.md
+++ b/content/README.md
@@ -68,7 +68,7 @@ schedule and display settings.
 | `timeout` | Seconds the message can wait in the queue before being discarded |
 | `priority` | Integer 0–10; higher number runs first when multiple messages are queued simultaneously |
 | `private` | If `true`, excluded when public mode is enabled (`[scheduler] public = true` in config.toml) |
-| `truncation` | `hard` cuts mid-word (default); `word` stops at a word boundary; `ellipsis` adds `...` |
+| `truncation` | `hard` cuts mid-word (default); `word` stops at a word boundary; `ellipsis` fills to the column limit then appends `...` |
 
 ### Variables
 

--- a/integrations/vestaboard.py
+++ b/integrations/vestaboard.py
@@ -402,7 +402,7 @@ def truncate_line(
   Strategies:
     hard     — cut at the column limit, mid-word if necessary.
     word     — cut at the last full word boundary that fits.
-    ellipsis — cut at the last full word boundary and append '...'.
+    ellipsis — cut at the column limit (hard cut) and append '...'.
 
   Multi-char tokens (❤️, color tags, escaped color tags) are never split.
   Escaped color tags (e.g. [[G]]) count as 3 display chars and are treated
@@ -420,15 +420,16 @@ def truncate_line(
     tok_display = 3 if len(tok) == 5 else 1
     if count + tok_display > target:
       break
-    if tok_display == 1 and tok == ' ' and strategy in ('word', 'ellipsis'):
+    if tok_display == 1 and tok == ' ' and strategy == 'word':
       last_word_end = len(result)
     result.append(tok)
     i += consumed
     count += tok_display
+  if strategy == 'ellipsis':
+    return ''.join(result) + '...'
   if strategy == 'hard' or last_word_end < 0:
     return ''.join(result)
-  base = ''.join(result[:last_word_end])
-  return base + ('...' if strategy == 'ellipsis' else '')
+  return ''.join(result[:last_word_end])
 
 
 def _wrap_lines(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.28.1"
+version = "0.28.2"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_vestaboard.py
+++ b/tests/core/test_vestaboard.py
@@ -141,8 +141,15 @@ def test_truncate_word() -> None:
 
 
 def test_truncate_ellipsis() -> None:
-  # target=7 (10-3): fits 'HELLO'(5) + space(6) + 'W'(7); base='HELLO' + '...'
-  assert vb.truncate_line('HELLO WORLD', 10, 'ellipsis') == 'HELLO...'
+  # target=7 (10-3): hard-cuts to 'HELLO W' (7 chars), then appends '...'
+  assert vb.truncate_line('HELLO WORLD', 10, 'ellipsis') == 'HELLO W...'
+
+
+def test_truncate_ellipsis_no_word_backtrack() -> None:
+  # ellipsis must NOT backtrack to the word boundary — result is longer than word cut
+  word_result = vb.truncate_line('HELLO WORLD', 10, 'word')
+  ellipsis_result = vb.truncate_line('HELLO WORLD', 10, 'ellipsis')
+  assert len(ellipsis_result.rstrip('.')) > len(word_result)
 
 
 def test_truncate_word_no_space_falls_back_to_hard() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.28.1"
+version = "0.28.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Fixes #346.

`ellipsis` was backtracking to the last word boundary before appending `...`, wasting columns between that boundary and the column limit. It now hard-cuts at `max_cols - 3` (same as the `hard` strategy) and appends `...`, filling every available column.

Before: `"HELLO FROM JASON"` at 15 cols → `"HELLO FROM..."` (12 chars, 2 wasted)
After: `"HELLO FROM JASON"` at 15 cols → `"HELLO FROM J..."` (15 chars, none wasted)

## Changes

- `integrations/vestaboard.py` — removed `'ellipsis'` from word-boundary tracking; added early return for `ellipsis` that joins the full hard-cut result and appends `...`; updated docstring
- `tests/core/test_vestaboard.py` — updated `test_truncate_ellipsis` expected value; added `test_truncate_ellipsis_no_word_backtrack`
- `content/README.md` and `content/DESIGN.md` — updated strategy descriptions

## Test plan

- [x] `uv run pytest` — 637 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run pyright` — clean
- [x] `uv run bandit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
