### PR TITLE
chore: add GitHub community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Something isn't working as expected
+labels: bug
+assignees: JasonPuglisi
+---
+
+**Board model**
+Note (3×15) or Flagship (6×22)?
+
+**Deployment method**
+Docker / uv / other?
+
+**Python version** (if not Docker)
+
+**What happened**
+<!-- What did you observe? -->
+
+**What you expected**
+<!-- What should have happened instead? -->
+
+**Steps to reproduce**
+1.
+2.
+3.
+
+**Relevant config** (redact all API keys and secrets)
+```toml
+```
+
+**Logs**
+```
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability
+labels: enhancement
+assignees: JasonPuglisi
+---
+
+**Use case / motivation**
+<!-- What problem does this solve? Who benefits? -->
+
+**Proposed approach**
+<!-- How might this work? Be as specific or as vague as you like. -->
+
+**Alternatives considered**
+<!-- Any other approaches you thought about? -->
+
+**Additional context**
+<!-- Screenshots, links, examples, etc. -->

--- a/.github/ISSUE_TEMPLATE/integration_request.md
+++ b/.github/ISSUE_TEMPLATE/integration_request.md
@@ -1,0 +1,21 @@
+---
+name: Integration request
+about: Request a new data source or external service integration
+labels: enhancement
+assignees: JasonPuglisi
+---
+
+**Data source / service**
+<!-- What would this integration pull from? Link to the service or API docs. -->
+
+**API access**
+Public (no key) / API key required / OAuth?
+
+**Update frequency**
+<!-- How often does the data change? Real-time, daily, etc. -->
+
+**What it would show on the board**
+<!-- Describe the content. Keep in mind the display is 3×15 (Note) or 6×22 (Flagship). -->
+
+**Additional context**
+<!-- Anything else that would help evaluate this request. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+Closes #
+
+## Changes
+
+<!-- Brief description of what this PR does. -->
+
+## Checklist
+
+- [ ] Linked issue exists and was discussed before coding
+- [ ] Tests added or updated; `uv run pytest` passes
+- [ ] `uv run ruff check .` and `uv run ruff format --check .` clean
+- [ ] `uv run pyright` clean
+- [ ] `uv run bandit -c pyproject.toml -r .` clean
+- [ ] No secrets logged or exposed; all HTTP calls include `timeout=`
+- [ ] `README.md` / `AGENTS.md` / sidecar docs updated if needed
+- [ ] Version bumped in `pyproject.toml` (and `uv.lock` staged) if release-worthy

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant v2.1][covenant].
+
+To report a violation, open a [GitHub Security Advisory][advisory] (private)
+or contact the maintainer through GitHub.
+
+[covenant]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+[advisory]: https://github.com/JasonPuglisi/e-note-ion/security/advisories/new

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,4 +29,20 @@ Requirements for all PRs:
 See [AGENTS.md](AGENTS.md) for code conventions (indentation, type hints,
 security practices, integration patterns).
 
+## Content contributions
+
+Personal display content lives in `content/user/` (git-ignored) and is never
+committed. If you want to share a content template with the community, add it
+to `content/contrib/` alongside a sidecar `.md` doc (use
+`content/contrib/TEMPLATE.md` as a starting point).
+
+See [`content/README.md`](content/README.md) for the JSON format reference and
+[`content/DESIGN.md`](content/DESIGN.md) for visual and layout conventions.
+
+## Security
+
+Do not report security issues through public GitHub issues. Use the
+[GitHub Security Advisory][advisory] instead.
+
 [issues]: https://github.com/JasonPuglisi/e-note-ion/issues
+[advisory]: https://github.com/JasonPuglisi/e-note-ion/security/advisories/new


### PR DESCRIPTION
Closes #223

## Changes

Adds standard GitHub community health files:

- `CODE_OF_CONDUCT.md` — references Contributor Covenant v2.1 by URL (avoids embedding the full text); security reports routed to GitHub Security Advisories
- `.github/ISSUE_TEMPLATE/bug_report.md` — board model, deployment method, repro steps, redacted config
- `.github/ISSUE_TEMPLATE/feature_request.md` — use case, proposed approach, alternatives
- `.github/ISSUE_TEMPLATE/integration_request.md` — data source, API access type, update frequency, board content description
- `.github/pull_request_template.md` — checklist covering tests, linting, docs, version bump
- `CONTRIBUTING.md` — adds "Content contributions" section (content/user/, contrib template, design docs) and "Security" section pointing to GitHub Security Advisories

## Checklist

- [ ] Linked issue exists and was discussed before coding
- [x] Tests added or updated; `uv run pytest` passes — no logic changes
- [x] `uv run ruff check .` and `uv run ruff format --check .` clean — no Python changes
- [x] `uv run pyright` clean — no Python changes
- [x] `uv run bandit -c pyproject.toml -r .` clean — no Python changes
- [x] No secrets logged or exposed; all HTTP calls include `timeout=`
- [x] `README.md` / `AGENTS.md` / sidecar docs updated if needed — docs-only PR
- [x] Version bumped in `pyproject.toml` (and `uv.lock` staged) if release-worthy — docs-only, no bump needed
