### PR TITLE
fix(calendar): use icalendar_instance instead of icalendar_object for CalDAV events

### DIFF
--- a/integrations/calendar.py
+++ b/integrations/calendar.py
@@ -405,7 +405,7 @@ def _collect_candidates_caldav(
     merged = Calendar()
     for event_obj in events:
       try:
-        for component in event_obj.icalendar_object.subcomponents:
+        for component in event_obj.icalendar_instance.subcomponents:
           if component.name == 'VEVENT':
             merged.add_component(component)
       except Exception:  # noqa: BLE001  # nosec B112 — skip malformed CalDAV event objects; continue to next

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.31.1"
+version = "0.31.2"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_calendar.py
+++ b/tests/core/test_calendar.py
@@ -458,7 +458,7 @@ def test_get_variables_both_modes_merged(monkeypatch: pytest.MonkeyPatch) -> Non
   # Build a fake CalDAV calendar that returns a CalDAV event.
   caldav_event_ics = _make_ics([_future_event('CALDAV EVENT', hours_ahead=3)])
   fake_cal_obj = MagicMock()
-  fake_cal_obj.icalendar_object = Calendar.from_ical(caldav_event_ics)
+  fake_cal_obj.icalendar_instance = Calendar.from_ical(caldav_event_ics)
   fake_caldav_cal = MagicMock()
   fake_caldav_cal.events.return_value = [fake_cal_obj]
 

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.31.1"
+version = "0.31.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Fixes #383.

## Summary
- `_collect_candidates_caldav` accessed `event_obj.icalendar_object`, which doesn't exist on caldav `Event` objects — the correct attribute is `icalendar_instance`
- The `AttributeError` was silently swallowed by `except Exception: continue`, leaving the merged `Calendar` empty on every call, so CalDAV events were never returned
- Updated the corresponding unit test mock to use `icalendar_instance`

## Test plan
- [ ] All calendar unit tests pass (`uv run pytest tests/ -k calendar`)
- [ ] Verify CalDAV events appear when running against a live iCloud account

🤖 Generated with [Claude Code](https://claude.com/claude-code)
