### PR TITLE
fix(ci): add CALENDAR_CARDDAV_URL to integration test env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
           CALENDAR_CALDAV_URL: ${{ secrets.CALENDAR_CALDAV_URL }}
           CALENDAR_USERNAME: ${{ secrets.CALENDAR_USERNAME }}
           CALENDAR_PASSWORD: ${{ secrets.CALENDAR_PASSWORD }}
+          CALENDAR_CARDDAV_URL: ${{ secrets.CALENDAR_CARDDAV_URL }}
           DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN }}
           TRAKT_CLIENT_ID: ${{ vars.TRAKT_CLIENT_ID }}
           TRAKT_CLIENT_SECRET: ${{ secrets.TRAKT_CLIENT_SECRET }}


### PR DESCRIPTION
Missing env mapping for the new `CALENDAR_CARDDAV_URL` secret added in #385 — caused `test_birthdays_mode_real_icloud` to skip in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)