### PR TITLE
fix(message): simplify registration — drop display_name, accept color names and spaces

### DIFF
--- a/content/contrib/message.md
+++ b/content/contrib/message.md
@@ -83,31 +83,28 @@ passphrase with the friend.
 **Build the admin Shortcut:**
 
 1. Open Shortcuts → tap **+** → name it "Register Board Friend"
-2. Add **Ask for Input** (Text) → prompt "Friend's name (e.g. alice)" → save as `name`
-3. Add **Ask for Input** (Text) → prompt "Display name (shown on board)" → save as `display_name`
-4. Add **Choose from List** → items: Red, Orange, Yellow, Green, Blue, Violet, White, Black, Heart → save as `color_name`
-5. Add a **Dictionary** action mapping color names to codes:
-   `Red→R, Orange→O, Yellow→Y, Green→G, Blue→B, Violet→V, White→W, Black→K, Heart→H`
-   Get value for key `color_name` → save as `color`
-6. Generate the passphrase (3 random words from the wordlist — see below):
+2. Add **Ask for Input** (Text) → prompt "Friend's name (e.g. Alice or Bob Smith)" → save as `name`
+3. Add **Choose from List** → items: Red, Orange, Yellow, Green, Blue, Violet, White, Black, Heart → save as `color`
+4. Generate the passphrase (3 random words from the wordlist — see below):
    - Add **Text** action with the wordlist (one word per line)
    - Add **Split Text** (by new lines) → save as `words`
    - Add **Count** of `words` → save as `word_count`
    - Repeat 3 times: **Get Random Number** (1 to `word_count`) → **Get Item from List** at that index
    - Combine: **Text** `word1-word2-word3` → save as `passphrase`
-7. Add **Get Contents of URL**:
+5. Add **Get Contents of URL**:
    - URL: `https://<your-board-host>/webhook/message`
    - Method: POST
    - Headers: `Content-Type: application/json`, `X-Webhook-Secret: <main-secret>`
    - Request Body (JSON):
      ```json
-     { "action": "register", "name": "<name>", "display_name": "<display_name>",
-       "color": "<color>", "passphrase": "<passphrase>" }
+     { "action": "register", "name": "<name>", "color": "<color>", "passphrase": "<passphrase>" }
      ```
-8. Add **Show Result** → text "Share this with <display_name>: <passphrase>"
-9. Add import questions for the board URL and main webhook secret
+6. Add **Show Result** → text "Share this with <name>: <passphrase>"
+7. Add import questions for the board URL and main webhook secret
 
 Share via iCloud link → send to yourself only. This Shortcut holds the main secret.
+
+The `display_name` field is optional — when omitted the board uses `name` (uppercased on display).
 
 ### Friend Shortcut
 
@@ -149,8 +146,7 @@ are needed — name and color come from the board's config.
 {
   "action": "register",
   "name": "alice",
-  "display_name": "Alice",
-  "color": "R",
+  "color": "Red",
   "passphrase": "river-candle-bench"
 }
 ```
@@ -158,9 +154,8 @@ are needed — name and color come from the board's config.
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `action` | string | Yes | — | Must be `"register"` |
-| `name` | string | Yes | — | Credential key: lowercase alphanumeric, hyphens, underscores |
-| `display_name` | string | No | `name` | Name shown on the board header row |
-| `color` | string | No | `"W"` | Header color: R O Y G B V W K H |
+| `name` | string | Yes | — | Friend's name; spaces become hyphens, then lowercased (e.g. "Bob Smith" → `bob-smith`); shown on the board uppercased |
+| `color` | string | No | `"White"` | Header color: full name (Red, Orange, Yellow, Green, Blue, Violet, White, Black, Heart) or single-letter code |
 | `passphrase` | string | Yes | — | Plaintext passphrase (min 8 chars); hashed before storing |
 
 Re-registering an existing `name` overwrites the previous credential and display config.

--- a/integrations/message.py
+++ b/integrations/message.py
@@ -38,6 +38,19 @@ _COLOR_MAP: dict[str, str] = {
   'H': '❤️',
 }
 
+# Maps full color names → config key (for Shortcut convenience; single-letter codes also accepted).
+_COLOR_NAMES: dict[str, str] = {
+  'red': 'R',
+  'orange': 'O',
+  'yellow': 'Y',
+  'green': 'G',
+  'blue': 'B',
+  'violet': 'V',
+  'white': 'W',
+  'black': 'K',
+  'heart': 'H',
+}
+
 # Max characters for the friend name in the header row per model.
 # Header: {color}(1) + ' '(1) + 'FROM '(5) = 7 cols used; remainder is for name.
 # Note: 15 cols → 8 for name. Flagship: 22 cols → 15 for name.
@@ -78,11 +91,10 @@ def _build_header(friend: dict[str, Any], credential_name: str, model: str) -> s
   Format: '{color} FROM {NAME}' where the name is hard-capped to fit row 1.
   The color character always occupies exactly 1 display column.
   """
-  display_name = str(friend.get('display_name', credential_name)).upper()
   color_key = str(friend.get('color', 'W')).upper()
   color_char = _COLOR_MAP.get(color_key, '[W]')
   max_cols = _MAX_NAME_COLS.get(model, _MAX_NAME_COLS['note'])
-  return f'{color_char} FROM {display_name[:max_cols]}'
+  return f'{color_char} FROM {credential_name.upper()[:max_cols]}'
 
 
 def handle_webhook(
@@ -153,9 +165,8 @@ def _handle_register(
   """Register a new friend credential. Only the admin (main webhook secret) may call this.
 
   Expects payload fields:
-    name         (str, required): credential key; lowercase alphanumeric, hyphens, underscores
-    display_name (str, optional): name shown on the board; defaults to name
-    color        (str, optional): one of R O Y G B V W K H; defaults to W (white)
+    name         (str, required): friend's name; spaces→hyphens, lowercased; shown on board (uppercased)
+    color        (str, optional): color name (Red, Orange, …, Heart) or code (R O Y G B V W K H); defaults to White
     passphrase   (str, required): plaintext passphrase; hashed with argon2id before storing
 
   Writes [webhook.credentials.<name>] and [message.friends.<name>] to config.toml.
@@ -170,15 +181,13 @@ def _handle_register(
     logger.warning('message: registration rejected: must use main webhook secret')
     return None
 
-  name = str(payload.get('name', '')).strip().lower()
+  name = re.sub(r'\s+', '-', str(payload.get('name', '')).strip().lower())
   if not name or not re.match(r'^[a-z0-9][a-z0-9_-]*$', name):
     logger.warning('message: registration rejected: invalid or missing name %r', name)
     return None
 
-  raw_display = str(payload.get('display_name', name)).strip()
-  display_name = raw_display if raw_display else name
-
-  color = str(payload.get('color', 'W')).upper()
+  color_raw = str(payload.get('color', 'W')).strip()
+  color = _COLOR_NAMES.get(color_raw.lower(), color_raw.upper())
   if color not in _COLOR_MAP:
     logger.warning('message: registration rejected: invalid color %r', color)
     return None
@@ -197,13 +206,8 @@ def _handle_register(
   )
   _config_mod.write_config_section(
     f'message.friends.{name}',
-    {'display_name': display_name, 'color': color},
+    {'color': color},
   )
 
-  logger.info(
-    'message: registered friend %r (display_name=%r, color=%r)',
-    name,
-    display_name,
-    color,
-  )
+  logger.info('message: registered friend %r (color=%r)', name, color)
   return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.30.1"
+version = "0.30.2"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -13,7 +13,7 @@ _TEMPLATE_CONFIG = {
   'truncation': 'ellipsis',
 }
 
-_FRIEND_ALICE = {'display_name': 'Alice', 'color': 'R'}
+_FRIEND_ALICE = {'color': 'R'}
 
 
 @pytest.fixture(autouse=True)
@@ -104,21 +104,21 @@ def test_unregistered_credential_returns_none() -> None:
 
 
 def test_header_uses_friend_color() -> None:
-  with patch('config.get_message_friend', return_value={'display_name': 'Alice', 'color': 'R'}):
+  with patch('config.get_message_friend', return_value={'color': 'R'}):
     result = message.handle_webhook(_make_payload(), credential_name='alice')
   assert isinstance(result, WebhookMessage)
   assert result.data['templates'][0]['format'][0] == '[R] FROM ALICE'
 
 
 def test_header_uses_heart_color() -> None:
-  with patch('config.get_message_friend', return_value={'display_name': 'Alice', 'color': 'H'}):
+  with patch('config.get_message_friend', return_value={'color': 'H'}):
     result = message.handle_webhook(_make_payload(), credential_name='alice')
   assert isinstance(result, WebhookMessage)
   assert result.data['templates'][0]['format'][0] == '❤️ FROM ALICE'
 
 
 def test_header_defaults_to_white_for_unknown_color() -> None:
-  with patch('config.get_message_friend', return_value={'display_name': 'Alice', 'color': 'Z'}):
+  with patch('config.get_message_friend', return_value={'color': 'Z'}):
     result = message.handle_webhook(_make_payload(), credential_name='alice')
   assert isinstance(result, WebhookMessage)
   assert result.data['templates'][0]['format'][0].startswith('[W] FROM')
@@ -126,27 +126,27 @@ def test_header_defaults_to_white_for_unknown_color() -> None:
 
 def test_name_hard_capped_to_note_budget() -> None:
   # Note: 15 cols. Header prefix = 7. Max name = 8.
-  # 'BARTHOLOMEW'[:8] = 'BARTHOLO'
-  with patch('config.get_message_friend', return_value={'display_name': 'Bartholomew', 'color': 'W'}):
-    result = message.handle_webhook(_make_payload(), credential_name='barth')
+  # credential_name 'bartholo' (8 chars) → 'BARTHOLO'
+  with patch('config.get_message_friend', return_value={'color': 'W'}):
+    result = message.handle_webhook(_make_payload(), credential_name='bartholo')
   assert isinstance(result, WebhookMessage)
   assert result.data['templates'][0]['format'][0] == '[W] FROM BARTHOLO'
 
 
 def test_name_hard_capped_to_flagship_budget() -> None:
   # Flagship: 22 cols. Header prefix = 7. Max name = 15.
-  # 'BARTHOLOMEW JONES'[:15] = 'BARTHOLOMEW JON'
+  # credential_name 'bartholomew-jones' → 'BARTHOLOMEW-JONE' (16 chars → capped at 15)
   with (
     patch('config.get_optional', return_value='flagship'),
-    patch('config.get_message_friend', return_value={'display_name': 'Bartholomew Jones', 'color': 'W'}),
+    patch('config.get_message_friend', return_value={'color': 'W'}),
   ):
-    result = message.handle_webhook(_make_payload(), credential_name='barth')
+    result = message.handle_webhook(_make_payload(), credential_name='bartholomew-jones')
   assert isinstance(result, WebhookMessage)
-  assert result.data['templates'][0]['format'][0] == '[W] FROM BARTHOLOMEW JON'
+  assert result.data['templates'][0]['format'][0] == '[W] FROM BARTHOLOMEW-JON'
 
 
-def test_display_name_falls_back_to_credential_name() -> None:
-  # display_name absent from friend config — use credential_name
+def test_header_uses_credential_name() -> None:
+  # Name on board comes from credential_name, not a stored display_name field.
   with patch('config.get_message_friend', return_value={'color': 'G'}):
     result = message.handle_webhook(_make_payload(), credential_name='bob')
   assert isinstance(result, WebhookMessage)
@@ -199,14 +199,12 @@ def test_interrupt_always_false() -> None:
 
 def _make_register_payload(
   name: str = 'alice',
-  display_name: str = 'Alice',
   color: str = 'R',
   passphrase: str = 'apple-river-bench',
 ) -> dict[str, Any]:
   return {
     'action': 'register',
     'name': name,
-    'display_name': display_name,
     'color': color,
     'passphrase': passphrase,
   }
@@ -238,10 +236,10 @@ def test_register_stores_credential_and_friend() -> None:
     },
   )
   assert cred_call.args[1]['secret_hash'].startswith('$argon2id$')
-  # Second call: friend display section
+  # Second call: friend display section (no display_name — name is the identity)
   assert mock_write.call_args_list[1] == call(
     'message.friends.alice',
-    {'display_name': 'Alice', 'color': 'R'},
+    {'color': 'R'},
   )
 
 
@@ -252,17 +250,14 @@ def test_register_overwrite_is_idempotent() -> None:
   assert mock_write.call_count == 4  # 2 calls per registration
 
 
-def test_register_display_name_defaults_to_name() -> None:
-  payload = _make_register_payload()
-  del payload['display_name']
+def test_register_spaces_in_name_converted_to_hyphens() -> None:
   with patch('config.write_config_section') as mock_write:
-    message.handle_webhook(payload, credential_name='')
-  friend_call = mock_write.call_args_list[1]
-  assert friend_call.args[1]['display_name'] == 'alice'
+    message.handle_webhook(_make_register_payload(name='Bob Smith'), credential_name='')
+  assert mock_write.call_args_list[0].args[0] == 'webhook.credentials.bob-smith'
 
 
 def test_register_invalid_name_returns_none(caplog: pytest.LogCaptureFixture) -> None:
-  result = message.handle_webhook(_make_register_payload(name='Alice With Spaces'), credential_name='')
+  result = message.handle_webhook(_make_register_payload(name='!invalid'), credential_name='')
   assert result is None
   assert 'invalid' in caplog.text.lower()
 
@@ -271,6 +266,27 @@ def test_register_invalid_color_returns_none(caplog: pytest.LogCaptureFixture) -
   result = message.handle_webhook(_make_register_payload(color='Z'), credential_name='')
   assert result is None
   assert 'invalid' in caplog.text.lower()
+
+
+def test_register_full_color_name_accepted() -> None:
+  with patch('config.write_config_section') as mock_write:
+    message.handle_webhook(_make_register_payload(color='Green'), credential_name='')
+  friend_call = mock_write.call_args_list[1]
+  assert friend_call.args[1]['color'] == 'G'
+
+
+def test_register_full_color_name_case_insensitive() -> None:
+  with patch('config.write_config_section') as mock_write:
+    message.handle_webhook(_make_register_payload(color='VIOLET'), credential_name='')
+  friend_call = mock_write.call_args_list[1]
+  assert friend_call.args[1]['color'] == 'V'
+
+
+def test_register_heart_full_name_accepted() -> None:
+  with patch('config.write_config_section') as mock_write:
+    message.handle_webhook(_make_register_payload(color='Heart'), credential_name='')
+  friend_call = mock_write.call_args_list[1]
+  assert friend_call.args[1]['color'] == 'H'
 
 
 def test_register_short_passphrase_returns_none(caplog: pytest.LogCaptureFixture) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.30.1"
+version = "0.30.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- **Remove `display_name`**: `name` is used directly as the board label (uppercased). Simplifies the stored config and the Shortcut.
- **Accept full color names**: server maps Red/Orange/Yellow/Green/Blue/Violet/White/Black/Heart → single-letter codes, so the Shortcut just passes a plain list selection with no dictionary step.
- **Normalize name input**: spaces are converted to hyphens and input is lowercased automatically — "Bob Smith" becomes `bob-smith`, shown on board as `BOB-SMITH`. No need for users to type slugs.

## Test plan

- [ ] CI passes
- [ ] `test_register_spaces_in_name_converted_to_hyphens` passes
- [ ] `test_register_full_color_name_accepted` / `_case_insensitive` / `_heart` pass