### PR TITLE
fix(message,notion): replace color tags with bare letter in webhook text

### DIFF
--- a/content/contrib/message.md
+++ b/content/contrib/message.md
@@ -185,7 +185,7 @@ The passphrase is their identity — keep each friend's iCloud link private.
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `message` | string | Yes | — | Body text. Newlines produce multiple display rows. |
+| `message` | string | Yes | — | Body text. Newlines produce multiple display rows. Color tag syntax (`[R]`, `[G]`, etc.) is not interpreted — brackets are stripped and the letter is kept. |
 | `action` | string | No | `"message"` | Must be `"message"` or omitted for posting. |
 
 The sender is identified by their `X-Webhook-Secret` passphrase. No other fields

--- a/content/contrib/notion.md
+++ b/content/contrib/notion.md
@@ -95,7 +95,7 @@ X-Webhook-Secret: <your-secret-here>
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `message` | string | Yes | — | Body text. Newlines (`\n`) produce multiple display lines. |
+| `message` | string | Yes | — | Body text. Newlines (`\n`) produce multiple display lines. Color tag syntax (`[R]`, `[G]`, etc.) is not interpreted — brackets are stripped and the letter is kept. |
 | `urgent` | boolean | No | `false` | If `true`, interrupt the current hold immediately. |
 | `tag` | string | No | `"notion"` | Deduplication key. A new notification replaces any queued message with the same tag. Set to `""` to disable superseding. |
 

--- a/integrations/message.py
+++ b/integrations/message.py
@@ -23,6 +23,11 @@ from scheduler import WebhookMessage
 
 logger = logging.getLogger(__name__)
 
+# Matches color tags like [R], [G], etc. in user-supplied text.
+# Brackets are not in the Vestaboard character set, so [R] cannot render as
+# literal text. Replace with the bare letter so intent is preserved.
+_COLOR_TAG_RE = re.compile(r'\[([ROYGBVWK])\]')
+
 _MESSAGE_JSON_PATH = Path(__file__).parent.parent / 'content' / 'contrib' / 'message.json'
 
 # Maps color config key → Vestaboard display character (each = 1 display column).
@@ -132,7 +137,10 @@ def handle_webhook(
       return None
 
     message_text = str(payload.get('message', '')).strip()
-    message_lines = [line.strip().upper() for line in message_text.split('\n') if line.strip()]
+    message_lines = [
+      _COLOR_TAG_RE.sub(r'\1', line.strip().upper()).strip() for line in message_text.split('\n') if line.strip()
+    ]
+    message_lines = [line for line in message_lines if line]
     if not message_lines:
       logger.debug('message: discarding: empty or missing message')
       return None

--- a/integrations/notion.py
+++ b/integrations/notion.py
@@ -13,12 +13,18 @@
 
 import json
 import logging
+import re
 from pathlib import Path
 from typing import Any
 
 from scheduler import WebhookMessage
 
 logger = logging.getLogger(__name__)
+
+# Matches color tags like [R], [G], etc. in user-supplied text.
+# Brackets are not in the Vestaboard character set, so [R] cannot render as
+# literal text. Replace with the bare letter so intent is preserved.
+_COLOR_TAG_RE = re.compile(r'\[([ROYGBVWK])\]')
 
 _NOTION_JSON_PATH = Path(__file__).parent.parent / 'content' / 'contrib' / 'notion.json'
 
@@ -81,7 +87,10 @@ def handle_webhook(payload: dict[str, Any]) -> WebhookMessage | None:
 
     title_items = properties.get('message', {}).get('title', [])
     message = ''.join(item.get('plain_text', '') for item in title_items if isinstance(item, dict))
-    message_lines = [line.strip().upper() for line in message.split('\n') if line.strip()]
+    message_lines = [
+      _COLOR_TAG_RE.sub(r'\1', line.strip().upper()).strip() for line in message.split('\n') if line.strip()
+    ]
+    message_lines = [line for line in message_lines if line]
     if not message_lines:
       logger.debug('notion: discarding: empty or missing message')
       return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.30.4"
+version = "0.30.5"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -193,6 +193,41 @@ def test_interrupt_always_false() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Color tag handling
+# ---------------------------------------------------------------------------
+
+
+def test_color_tag_replaced_with_letter() -> None:
+  # [R] → R (brackets not in VB charset; keep the letter)
+  with patch('config.get_message_friend', return_value=_FRIEND_ALICE):
+    result = message.handle_webhook(_make_payload('[R] HEY'), credential_name='alice')
+  assert isinstance(result, WebhookMessage)
+  assert result.data['variables']['message'] == [['R HEY']]
+
+
+def test_all_color_tags_replaced() -> None:
+  with patch('config.get_message_friend', return_value=_FRIEND_ALICE):
+    result = message.handle_webhook(_make_payload('[R][O][Y][G][B][V][W][K]'), credential_name='alice')
+  assert isinstance(result, WebhookMessage)
+  assert result.data['variables']['message'] == [['ROYGBVWK']]
+
+
+def test_inline_color_tag_replaced() -> None:
+  # [B]ob → BOB after upper
+  with patch('config.get_message_friend', return_value=_FRIEND_ALICE):
+    result = message.handle_webhook(_make_payload('[B]ob called'), credential_name='alice')
+  assert isinstance(result, WebhookMessage)
+  assert result.data['variables']['message'] == [['BOB CALLED']]
+
+
+def test_heart_emoji_preserved() -> None:
+  with patch('config.get_message_friend', return_value=_FRIEND_ALICE):
+    result = message.handle_webhook(_make_payload('❤️ love you'), credential_name='alice')
+  assert isinstance(result, WebhookMessage)
+  assert result.data['variables']['message'] == [['❤️ LOVE YOU']]
+
+
+# ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
 

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -155,6 +155,28 @@ def test_config_override_applied() -> None:
   assert result.priority == 9
 
 
+# --- Color tag handling ---
+
+
+def test_color_tag_replaced_with_letter() -> None:
+  # [R] → R (brackets not in VB charset; keep the letter)
+  result = notion.handle_webhook(_make_payload('[R] alert'))
+  assert isinstance(result, WebhookMessage)
+  assert result.data['variables']['message'] == [['R ALERT']]
+
+
+def test_all_color_tags_replaced() -> None:
+  result = notion.handle_webhook(_make_payload('[R][O][Y][G][B][V][W][K]'))
+  assert isinstance(result, WebhookMessage)
+  assert result.data['variables']['message'] == [['ROYGBVWK']]
+
+
+def test_inline_color_tag_replaced() -> None:
+  result = notion.handle_webhook(_make_payload('[G]reen light'))
+  assert isinstance(result, WebhookMessage)
+  assert result.data['variables']['message'] == [['GREEN LIGHT']]
+
+
 # --- Error handling ---
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.30.4"
+version = "0.30.5"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- `[R]` (and other color tags) in user-supplied webhook message text now render as the bare letter (`R`) rather than a color square
- Brackets are not in the Vestaboard character set — the previous behavior (color square rendering) was an unintended side-effect of the color tag pipeline, not an intentional feature
- Applied consistently to both `message` and `notion` integrations; sidecar docs updated

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)