### PR TITLE
fix(config): group sibling sections and prevent double blank lines

### DIFF
--- a/config.py
+++ b/config.py
@@ -218,7 +218,10 @@ def write_config_section(section: str, values: dict[str, str | int | list[str]])
 
   Handles dotted section names (e.g. 'webhook.credentials.alice').
   Supports str, int, and list[str] values (rendered as TOML inline arrays).
-  Creates the section if absent (appended to end of file).
+  Creates the section if absent; inserts it after the last existing section
+  that shares the same parent prefix (e.g. 'webhook.credentials.bob' goes
+  after 'webhook.credentials.alice'), or appends at end if none exists.
+  Always produces exactly one blank line between sections and a trailing newline.
   Updates the in-memory config cache.
   """
   if not _CONFIG_PATH.exists():
@@ -266,12 +269,47 @@ def write_config_section(section: str, values: dict[str, str | int | list[str]])
         section_lines.insert(insert_at, new_line)
     lines[section_start:section_end] = section_lines
   else:
-    if lines and not lines[-1].endswith('\n'):
-      lines[-1] += '\n'
-    lines.append('\n')
-    lines.append(f'{header}\n')
+    # Find insertion point: after the last section that shares our parent prefix
+    # (e.g. 'webhook.credentials.bob' groups with 'webhook.credentials.alice').
+    parent_prefix = '.'.join(section.split('.')[:-1])
+    sibling_end: int | None = None
+    i = 0
+    while i < len(lines):
+      stripped = lines[i].strip()
+      if stripped.startswith('[') and not stripped.startswith('#'):
+        inner = stripped[1:].rstrip(']')
+        if inner == parent_prefix or inner.startswith(f'{parent_prefix}.'):
+          j = i + 1
+          while j < len(lines):
+            if lines[j].strip().startswith('[') and not lines[j].strip().startswith('#'):
+              break
+            j += 1
+          sibling_end = j
+      i += 1
+
+    new_lines = [f'{header}\n']
     for key, value in values.items():
-      lines.append(f'{key} = {_render(value)}\n')
+      new_lines.append(f'{key} = {_render(value)}\n')
+
+    if sibling_end is not None and sibling_end < len(lines):
+      # Insert between two sections: append a trailing blank line so the
+      # section that follows keeps its preceding separator.
+      new_lines.append('\n')
+      lines[sibling_end:sibling_end] = new_lines
+    else:
+      # Append at end: strip any trailing blank lines, add exactly one separator.
+      while lines and lines[-1].strip() == '':
+        lines.pop()
+      if lines and not lines[-1].endswith('\n'):
+        lines[-1] += '\n'
+      lines.append('\n')
+      lines.extend(new_lines)
+
+  # Ensure file ends with a single newline.
+  while lines and lines[-1] == '\n' and len(lines) >= 2 and lines[-2] == '\n':
+    lines.pop()
+  if lines and not lines[-1].endswith('\n'):
+    lines[-1] += '\n'
 
   _CONFIG_PATH.write_text(''.join(lines))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.30.3"
+version = "0.30.4"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -333,3 +333,89 @@ def test_write_section_values_updates_memory_cache(
   monkeypatch.setattr(_mod, '_config', cache)
   _mod.write_section_values('myapp', {'token': 'fresh'})
   assert cache.get('myapp', {}).get('token') == 'fresh'
+
+
+# --- write_config_section ---
+
+
+def _setup_wcs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, content: str) -> Path:
+  cfg = tmp_path / 'config.toml'
+  cfg.write_text(content)
+  monkeypatch.setattr(_mod, '_CONFIG_PATH', cfg)
+  monkeypatch.setattr(_mod, '_config', {})
+  return cfg
+
+
+def test_write_config_section_creates_new_section(
+  tmp_path: Path,
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  cfg = _setup_wcs(tmp_path, monkeypatch, '[webhook]\nsecret = "abc"\n')
+  _mod.write_config_section('webhook.credentials.alice', {'secret_hash': 'hash1', 'webhooks': ['message']})
+  text = cfg.read_text()
+  assert '[webhook.credentials.alice]' in text
+  assert 'secret_hash = "hash1"' in text
+  assert 'webhooks = ["message"]' in text
+
+
+def test_write_config_section_updates_existing_section(
+  tmp_path: Path,
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  cfg = _setup_wcs(tmp_path, monkeypatch, '[webhook.credentials.alice]\nsecret_hash = "old"\nwebhooks = ["message"]\n')
+  _mod.write_config_section('webhook.credentials.alice', {'secret_hash': 'new'})
+  text = cfg.read_text()
+  assert text.count('[webhook.credentials.alice]') == 1
+  assert 'secret_hash = "new"' in text
+
+
+def test_write_config_section_groups_siblings_together(
+  tmp_path: Path,
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  # Second credential must be inserted after the first, before unrelated sections.
+  content = (
+    '[webhook]\nsecret = "x"\n\n'
+    '[webhook.credentials.alice]\nsecret_hash = "a"\nwebhooks = ["message"]\n\n'
+    '[message.friends.alice]\ncolor = "R"\n'
+  )
+  cfg = _setup_wcs(tmp_path, monkeypatch, content)
+  _mod.write_config_section('webhook.credentials.bob', {'secret_hash': 'b', 'webhooks': ['message']})
+  text = cfg.read_text()
+  alice_pos = text.index('[webhook.credentials.alice]')
+  bob_pos = text.index('[webhook.credentials.bob]')
+  friends_pos = text.index('[message.friends.alice]')
+  assert alice_pos < bob_pos < friends_pos
+
+
+def test_write_config_section_no_double_blank_lines(
+  tmp_path: Path,
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  content = (
+    '[webhook]\nsecret = "x"\n\n'
+    '[webhook.credentials.alice]\nsecret_hash = "a"\nwebhooks = ["message"]\n\n'
+    '[message.friends.alice]\ncolor = "R"\n'
+  )
+  cfg = _setup_wcs(tmp_path, monkeypatch, content)
+  _mod.write_config_section('webhook.credentials.bob', {'secret_hash': 'b', 'webhooks': ['message']})
+  assert '\n\n\n' not in cfg.read_text()
+
+
+def test_write_config_section_ends_with_newline(
+  tmp_path: Path,
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  cfg = _setup_wcs(tmp_path, monkeypatch, '[webhook]\nsecret = "x"\n')
+  _mod.write_config_section('message.friends.alice', {'color': 'R'})
+  assert cfg.read_text().endswith('\n')
+  assert not cfg.read_text().endswith('\n\n')
+
+
+def test_write_config_section_updates_memory_cache(
+  tmp_path: Path,
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  _setup_wcs(tmp_path, monkeypatch, '[webhook]\nsecret = "x"\n')
+  _mod.write_config_section('webhook.credentials.alice', {'secret_hash': 'h', 'webhooks': ['message']})
+  assert _mod._config['webhook']['credentials']['alice']['secret_hash'] == 'h'  # noqa: SLF001

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.30.3"
+version = "0.30.4"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- `write_config_section` now inserts new sections after the last existing section sharing the same parent prefix — `webhook.credentials.bob` goes after `webhook.credentials.alice`, before unrelated sections like `message.friends.*`
- Fixes double blank line between sections: the append path previously added a blank line separator unconditionally, even when the file already ended with one
- File now always ends with exactly one trailing newline
- Adds unit tests for `write_config_section` (none existed previously)

## Test plan

- [ ] Register two friends via webhook; verify config has credentials grouped together and friends grouped together
- [ ] Verify no double blank lines appear between sections
- [ ] Verify file ends with exactly one newline
