### PR TITLE
fix(vestaboard): strip trailing space before appending ellipsis

### DIFF
--- a/integrations/vestaboard.py
+++ b/integrations/vestaboard.py
@@ -426,7 +426,7 @@ def truncate_line(
     i += consumed
     count += tok_display
   if strategy == 'ellipsis':
-    return ''.join(result) + '...'
+    return ''.join(result).rstrip() + '...'
   if strategy == 'hard' or last_word_end < 0:
     return ''.join(result)
   return ''.join(result[:last_word_end])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.28.2"
+version = "0.28.3"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_vestaboard.py
+++ b/tests/core/test_vestaboard.py
@@ -145,6 +145,11 @@ def test_truncate_ellipsis() -> None:
   assert vb.truncate_line('HELLO WORLD', 10, 'ellipsis') == 'HELLO W...'
 
 
+def test_truncate_ellipsis_strips_trailing_space() -> None:
+  # target=6 (9-3): hard-cuts to 'HELLO ' (trailing space), must strip before '...'
+  assert vb.truncate_line('HELLO WORLD', 9, 'ellipsis') == 'HELLO...'
+
+
 def test_truncate_ellipsis_no_word_backtrack() -> None:
   # ellipsis must NOT backtrack to the word boundary — result is longer than word cut
   word_result = vb.truncate_line('HELLO WORLD', 10, 'word')

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.28.2"
+version = "0.28.3"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- `truncate_line` with `ellipsis` strategy now calls `.rstrip()` on the accumulated characters before appending `...`, so a trailing space from a mid-word cut no longer leaks into the output
- Bumps to v0.28.3

## Test plan

- [ ] New unit test `test_truncate_ellipsis_strips_trailing_space`: `truncate_line('HELLO WORLD', 9, 'ellipsis')` → `'HELLO...'` (was `'HELLO ...'`)
- [ ] Existing ellipsis tests still pass
- [ ] Full `uv run pytest` green
