### PR TITLE
chore: remove ineffective lgtm suppression annotations

### DIFF
--- a/config.py
+++ b/config.py
@@ -116,7 +116,7 @@ def write_section_values(section: str, values: dict[str, str | int]) -> None:
       section_lines.insert(insert_at, new_line)
 
   lines[section_start:section_end] = section_lines
-  _CONFIG_PATH.write_text(''.join(lines))  # lgtm[py/clear-text-storage-sensitive-data]
+  _CONFIG_PATH.write_text(''.join(lines))
   _config.setdefault(section, {}).update(values)
 
 
@@ -273,7 +273,7 @@ def write_config_section(section: str, values: dict[str, str | int | list[str]])
     for key, value in values.items():
       lines.append(f'{key} = {_render(value)}\n')
 
-  _CONFIG_PATH.write_text(''.join(lines))  # lgtm[py/clear-text-storage-sensitive-data]
+  _CONFIG_PATH.write_text(''.join(lines))
 
   # Update in-memory cache for dotted section names.
   parts = section.split('.')


### PR DESCRIPTION
— *Claude Code*

## Summary

- Removes `# lgtm[py/clear-text-storage-sensitive-data]` comments from two `write_text` call sites in `config.py`
- GitHub code scanning does not honour `# lgtm[]` inline suppression comments; the 6 false positive alerts on #362 were dismissed via the GitHub API as false positives instead
- These comments added noise without providing any actual suppression

## Test plan

- [ ] CI passes (no behaviour change)