### PR TITLE
feat(calendar): add birthdays integration via iCloud Contacts CardDAV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ CALENDAR_URL=https://calendar.google.com/calendar/ical/.../basic.ics
 CALENDAR_CALDAV_URL=https://caldav.icloud.com/
 CALENDAR_USERNAME=you@icloud.com
 CALENDAR_PASSWORD=xxxx-xxxx-xxxx-xxxx
+# CardDAV mode — iCloud Contacts birthdays (same username/password as CalDAV):
+CALENDAR_CARDDAV_URL=https://contacts.icloud.com/
 #
 # Required for BART integration tests:
 BART_API_KEY=your-bart-api-key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,7 +359,7 @@ prevention here — not just a one-off fix. See #65 for extended notes.
    ```
    gh api repos/JasonPuglisi/e-note-ion/rulesets/13082160 --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
    ```
-9. **Integration test hygiene** — advisory CI job passing on `main`; GitHub environment secrets/vars present (`VESTABOARD_VIRTUAL_API_KEY`, `CALENDAR_URL`, `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `DISCOGS_TOKEN` as secrets; `TRAKT_CLIENT_ID` as a variable); new integrations have `test_<name>_integration.py` and env vars in `tests/integrations/conftest.py`
+9. **Integration test hygiene** — advisory CI job passing on `main`; GitHub environment secrets/vars present (`VESTABOARD_VIRTUAL_API_KEY`, `CALENDAR_URL`, `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD`, `CALENDAR_CARDDAV_URL`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `DISCOGS_TOKEN` as secrets; `TRAKT_CLIENT_ID` as a variable); new integrations have `test_<name>_integration.py` and env vars in `tests/integrations/conftest.py`
    - **`TRAKT_ACCESS_TOKEN` expires every ~90 days** — if the Trakt integration tests start failing with an auth error, copy the current `access_token` from `config.toml` (kept fresh by the prod refresh flow) into the `integration` environment secret
 10. **Issue/milestone hygiene**:
     - Every open issue has a milestone (no orphans); scope is right-sized

--- a/config.example.toml
+++ b/config.example.toml
@@ -87,6 +87,12 @@ city = "San Francisco"
 # password = "xxxx-xxxx-xxxx-xxxx"
 # calendar_names = ["Work", "Personal"]  # optional; default: all calendars
 
+# CardDAV mode — iCloud Contacts birthdays (birthdays.json).
+# Uses the same username and password as CalDAV mode above.
+# Omit carddav_url to disable the birthdays integration entirely.
+# carddav_url = "https://contacts.icloud.com/"
+# birthdays_lookahead_days = 7  # optional; default: 7
+
 # [calendar.schedules.today]
 # cron = "30 * * * *"
 # hold = 300

--- a/content/README.md
+++ b/content/README.md
@@ -176,6 +176,7 @@ template to keep everything playing nicely together.
 | `:00` every 4h | `trakt.calendar` | 4 | 1200s | 1800s | Private; queues behind weather |
 | `:30` every hour | `calendar` | 5 | 300s | 1800s | |
 | `8:30` daily | `discogs` | 5 | 600s | 3600s | Queues behind calendar at :30 |
+| `9:00` daily | `birthdays` | 5 | 600s | 3600s | Queues behind weather at :00; done by ~9:20 |
 | `*/5` 07–09 Mon–Fri | `bart` | 8 | 290s | 60s | Refresh 60s; dominates mornings |
 | `*/3` always | `trakt.watching` | 7 | 180s | 120s | Refresh 30s; no-op when idle |
 | webhook only | `plex` | 8 | indef | 30s | Private; interrupts on state change |
@@ -238,6 +239,7 @@ Don't inflate priority to "win" — see the priority guidelines above.
 |---|---|
 | [`weather.json`](contrib/weather.md) | Current weather conditions via Open-Meteo |
 | [`calendar.json`](contrib/calendar.md) | Today's calendar events (ICS and iCloud CalDAV) |
+| [`birthdays.json`](contrib/birthdays.md) | Upcoming birthdays from iCloud Contacts |
 | [`bart.json`](contrib/bart.md) | BART real-time departure board |
 | [`discogs.json`](contrib/discogs.md) | Daily vinyl suggestion from your Discogs collection |
 | [`trakt.json`](contrib/trakt.md) | Trakt.tv upcoming calendar and now-playing |

--- a/content/contrib/birthdays.json
+++ b/content/contrib/birthdays.json
@@ -1,0 +1,23 @@
+{
+  "templates": {
+    "today": {
+      "schedule": {
+        "cron": "0 9 * * *",
+        "hold": 600,
+        "timeout": 3600
+      },
+      "priority": 5,
+      "truncation": "ellipsis",
+      "integration": "calendar",
+      "integration_fn": "get_variables_birthdays",
+      "templates": [
+        {
+          "format": [
+            "\u2764\ufe0f BIRTHDAYS",
+            "{birthdays}"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/content/contrib/birthdays.md
+++ b/content/contrib/birthdays.md
@@ -1,0 +1,49 @@
+# birthdays.json
+
+Upcoming birthdays from iCloud Contacts, shown once daily at 9am. Displays
+contacts whose birthday falls today or within the lookahead window, one per
+line. Requires the same iCloud app-specific password as the CalDAV calendar
+integration.
+
+Omit `carddav_url` from `[calendar]` to disable this integration entirely.
+
+## Configuration
+
+Add the following to your `[calendar]` section in `config.toml`:
+
+```toml
+[calendar]
+carddav_url = "https://contacts.icloud.com/"
+username = "you@icloud.com"
+password = "xxxx-xxxx-xxxx-xxxx"
+# birthdays_lookahead_days = 7
+```
+
+| Key | Required | Description |
+|---|---|---|
+| `carddav_url` | Yes | CardDAV server URL. iCloud: `https://contacts.icloud.com/` |
+| `username` | Yes | Apple ID email address (shared with CalDAV mode if both are enabled) |
+| `password` | Yes | App-specific password. Generate at https://appleid.apple.com → Security → App-Specific Passwords. |
+| `birthdays_lookahead_days` | No | How many days ahead to show birthdays. Default: `7`. |
+
+The `username` and `password` keys are shared with CalDAV calendar mode — if
+both are configured under `[calendar]`, one set of credentials serves both.
+
+## Display format
+
+```
+❤️ BIRTHDAYS
+ADAM TODAY
+BRIANNA FRI
+```
+
+Each line shows the contact's first name and either `TODAY` or a 3-letter
+weekday abbreviation (`MON`–`SUN`). Lines are sorted: today first, then
+ascending days ahead, then alphabetically by name.
+
+## Keeping data current
+
+Birthdays are read live from iCloud Contacts — no hardcoded data to maintain.
+App-specific passwords do not expire but can be revoked at
+https://appleid.apple.com → Security → App-Specific Passwords. If the
+password is revoked, generate a new one and update `config.toml`.

--- a/integrations/calendar.py
+++ b/integrations/calendar.py
@@ -25,12 +25,24 @@
 # Timed events that have already ended are excluded.
 # Events with no SUMMARY or STATUS:CANCELLED are silently skipped.
 # If no events remain after filtering, raises IntegrationDataUnavailableError.
+#
+# Birthdays mode — iCloud Contacts via CardDAV:
+#   [calendar]
+#   carddav_url = "https://contacts.icloud.com/"
+#   username = "you@icloud.com"
+#   password = "xxxx-xxxx-xxxx-xxxx"   # same app-specific password
+#   birthdays_lookahead_days = 7        # optional; default 7
+#
+# Omit carddav_url to disable birthdays entirely. get_variables_birthdays()
+# raises IntegrationDataUnavailableError immediately if carddav_url is absent.
 
 import logging
 import math
 import time
 from datetime import date, datetime, timedelta
 from typing import Any
+from urllib.parse import urljoin
+from xml.etree import ElementTree as ET  # nosec B405 — XML from authenticated Apple API
 
 import recurring_ical_events
 import requests
@@ -64,6 +76,14 @@ _ICS_CACHE_TTL = 30 * 60  # 30 minutes
 # CalDAV calendar cache: list of (caldav.Calendar, color_tag | None) pairs.
 # None = not yet populated.
 _caldav_cache: list[tuple[Any, str | None]] | None = None
+
+# CardDAV addressbook URL cache (process lifetime — URL structure never changes).
+_carddav_addressbook_url: str | None = None
+
+# Birthday contacts cache: (contacts, monotonic_fetch_time) or None.
+# contacts is a list of (first_name, month, day).
+_birthday_cache: tuple[list[tuple[str, int, int]], float] | None = None
+_BIRTHDAY_CACHE_TTL = 24 * 60 * 60  # 24 hours
 
 
 # ── Color helpers ──────────────────────────────────────────────────────────────
@@ -423,6 +443,189 @@ def _collect_candidates_caldav(
   return candidates
 
 
+# ── CardDAV / birthdays ────────────────────────────────────────────────────────
+
+
+def _parse_bday(bday_str: str) -> tuple[int, int] | None:
+  """Parse a BDAY vCard value into (month, day), or None if unparseable.
+
+  Handles: YYYY-MM-DD, YYYYMMDD, --MM-DD, --MMDD.
+  """
+  s = bday_str.strip()
+  try:
+    if s.startswith('--'):
+      digits = s[2:].replace('-', '')
+      if len(digits) == 4:
+        return int(digits[:2]), int(digits[2:])
+    elif len(s) == 10 and s[4] == '-' and s[7] == '-':
+      return int(s[5:7]), int(s[8:10])
+    elif len(s) == 8 and s.isdigit():
+      return int(s[4:6]), int(s[6:8])
+  except ValueError:
+    pass
+  return None
+
+
+def _get_addressbook_url(carddav_url: str, username: str, password: str) -> str:
+  """Discover the CardDAV addressbook URL. Cached for process lifetime.
+
+  Performs a three-step PROPFIND discovery: root → principal →
+  addressbook-home → first addressbook collection.
+  Raises IntegrationDataUnavailableError on failure.
+  """
+  global _carddav_addressbook_url
+
+  if _carddav_addressbook_url is not None:
+    logger.debug('calendar: CardDAV addressbook cache hit')
+    return _carddav_addressbook_url
+
+  auth = (username, password)
+  ns = {'d': 'DAV:', 'card': 'urn:ietf:params:xml:ns:carddav'}
+
+  try:
+    # Step 1: current-user-principal
+    r = requests.request(
+      'PROPFIND',
+      carddav_url,
+      headers={'Depth': '0', 'Content-Type': 'application/xml'},
+      data=(
+        '<?xml version="1.0" encoding="utf-8"?><propfind xmlns="DAV:"><prop><current-user-principal/></prop></propfind>'
+      ),
+      auth=auth,
+      timeout=15,
+    )
+    r.raise_for_status()
+    root = ET.fromstring(r.content)  # nosec B314 — XML from authenticated Apple API
+    principal_href = root.findtext('.//d:current-user-principal/d:href', namespaces=ns)
+    if not principal_href:
+      raise IntegrationDataUnavailableError('calendar: CardDAV principal not found')
+    principal_url = urljoin(carddav_url, principal_href)
+
+    # Step 2: addressbook-home-set
+    r = requests.request(
+      'PROPFIND',
+      principal_url,
+      headers={'Depth': '0', 'Content-Type': 'application/xml'},
+      data=(
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<propfind xmlns="DAV:" xmlns:card="urn:ietf:params:xml:ns:carddav">'
+        '<prop><card:addressbook-home-set/></prop></propfind>'
+      ),
+      auth=auth,
+      timeout=15,
+    )
+    r.raise_for_status()
+    root = ET.fromstring(r.content)  # nosec B314 — XML from authenticated Apple API
+    home_href = root.findtext('.//card:addressbook-home-set/d:href', namespaces=ns)
+    if not home_href:
+      raise IntegrationDataUnavailableError('calendar: CardDAV addressbook home not found')
+    home_url = urljoin(carddav_url, home_href)
+
+    # Step 3: first addressbook collection
+    r = requests.request(
+      'PROPFIND',
+      home_url,
+      headers={'Depth': '1', 'Content-Type': 'application/xml'},
+      data=(
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<propfind xmlns="DAV:" xmlns:card="urn:ietf:params:xml:ns:carddav">'
+        '<prop><resourcetype/></prop></propfind>'
+      ),
+      auth=auth,
+      timeout=15,
+    )
+    r.raise_for_status()
+    root = ET.fromstring(r.content)  # nosec B314 — XML from authenticated Apple API
+    addressbook_url: str | None = None
+    for resp in root.findall('d:response', ns):
+      rtype = resp.find('.//d:resourcetype', ns)
+      if rtype is not None and rtype.find('card:addressbook', ns) is not None:
+        href = resp.findtext('d:href', namespaces=ns)
+        if href:
+          addressbook_url = urljoin(home_url, href)
+          break
+    if not addressbook_url:
+      raise IntegrationDataUnavailableError('calendar: no CardDAV addressbook found')
+
+  except requests.RequestException as e:
+    raise IntegrationDataUnavailableError(f'calendar: CardDAV discovery failed — {e}') from None
+
+  logger.debug('calendar: CardDAV addressbook discovered: %r', addressbook_url)
+  _carddav_addressbook_url = addressbook_url
+  return addressbook_url
+
+
+def _fetch_birthday_contacts(
+  addressbook_url: str,
+  username: str,
+  password: str,
+) -> list[tuple[str, int, int]]:
+  """Fetch contacts with BDAY fields from a CardDAV addressbook.
+
+  Returns a list of (first_name, month, day) tuples. Results are cached
+  for _BIRTHDAY_CACHE_TTL seconds.
+  """
+  global _birthday_cache
+
+  if _birthday_cache is not None:
+    contacts, fetched_at = _birthday_cache
+    age = time.monotonic() - fetched_at
+    if age <= _BIRTHDAY_CACHE_TTL:
+      logger.debug('calendar: birthday cache hit (%.0fs old)', age)
+      return contacts
+
+  try:
+    r = requests.request(
+      'REPORT',
+      addressbook_url,
+      headers={'Depth': '1', 'Content-Type': 'application/xml'},
+      data=(
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<card:addressbook-query'
+        ' xmlns:d="DAV:" xmlns:card="urn:ietf:params:xml:ns:carddav">'
+        '<d:prop><card:address-data>'
+        '<card:prop name="FN"/><card:prop name="BDAY"/>'
+        '</card:address-data></d:prop>'
+        '</card:addressbook-query>'
+      ),
+      auth=(username, password),
+      timeout=15,
+    )
+    r.raise_for_status()
+  except requests.RequestException as e:
+    raise IntegrationDataUnavailableError(f'calendar: birthday contacts fetch failed — {e}') from None
+
+  ns = {'d': 'DAV:', 'card': 'urn:ietf:params:xml:ns:carddav'}
+  root = ET.fromstring(r.content)  # nosec B314 — XML from authenticated Apple API
+  contacts: list[tuple[str, int, int]] = []
+
+  for resp in root.findall('d:response', ns):
+    data = resp.findtext('.//card:address-data', namespaces=ns)
+    if not data:
+      continue
+    fn: str | None = None
+    bday_raw: str | None = None
+    for line in data.splitlines():
+      upper = line.upper()
+      if upper.startswith('FN:'):
+        fn = line[3:].strip()
+      elif upper.startswith('BDAY') and ':' in line:
+        bday_raw = line.split(':', 1)[1].strip()
+    if not fn or not bday_raw:
+      continue
+    parsed = _parse_bday(bday_raw)
+    if parsed is None:
+      continue
+    parts = fn.split()
+    if not parts:
+      continue
+    contacts.append((parts[0].upper(), parsed[0], parsed[1]))
+
+  logger.debug('calendar: fetched %d birthday contact(s)', len(contacts))
+  _birthday_cache = (contacts, time.monotonic())
+  return contacts
+
+
 # ── Sorting and formatting ─────────────────────────────────────────────────────
 
 
@@ -514,3 +717,57 @@ def get_variables() -> dict[str, list[list[str]]]:
     raise IntegrationDataUnavailableError('calendar: no events today')
 
   return {'events': [lines]}
+
+
+def get_variables_birthdays() -> dict[str, list[list[str]]]:
+  """Return upcoming birthdays as a variables dict for template rendering.
+
+  Returns key 'birthdays' as a single option containing one line per birthday,
+  formatted as 'FIRSTNAME TODAY' or 'FIRSTNAME MON'.
+  Requires carddav_url in [calendar] config — omit it to disable birthdays.
+  Raises IntegrationDataUnavailableError if not configured or no birthdays
+  fall within the lookahead window.
+  """
+  import config as _cfg
+
+  cal_cfg: dict[str, Any] = _cfg._config.get('calendar', {})
+  carddav_url = cal_cfg.get('carddav_url', '')
+  username = cal_cfg.get('username', '')
+  password = cal_cfg.get('password', '')
+
+  if not carddav_url:
+    raise IntegrationDataUnavailableError('calendar: birthdays require carddav_url in [calendar] config')
+  if not username or not password:
+    raise IntegrationDataUnavailableError('calendar: birthdays require username and password in [calendar] config')
+
+  lookahead = int(cal_cfg.get('birthdays_lookahead_days', 7))
+
+  tz = _display_tz()
+  now = _get_now(tz)
+  today = now.date()
+
+  addressbook_url = _get_addressbook_url(carddav_url, username, password)
+  contacts = _fetch_birthday_contacts(addressbook_url, username, password)
+
+  entries: list[tuple[int, str, str]] = []  # (days_ahead, first_name, line)
+  for first_name, month, day in contacts:
+    try:
+      candidate = today.replace(month=month, day=day)
+    except ValueError:
+      continue  # e.g. Feb 29 on a non-leap year — skip
+    if candidate < today:
+      try:
+        candidate = candidate.replace(year=today.year + 1)
+      except ValueError:
+        continue
+    days_ahead = (candidate - today).days
+    if days_ahead > lookahead:
+      continue
+    day_label = 'TODAY' if days_ahead == 0 else candidate.strftime('%a').upper()
+    entries.append((days_ahead, first_name, f'{first_name} {day_label}'))
+
+  if not entries:
+    raise IntegrationDataUnavailableError(f'calendar: no birthdays in the next {lookahead} days')
+
+  entries.sort(key=lambda x: (x[0], x[1]))
+  return {'birthdays': [[line for _, _, line in entries]]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.31.2"
+version = "0.32.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_calendar.py
+++ b/tests/core/test_calendar.py
@@ -1,3 +1,4 @@
+import time
 from datetime import datetime, timedelta, timezone
 from typing import Generator
 from unittest.mock import patch
@@ -505,3 +506,153 @@ def test_get_variables_caldav_absent_does_not_block_ics(monkeypatch: pytest.Monk
 
   lines = result['events'][0]
   assert any('ICS ONLY EVENT' in ln for ln in lines)
+
+
+# ── Birthday tests ─────────────────────────────────────────────────────────────
+
+_BDAY_CONFIG = {
+  'calendar': {
+    'carddav_url': 'https://contacts.icloud.com/',
+    'username': 'user@icloud.com',
+    'password': 'xxxx-xxxx-xxxx-xxxx',
+  },
+  'scheduler': {},
+}
+
+# Fixed date for birthday tests: Thursday 2026-01-15.
+_BDAY_TODAY = _FIXED_NOW.date()
+
+
+@pytest.fixture(autouse=True)
+def reset_birthday_caches() -> Generator[None, None, None]:
+  calendar._carddav_addressbook_url = None
+  calendar._birthday_cache = None
+  yield
+  calendar._carddav_addressbook_url = None
+  calendar._birthday_cache = None
+
+
+def _patch_birthdays(
+  monkeypatch: pytest.MonkeyPatch,
+  contacts: list[tuple[str, int, int]],
+  config: dict | None = None,
+) -> None:
+  """Patch config, birthday cache, and now for birthday unit tests."""
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', config or _BDAY_CONFIG)
+  monkeypatch.setattr(calendar, '_birthday_cache', (contacts, time.monotonic()))
+  monkeypatch.setattr(calendar, '_carddav_addressbook_url', 'https://fake/ab/')
+  monkeypatch.setattr(calendar, '_display_tz', lambda: _UTC)
+  monkeypatch.setattr(calendar, '_get_now', lambda tz: _FIXED_NOW)
+
+
+def test_birthday_formats_today(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Birthday today → 'FIRSTNAME TODAY'."""
+  _patch_birthdays(monkeypatch, [('ADAM', _BDAY_TODAY.month, _BDAY_TODAY.day)])
+  result = calendar.get_variables_birthdays()
+  assert result['birthdays'][0] == ['ADAM TODAY']
+
+
+def test_birthday_formats_day_name(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Birthday in 3 days → 'FIRSTNAME <DAY>'."""
+  target = _BDAY_TODAY + timedelta(days=3)
+  expected_day = target.strftime('%a').upper()
+  _patch_birthdays(monkeypatch, [('BRIANNA', target.month, target.day)])
+  result = calendar.get_variables_birthdays()
+  assert result['birthdays'][0] == [f'BRIANNA {expected_day}']
+
+
+def test_birthday_uses_first_name_only(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Contacts are already stored as first names — pass-through check."""
+  _patch_birthdays(monkeypatch, [('ADAM', _BDAY_TODAY.month, _BDAY_TODAY.day)])
+  result = calendar.get_variables_birthdays()
+  assert result['birthdays'][0][0].startswith('ADAM')
+
+
+def test_birthday_filters_outside_window(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Birthdays beyond lookahead_days are excluded."""
+  far = _BDAY_TODAY + timedelta(days=30)
+  _patch_birthdays(monkeypatch, [('FAR', far.month, far.day)])
+  with pytest.raises(IntegrationDataUnavailableError):
+    calendar.get_variables_birthdays()
+
+
+def test_birthday_multiple_sorted(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Multiple birthdays sorted: today first, then ascending days, then name."""
+  day3 = _BDAY_TODAY + timedelta(days=3)
+  day1 = _BDAY_TODAY + timedelta(days=1)
+  contacts = [
+    ('ZARA', day3.month, day3.day),
+    ('ADAM', _BDAY_TODAY.month, _BDAY_TODAY.day),
+    ('BLAKE', day1.month, day1.day),
+  ]
+  _patch_birthdays(monkeypatch, contacts)
+  result = calendar.get_variables_birthdays()
+  lines = result['birthdays'][0]
+  assert lines[0].startswith('ADAM')
+  assert lines[1].startswith('BLAKE')
+  assert lines[2].startswith('ZARA')
+
+
+def test_birthday_no_results_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Empty window raises IntegrationDataUnavailableError."""
+  _patch_birthdays(monkeypatch, [])
+  with pytest.raises(IntegrationDataUnavailableError):
+    calendar.get_variables_birthdays()
+
+
+def test_birthday_no_carddav_url_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Missing carddav_url raises IntegrationDataUnavailableError immediately."""
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'calendar': {}, 'scheduler': {}})
+  with pytest.raises(IntegrationDataUnavailableError, match='carddav_url'):
+    calendar.get_variables_birthdays()
+
+
+def test_birthday_cache_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Stale cache (> 24h) triggers a real HTTP fetch; fresh cache does not."""
+  from unittest.mock import MagicMock
+
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _BDAY_CONFIG)
+  monkeypatch.setattr(calendar, '_carddav_addressbook_url', 'https://fake/ab/')
+  monkeypatch.setattr(calendar, '_display_tz', lambda: _UTC)
+  monkeypatch.setattr(calendar, '_get_now', lambda tz: _FIXED_NOW)
+
+  contacts = [('ADAM', _BDAY_TODAY.month, _BDAY_TODAY.day)]
+  fresh_time = time.monotonic()
+  stale_time = fresh_time - calendar._BIRTHDAY_CACHE_TTL - 1
+
+  # Fresh cache — no HTTP request should be made.
+  monkeypatch.setattr(calendar, '_birthday_cache', (contacts, fresh_time))
+  with patch('integrations.calendar.requests.request') as mock_req:
+    calendar.get_variables_birthdays()
+    mock_req.assert_not_called()
+
+  # Stale cache — HTTP request should be made.
+  fake_response = MagicMock()
+  fake_response.content = (
+    b'<?xml version="1.0"?>'
+    b'<multistatus xmlns="DAV:" xmlns:card="urn:ietf:params:xml:ns:carddav">'
+    b'<response><href>/ab/1.vcf</href>'
+    b'<propstat><prop><card:address-data>'
+    b'FN:Adam Test\r\nBDAY:2000-01-15\r\n'
+    b'</card:address-data></prop>'
+    b'<status>HTTP/1.1 200 OK</status></propstat></response>'
+    b'</multistatus>'
+  )
+  monkeypatch.setattr(calendar, '_birthday_cache', (contacts, stale_time))
+  with patch('integrations.calendar.requests.request', return_value=fake_response):
+    calendar.get_variables_birthdays()
+
+
+def test_parse_bday_formats() -> None:
+  """_parse_bday handles all supported BDAY formats."""
+  assert calendar._parse_bday('1997-03-10') == (3, 10)
+  assert calendar._parse_bday('19970310') == (3, 10)
+  assert calendar._parse_bday('--03-10') == (3, 10)
+  assert calendar._parse_bday('--0310') == (3, 10)
+  assert calendar._parse_bday('not-a-date') is None

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -9,6 +9,7 @@ _INTEGRATION_VARS: list[tuple[str, str]] = [
   ('CALENDAR_CALDAV_URL', 'Calendar integration (CalDAV mode)'),
   ('CALENDAR_USERNAME', 'Calendar integration (CalDAV mode)'),
   ('CALENDAR_PASSWORD', 'Calendar integration (CalDAV mode)'),
+  ('CALENDAR_CARDDAV_URL', 'Calendar integration (birthdays/CardDAV mode)'),
   ('BART_API_KEY', 'BART integration'),
   ('TRAKT_CLIENT_ID', 'Trakt integration'),
   ('TRAKT_CLIENT_SECRET', 'Trakt integration'),

--- a/tests/integrations/test_calendar_integration.py
+++ b/tests/integrations/test_calendar_integration.py
@@ -5,8 +5,9 @@ Run with: uv run pytest -m integration
 Required env vars (at least one mode must be configured):
   CALENDAR_URL             — public/secret-address .ics URL (ICS mode)
   CALENDAR_CALDAV_URL      — CalDAV server URL (CalDAV mode)
-  CALENDAR_USERNAME        — CalDAV username / Apple ID
-  CALENDAR_PASSWORD        — CalDAV app-specific password
+  CALENDAR_USERNAME        — CalDAV/CardDAV username / Apple ID
+  CALENDAR_PASSWORD        — CalDAV/CardDAV app-specific password
+  CALENDAR_CARDDAV_URL     — CardDAV server URL (birthdays mode)
 """
 
 import os
@@ -23,9 +24,13 @@ from exceptions import IntegrationDataUnavailableError
 def reset_caches() -> Generator[None, None, None]:
   calendar._ics_cache.clear()
   calendar._caldav_cache = None
+  calendar._carddav_addressbook_url = None
+  calendar._birthday_cache = None
   yield
   calendar._ics_cache.clear()
   calendar._caldav_cache = None
+  calendar._carddav_addressbook_url = None
+  calendar._birthday_cache = None
 
 
 @pytest.mark.integration
@@ -74,3 +79,33 @@ def test_caldav_mode_real_icloud(require_env: None, monkeypatch: pytest.MonkeyPa
   assert lines, 'events list is empty'
   for line in lines:
     assert isinstance(line, str) and line.strip(), f'empty line in events: {lines!r}'
+
+
+@pytest.mark.integration
+@pytest.mark.require_env('CALENDAR_CARDDAV_URL', 'CALENDAR_USERNAME', 'CALENDAR_PASSWORD')
+def test_birthdays_mode_real_icloud(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+  """get_variables_birthdays() connects to real iCloud Contacts and returns valid results."""
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {
+      'calendar': {
+        'carddav_url': os.environ['CALENDAR_CARDDAV_URL'],
+        'username': os.environ['CALENDAR_USERNAME'],
+        'password': os.environ['CALENDAR_PASSWORD'],
+        'birthdays_lookahead_days': 365,
+      },
+      'scheduler': {},
+    },
+  )
+
+  result = calendar.get_variables_birthdays()
+
+  assert 'birthdays' in result
+  lines = result['birthdays'][0]
+  assert lines, 'birthdays list is empty'
+  for line in lines:
+    assert isinstance(line, str) and line.strip(), f'empty line in birthdays: {lines!r}'
+    parts = line.split()
+    assert len(parts) == 2, f'expected "FIRSTNAME DAY", got: {line!r}'  # noqa: PLR2004
+    assert parts[1] in {'TODAY', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'}, f'unexpected day label: {line!r}'

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.31.2"
+version = "0.32.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Closes #260.

## Summary
- Adds `get_variables_birthdays()` to `integrations/calendar.py`, fetching upcoming birthdays from iCloud Contacts via CardDAV (three-step PROPFIND discovery + REPORT)
- Enabled by adding `carddav_url` to `[calendar]` config; omitting it disables the feature entirely — no separate toggle needed
- Birthday contacts cached for 24h; addressbook URL cached for process lifetime
- Displays as `FIRSTNAME TODAY` or `FIRSTNAME MON` with a ❤️ BIRTHDAYS header, sorted today-first then ascending days then name
- New `content/contrib/birthdays.json` fires daily at 9:00am (after BART window, before calendar at :30)
- Reuses existing `username`/`password` from `[calendar]`; adds `CALENDAR_CARDDAV_URL` env var for integration tests

## Test plan
- [ ] Unit tests pass (`uv run pytest tests/core/test_calendar.py`)
- [ ] Integration test passes locally with real iCloud Contacts (`uv run pytest -m integration tests/integrations/test_calendar_integration.py::test_birthdays_mode_real_icloud`)
- [ ] Add `CALENDAR_CARDDAV_URL` secret to `integration` GitHub environment before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
