### PR TITLE
chore(notion): shorten header label to NOTION

### DIFF
--- a/content/contrib/notion.json
+++ b/content/contrib/notion.json
@@ -12,7 +12,7 @@
       "templates": [
         {
           "format": [
-            "[W] FROM NOTION",
+            "[W] NOTION",
             "{message}"
           ]
         }

--- a/content/contrib/notion.md
+++ b/content/contrib/notion.md
@@ -1,7 +1,7 @@
 # notion.json
 
 Notion integration — displays automation-triggered notifications on the board
-via webhook. Each notification shows a `[W] FROM NOTION` header row followed
+via webhook. Each notification shows a `[W] NOTION` header row followed
 by the message body.
 
 Unlike cron-scheduled templates, this template is triggered entirely by
@@ -129,7 +129,7 @@ Urgent with a custom dedup tag:
 **Note (3×15):**
 
 ```
-[W] FROM NOTION
+[W] NOTION
 TASK COMPLETED
 Q1 PLANNING DOC
 ```
@@ -137,12 +137,12 @@ Q1 PLANNING DOC
 **Flagship (6×22):**
 
 ```
-[W] FROM NOTION
+[W] NOTION
 TASK COMPLETED
 Q1 PLANNING DOC
 ```
 
-- Row 1: `[W] FROM NOTION` (static header)
+- Row 1: `[W] NOTION` (static header)
 - Rows 2+: message body, word-wrapped to board width; excess rows are dropped
 
 ## Keeping data current

--- a/integrations/notion.py
+++ b/integrations/notion.py
@@ -4,7 +4,7 @@
 #
 # Notion automations send an HTTP POST to the webhook endpoint with a
 # structured payload. This integration parses the payload and formats a
-# display message with a static "[W] FROM NOTION" header row.
+# display message with a static "[W] NOTION" header row.
 #
 # No config.toml keys are required for the integration itself. To override
 # hold/timeout/priority for the notification template, add a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.29.1"
+version = "0.29.2"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -11,7 +11,7 @@ _TEMPLATE_CONFIG = {
   'timeout': 120,
   'priority': 7,
   'truncation': 'word',
-  'templates': [{'format': ['[W] FROM NOTION', '{message}']}],
+  'templates': [{'format': ['[W] NOTION', '{message}']}],
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.29.1"
+version = "0.29.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Shortens the static Notion notification header from `[W] FROM NOTION` to `[W] NOTION`, saving 5 characters on the header row and leaving more display space for the message body.

Updated in `notion.json`, `notion.py` (comment), `notion.md` (docs), and `test_notion.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)