### PR TITLE
fix(message): wrap body across rows before ellipsis truncation

### DIFF
--- a/content/contrib/message.json
+++ b/content/contrib/message.json
@@ -7,7 +7,7 @@
         "timeout": 120
       },
       "priority": 8,
-      "truncation": "ellipsis",
+      "truncation": "wrap_ellipsis",
       "integration": "message"
     }
   }

--- a/integrations/vestaboard.py
+++ b/integrations/vestaboard.py
@@ -152,10 +152,11 @@ _CHAR_CODES['❤️'] = 62  # U+2764 + U+FE0F variation selector
 _CHAR_CODES['°'] = 62  # degree sign on the Flagship (same code as ❤ on Note)
 
 # Truncation strategy: how to shorten a line that exceeds model.cols.
-#   hard     — cut at the column limit, mid-word if necessary (default)
-#   word     — cut at the last full word that fits
-#   ellipsis — cut at the last full word and append '...'
-TruncationStrategy = Literal['hard', 'word', 'ellipsis']
+#   hard          — cut at the column limit, mid-word if necessary (default)
+#   word          — cut at the last full word that fits
+#   ellipsis      — truncate each line to one row with '...' (no wrapping; preserves fixed layouts)
+#   wrap_ellipsis — word-wrap across rows first; append '...' to the last row only if rows overflow
+TruncationStrategy = Literal['hard', 'word', 'ellipsis', 'wrap_ellipsis']
 
 # Short color tags usable in format strings and integration output.
 # Each tag is exactly 3 characters and encodes to a Vestaboard color square.
@@ -443,9 +444,14 @@ def _wrap_lines(
   are never joined together — wrapping only splits; short lines pass through
   unchanged.
 
-  Exception: when `truncation` is 'ellipsis', long lines are truncated to one
-  row with '...' rather than wrapped. This preserves fixed-layout templates
-  where each format entry must occupy exactly one row.
+  When `truncation` is 'ellipsis': long lines are truncated to one row with
+  '...' rather than wrapped. This preserves fixed-layout templates where each
+  format entry must occupy exactly one row.
+
+  When `truncation` is 'wrap_ellipsis': lines are word-wrapped normally across
+  rows; if the total result exceeds model.rows, '...' is appended to the last
+  kept row. Use this for free-form text that should fill available rows before
+  truncating.
   """
   cols = model.cols
   result: list[str] = []
@@ -468,7 +474,7 @@ def _wrap_lines(
           result.append(' '.join(current))
           current = []
           current_len = 0
-        result.append(truncate_line(word, cols, truncation))
+        result.append(truncate_line(word, cols, 'hard'))
         continue
       if not current:
         current = [word]
@@ -482,6 +488,11 @@ def _wrap_lines(
         current_len = word_len
     if current:
       result.append(' '.join(current))
+  if truncation == 'wrap_ellipsis' and len(result) > model.rows:
+    result = result[: model.rows]
+    # Truncate the last kept row to cols-3 (hard cut) then append '...',
+    # even if it already fits in cols — there is content beyond it.
+    result[-1] = truncate_line(result[-1], cols - 3, 'hard').rstrip() + '...'
   return result[: model.rows]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.30.2"
+version = "0.30.3"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -714,7 +714,7 @@ def parse_cron(cron: str) -> dict[str, str]:
   return {'minute': minute, 'hour': hour, 'day': day, 'month': month, 'day_of_week': day_of_week}
 
 
-_VALID_TRUNCATION: frozenset[str] = frozenset({'hard', 'word', 'ellipsis'})
+_VALID_TRUNCATION: frozenset[str] = frozenset({'hard', 'word', 'ellipsis', 'wrap_ellipsis'})
 
 
 def _coerce_bool(val: object, label: str) -> bool | None:

--- a/tests/core/test_vestaboard.py
+++ b/tests/core/test_vestaboard.py
@@ -225,6 +225,36 @@ def test_wrap_lines_ellipsis_preserves_fixed_layout() -> None:
   assert result[2] == 'TEAM CHERRY'
 
 
+# --- wrap_ellipsis ---
+
+
+def test_wrap_ellipsis_wraps_long_line() -> None:
+  # A line that exceeds cols should wrap rather than truncate on the first row.
+  # Note board: 3 rows x 15 cols. Header uses row 1; body has 2 rows.
+  lines = ['[R] FROM ALICE', 'HEY THE FOOD IS READY']  # body is 21 chars
+  result = vb._wrap_lines(lines, truncation='wrap_ellipsis')  # noqa: SLF001
+  assert result[0] == '[R] FROM ALICE'
+  assert result[1] == 'HEY THE FOOD IS'
+  assert result[2] == 'READY'
+
+
+def test_wrap_ellipsis_adds_ellipsis_on_row_overflow() -> None:
+  # When wrapped content exceeds model.rows, the last kept row gets '...'.
+  # Note board: 3 rows. Header + 3 body words that wrap to 3 rows = overflow.
+  lines = ['[R] FROM ALICE', 'WORD ONE TWO THREE FOUR FIVE SIX SEVEN']
+  result = vb._wrap_lines(lines, truncation='wrap_ellipsis')  # noqa: SLF001
+  assert len(result) == vb.model.rows
+  assert result[-1].endswith('...')
+
+
+def test_wrap_ellipsis_no_ellipsis_when_fits() -> None:
+  # No ellipsis when content fits within model.rows without overflow.
+  lines = ['[R] FROM ALICE', 'SHORT MSG']
+  result = vb._wrap_lines(lines, truncation='wrap_ellipsis')  # noqa: SLF001
+  assert result == ['[R] FROM ALICE', 'SHORT MSG']
+  assert not result[-1].endswith('...')
+
+
 # --- _strip_unsupported ---
 
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -10,7 +10,7 @@ _TEMPLATE_CONFIG = {
   'hold': 120,
   'timeout': 120,
   'priority': 8,
-  'truncation': 'ellipsis',
+  'truncation': 'wrap_ellipsis',
 }
 
 _FRIEND_ALICE = {'color': 'R'}

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.30.2"
+version = "0.30.3"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Adds `'wrap_ellipsis'` truncation strategy: word-wraps content across available rows first, then appends `...` to the last kept row only if the total overflows `model.rows`
- Plain `'ellipsis'` is unchanged — it still truncates each line to one row (correct for fixed-layout templates like Discogs, where long album title must not push artist name off the board)
- Switches `message.json` from `'ellipsis'` to `'wrap_ellipsis'` so friend messages fill both body rows on Note (or up to 5 on Flagship) before truncating

## Test plan

- [ ] Short message — displays on row 2, no ellipsis
- [ ] Medium message that wraps — fills row 2 and row 3 on Note, no ellipsis
- [ ] Long message that overflows — fills row 2 and row 3, last row ends with `...`
- [ ] Existing Discogs / Trakt templates unaffected (still use `'ellipsis'`)
