### PR TITLE
chore(ci): add TMDB_API_READ_ACCESS_TOKEN to integration test env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,5 +101,6 @@ jobs:
           DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN }}
           TRAKT_CLIENT_ID: ${{ vars.TRAKT_CLIENT_ID }}
           TRAKT_CLIENT_SECRET: ${{ secrets.TRAKT_CLIENT_SECRET }}
+          TMDB_API_READ_ACCESS_TOKEN: ${{ secrets.TMDB_API_READ_ACCESS_TOKEN }}
           TRAKT_ACCESS_TOKEN: ${{ secrets.TRAKT_ACCESS_TOKEN }}
           VESTABOARD_VIRTUAL_API_KEY: ${{ secrets.VESTABOARD_VIRTUAL_API_KEY }}


### PR DESCRIPTION
— *Claude Code*

Missed from #388 — adds the `TMDB_API_READ_ACCESS_TOKEN` env var mapping to the integration test job so the TMDb integration tests run in CI.

You'll need to add `TMDB_API_READ_ACCESS_TOKEN` as a secret on the `integration` GitHub environment (Settings → Environments → integration) before this will pick it up.