### PR TITLE
chore(content): set truncation to ellipsis for all live-data templates

### DIFF
--- a/content/contrib/notion.json
+++ b/content/contrib/notion.json
@@ -7,7 +7,7 @@
         "timeout": 120
       },
       "priority": 7,
-      "truncation": "word",
+      "truncation": "ellipsis",
       "integration": "notion",
       "templates": [
         {

--- a/content/contrib/plex.json
+++ b/content/contrib/plex.json
@@ -48,7 +48,7 @@
       },
       "priority": 8,
       "private": true,
-      "truncation": "word",
+      "truncation": "ellipsis",
       "integration": "plex",
       "templates": [
         {

--- a/content/contrib/weather.json
+++ b/content/contrib/weather.json
@@ -7,7 +7,7 @@
         "timeout": 1800
       },
       "priority": 5,
-      "truncation": "word",
+      "truncation": "ellipsis",
       "integration": "weather",
       "templates": [
         {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.29.0"
+version = "0.29.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.29.0"
+version = "0.29.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- `notion.json` notification: `word` → `ellipsis` (live Notion message text)
- `weather.json` conditions: `word` → `ellipsis` (live city/condition strings from Open-Meteo)
- `plex.json` stopped: `word` → `ellipsis` (live Plex show name and episode metadata)

Templates with pre-fitted output (morning/moon color grids) and static hand-authored content (aria quips) are correct as-is and unchanged.

All other contrib templates (`bart`, `calendar`, `discogs`, `trakt`, `plex` now_playing/paused) were already set to `ellipsis`.

Closes #347

## Test plan

- [ ] Full `uv run pytest` passes (no logic changes, just JSON)
- [ ] `uv run pre-commit run pretty-format-json --all-files` passes
