### PR TITLE
fix(tests): replace call-phase skips with pass in integration tests

### DIFF
--- a/tests/integrations/test_calendar_integration.py
+++ b/tests/integrations/test_calendar_integration.py
@@ -41,15 +41,14 @@ def test_ics_mode_real_feed(require_env: None, monkeypatch: pytest.MonkeyPatch) 
 
   try:
     result = calendar.get_variables()
+    assert 'events' in result
+    assert len(result['events']) == 1
+    lines = result['events'][0]
+    assert lines, 'events list is empty'
+    for line in lines:
+      assert isinstance(line, str) and line.strip(), f'empty line in events: {lines!r}'
   except IntegrationDataUnavailableError:
-    pytest.skip('no events today in the configured calendar — not a failure')
-
-  assert 'events' in result
-  assert len(result['events']) == 1
-  lines = result['events'][0]
-  assert lines, 'events list is empty'
-  for line in lines:
-    assert isinstance(line, str) and line.strip(), f'empty line in events: {lines!r}'
+    pass  # no events today — valid outcome
 
 
 @pytest.mark.integration
@@ -71,14 +70,13 @@ def test_caldav_mode_real_icloud(require_env: None, monkeypatch: pytest.MonkeyPa
 
   try:
     result = calendar.get_variables()
+    assert 'events' in result
+    lines = result['events'][0]
+    assert lines, 'events list is empty'
+    for line in lines:
+      assert isinstance(line, str) and line.strip(), f'empty line in events: {lines!r}'
   except IntegrationDataUnavailableError:
-    pytest.skip('no events today in the CalDAV calendars — not a failure')
-
-  assert 'events' in result
-  lines = result['events'][0]
-  assert lines, 'events list is empty'
-  for line in lines:
-    assert isinstance(line, str) and line.strip(), f'empty line in events: {lines!r}'
+    pass  # no events today — valid outcome
 
 
 @pytest.mark.integration

--- a/tests/integrations/test_trakt_integration.py
+++ b/tests/integrations/test_trakt_integration.py
@@ -49,19 +49,17 @@ def test_get_variables_calendar_live(require_env: None, monkeypatch: pytest.Monk
 
   try:
     result = trakt.get_variables_calendar()
+    assert 'show_name' in result
+    assert 'episode_ref' in result
+    assert 'air_day' in result
+    assert 'air_time' in result
+    assert 'episode_title' in result
+    for key in result:
+      assert len(result[key]) == 1
+      assert len(result[key][0]) == 1
+      assert isinstance(result[key][0][0], str)
   except IntegrationDataUnavailableError:
-    pytest.skip('Calendar is empty for the lookahead window — valid outcome')
-
-  assert 'show_name' in result
-  assert 'episode_ref' in result
-  assert 'air_day' in result
-  assert 'air_time' in result
-  assert 'episode_title' in result
-
-  for key in result:
-    assert len(result[key]) == 1
-    assert len(result[key][0]) == 1
-    assert isinstance(result[key][0][0], str)
+    pass  # calendar empty for lookahead window — valid outcome
 
 
 @pytest.mark.integration


### PR DESCRIPTION
— *Claude Code*

## Summary

- `test_ics_mode_real_feed`, `test_caldav_mode_real_icloud`, and `test_get_variables_calendar_live` were calling `pytest.skip()` when the integration returned no data (no events today / empty Trakt calendar window)
- This caused those tests to show as skipped in CI on most days, making it impossible to distinguish "env var missing" skips from "no data today" skips
- Both outcomes are correct behaviour — returning data or raising `IntegrationDataUnavailableError` — so the tests now assert structure on success and silently accept the exception rather than skipping
- `test_get_variables_watching_live` and `test_get_variables_next_up_live` already used the correct pattern; no change needed there

## Test plan

- [ ] Integration job on `main` post-merge: all three previously-skipping tests now show as `PASSED` rather than `SKIPPED`