### PR TITLE
fix(trakt): mock config writes in integration tests to prevent FileNotFoundError

### DIFF
--- a/tests/integrations/test_trakt_integration.py
+++ b/tests/integrations/test_trakt_integration.py
@@ -35,6 +35,9 @@ def _patch_config(monkeypatch: pytest.MonkeyPatch) -> None:
       }
     },
   )
+  # Prevent any config writes (e.g. _clear_tokens after a failed refresh) from
+  # touching the filesystem — config.toml does not exist in CI.
+  monkeypatch.setattr(_cfg, 'write_section_values', lambda section, values: None)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Follow-up to #380 / #130.

When `TRAKT_ACCESS_TOKEN` in CI is expired, `_handle_api_401()` calls `_refresh_token()` (with our `'expired'` placeholder), which fails with `HTTPError`, then `_clear_tokens()` tries to write to `config.toml` — which doesn't exist in CI — causing `FileNotFoundError`.

Patching `write_section_values` to a no-op in `_patch_config` prevents any config write from touching the filesystem. `IntegrationDataUnavailableError` then propagates correctly → `pytest.skip()`.

With the updated `TRAKT_ACCESS_TOKEN` in the `integration` environment secret, the tests should pass. When the token expires again in ~90 days, the tests will skip gracefully rather than crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)