### PR TITLE
fix(trakt): bump test expires_at to avoid spurious token refresh in CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,6 +360,7 @@ prevention here — not just a one-off fix. See #65 for extended notes.
    gh api repos/JasonPuglisi/e-note-ion/rulesets/13082160 --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
    ```
 9. **Integration test hygiene** — advisory CI job passing on `main`; GitHub environment secrets/vars present (`VESTABOARD_VIRTUAL_API_KEY`, `CALENDAR_URL`, `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `DISCOGS_TOKEN` as secrets; `TRAKT_CLIENT_ID` as a variable); new integrations have `test_<name>_integration.py` and env vars in `tests/integrations/conftest.py`
+   - **`TRAKT_ACCESS_TOKEN` expires every ~90 days** — if the Trakt integration tests start failing with an auth error, copy the current `access_token` from `config.toml` (kept fresh by the prod refresh flow) into the `integration` environment secret
 10. **Issue/milestone hygiene**:
     - Every open issue has a milestone (no orphans); scope is right-sized
     - Blocking relationships explicit ("Blocked by #X" in body)

--- a/tests/integrations/test_trakt_integration.py
+++ b/tests/integrations/test_trakt_integration.py
@@ -28,7 +28,7 @@ def _patch_config(monkeypatch: pytest.MonkeyPatch) -> None:
         'client_id': os.environ['TRAKT_CLIENT_ID'],
         'client_secret': os.environ['TRAKT_CLIENT_SECRET'],
         'access_token': os.environ['TRAKT_ACCESS_TOKEN'],
-        'expires_at': int(time.time()) + 10000,  # assume valid for test run
+        'expires_at': int(time.time()) + 7776000,  # 90 days — avoid triggering refresh during test
       }
     },
   )


### PR DESCRIPTION
Closes #130.

## Summary

- `_patch_config` in `test_trakt_integration.py` set `expires_at = time.time() + 10000` (~2.8h), which is under the 24h refresh threshold — every CI run triggered a `_refresh_token()` call that failed with `ValueError: Missing required config key [trakt].refresh_token`
- Bumped to `time.time() + 7776000` (90 days) so the test always runs with a notionally fresh token and never attempts a refresh
- Added a ~90-day manual rotation reminder to the health review checklist in `AGENTS.md`

No rotation automation — CI holds only `TRAKT_ACCESS_TOKEN`; when it expires the advisory job fails visibly, which is the signal to copy the current token from `config.toml` into the GitHub secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)