### PR TITLE
docs: add Bot Fight Mode recommendation to webhook rate limiting doc

### DIFF
--- a/docs/webhook-reverse-proxy.md
+++ b/docs/webhook-reverse-proxy.md
@@ -137,6 +137,11 @@ The free plan includes **one rate limiting rule**; spending it here is the
 highest-value use. It fires at Cloudflare's edge before the request reaches
 `cloudflared`, so the origin never sees the blocked traffic.
 
+Also enable **Bot Fight Mode** (**Security → Bots → Bot Fight Mode**) if not
+already on. It challenges requests from known bot infrastructure and automated
+scanners globally — free, no configuration required, and safe for
+machine-to-machine webhook senders like Plex, Notion, and iOS Shortcuts.
+
 ### Nginx
 
 ```nginx


### PR DESCRIPTION
Follow-up to #377.

Adds a note to enable Bot Fight Mode (`Security → Bots → Bot Fight Mode`) alongside the rate limiting rule. Free, no configuration required, safe for machine-to-machine senders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)