### PR TITLE
fix(plex): add debug logging for TMDb canonicalization path

### DIFF
--- a/integrations/plex.py
+++ b/integrations/plex.py
@@ -100,8 +100,13 @@ def _canonicalize_plex_title(raw_title: str, guids: list[dict[str, Any]], media_
     return raw_title
   tmdb_id = _parse_tmdb_id_from_guids(guids)
   if tmdb_id is None:
+    logger.debug('plex: no tmdb:// guid for %r, using raw title', raw_title)
     return raw_title
   canonical = _tmdb.get_show_title(tmdb_id) if media_type == 'show' else _tmdb.get_movie_title(tmdb_id)
+  if canonical:
+    logger.debug('plex: tmdb canonical %r -> %r', raw_title, canonical)
+  else:
+    logger.debug('plex: tmdb lookup failed for id=%d, using raw title %r', tmdb_id, raw_title)
   return canonical if canonical else raw_title
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.33.0"
+version = "0.33.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.33.0"
+version = "0.33.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Adds debug log lines to `_canonicalize_plex_title` so it's visible in logs which path was taken for each webhook event:
  - `plex: no tmdb:// guid for 'X', using raw title` — Plex didn't send a TMDb GUID (show unmatched or using a non-TMDb agent)
  - `plex: tmdb canonical 'X' -> 'Y'` — lookup succeeded and canonical name was applied
  - `plex: tmdb lookup failed for id=N, using raw title 'X'` — TMDb API error, fell back

Prompted by `MASTERCHEF (US)` appearing in logs without any TMDb HTTP requests, suggesting the show's Plex metadata has no `tmdb://` GUID entry.

## Test plan

- [x] `uv run pytest tests/core/test_plex.py` — 61 passed
- [x] Ruff + pyright clean