### PR TITLE
fix(plex): use TVDb episode ID to resolve canonical show title via TMDb

### DIFF
--- a/integrations/plex.py
+++ b/integrations/plex.py
@@ -74,39 +74,60 @@ def _stop_debounce() -> int:
     return 3
 
 
-def _parse_tmdb_id_from_guids(guids: list[dict[str, Any]]) -> int | None:
-  """Extract a TMDb ID from a Plex Metadata.Guid array, or None if absent."""
+def _parse_guid_id(guids: list[dict[str, Any]], scheme: str) -> int | None:
+  """Extract a numeric ID for the given scheme from a Plex Metadata.Guid array."""
   for guid in guids:
     guid_id = guid.get('id', '')
-    if guid_id.startswith('tmdb://'):
+    if guid_id.startswith(scheme):
       try:
-        return int(guid_id[len('tmdb://') :])
+        return int(guid_id[len(scheme) :])
       except ValueError:
         pass
   return None
 
 
 def _canonicalize_plex_title(raw_title: str, guids: list[dict[str, Any]], media_type: str) -> str:
-  """Return the canonical title via TMDb if configured and Guid contains a tmdb:// entry.
+  """Return the canonical title via TMDb if configured and a matching Guid is present.
 
-  Falls back to raw_title if TMDb is unconfigured, the Guid array has no TMDb
-  entry (e.g. older Plex Media Server), or the lookup fails.
+  For episodes, Plex sends episode-level external IDs in the Guid array, so
+  the tmdb:// entry is the TMDb episode ID (not the series ID). The tvdb://
+  entry is the TVDb episode ID, which TMDb's /find endpoint can resolve to the
+  TMDb series ID via the tv_episode_results[].show_id field.
 
-  media_type must be 'show' or 'movie'.
+  For movies, the tmdb:// entry is the TMDb movie ID and is used directly.
+
+  Falls back to raw_title if TMDb is unconfigured, the Guid array has no
+  usable entry, or any lookup fails.
+
+  media_type must be 'episode' or 'movie'.
   """
   import integrations.tmdb as _tmdb
 
   if not _tmdb.is_configured():
     return raw_title
-  tmdb_id = _parse_tmdb_id_from_guids(guids)
-  if tmdb_id is None:
-    logger.debug('plex: no tmdb:// guid for %r, using raw title', raw_title)
-    return raw_title
-  canonical = _tmdb.get_show_title(tmdb_id) if media_type == 'show' else _tmdb.get_movie_title(tmdb_id)
+
+  if media_type == 'episode':
+    tvdb_id = _parse_guid_id(guids, 'tvdb://')
+    if tvdb_id is None:
+      logger.debug('plex: no tvdb:// guid for episode %r, using raw title', raw_title)
+      return raw_title
+    ep_result = _tmdb.find_episode_by_tvdb_id(tvdb_id)
+    if ep_result is None:
+      logger.debug('plex: tvdb ep lookup failed for id=%d, using raw title %r', tvdb_id, raw_title)
+      return raw_title
+    _, _, _, show_id = ep_result
+    canonical = _tmdb.get_show_title(show_id)
+  else:
+    tmdb_id = _parse_guid_id(guids, 'tmdb://')
+    if tmdb_id is None:
+      logger.debug('plex: no tmdb:// guid for %r, using raw title', raw_title)
+      return raw_title
+    canonical = _tmdb.get_movie_title(tmdb_id)
+
   if canonical:
     logger.debug('plex: tmdb canonical %r -> %r', raw_title, canonical)
   else:
-    logger.debug('plex: tmdb lookup failed for id=%d, using raw title %r', tmdb_id, raw_title)
+    logger.debug('plex: tmdb lookup failed, using raw title %r', raw_title)
   return canonical if canonical else raw_title
 
 
@@ -224,7 +245,7 @@ def handle_webhook(payload: dict[str, Any], credential_name: str | None = None) 
 
     if media_type == 'episode' and metadata:
       guids: list[dict[str, Any]] = metadata.get('Guid') or []
-      raw_show = _canonicalize_plex_title(metadata['grandparentTitle'], guids, 'show')
+      raw_show = _canonicalize_plex_title(metadata['grandparentTitle'], guids, 'episode')
       show_name = _vb.truncate_line(raw_show.upper(), _vb.model.cols, 'word')
       episode_ref = _media.format_episode_ref(metadata['parentIndex'], metadata['index'])
       episode_detail = _media.strip_leading_article((metadata.get('title') or '').upper())

--- a/integrations/tmdb.py
+++ b/integrations/tmdb.py
@@ -90,12 +90,14 @@ def get_movie_title(tmdb_movie_id: int) -> str | None:
 
 
 @functools.lru_cache(maxsize=512)
-def find_episode_by_tvdb_id(tvdb_episode_id: int) -> tuple[int, int, str] | None:
-  """Return (season, episode, title) from TMDb for a TVDb episode ID.
+def find_episode_by_tvdb_id(tvdb_episode_id: int) -> tuple[int, int, str, int] | None:
+  """Return (season, episode, title, show_id) from TMDb for a TVDb episode ID.
 
   Uses TMDb's /find endpoint with external_source=tvdb_id to resolve the
   canonical TMDb season and episode numbers. This corrects Trakt's TVDb-based
   single-flat-season numbering for anime to the proper multi-season form.
+  The returned show_id is the TMDb series ID and can be passed to
+  get_show_title() to retrieve the canonical show name.
 
   Result is cached in-memory by TVDb episode ID for the lifetime of the
   process. Returns None if the lookup fails or returns no results.
@@ -114,10 +116,11 @@ def find_episode_by_tvdb_id(tvdb_episode_id: int) -> tuple[int, int, str] | None
       ep = results[0]
       season = ep.get('season_number')
       episode = ep.get('episode_number')
+      show_id = ep.get('show_id')
       title: str = ep.get('name') or ''
-      if season is not None and episode is not None:
-        logger.debug('TMDb: tvdb_ep %d → S%dE%d %r', tvdb_episode_id, season, episode, title)
-        return (season, episode, title)
+      if season is not None and episode is not None and show_id is not None:
+        logger.debug('TMDb: tvdb_ep %d → S%dE%d %r (show=%d)', tvdb_episode_id, season, episode, title, show_id)
+        return (season, episode, title, show_id)
   except Exception as e:  # noqa: BLE001
     logger.debug('TMDb: find_episode_by_tvdb_id(%d) failed — %s', tvdb_episode_id, e)
   return None

--- a/integrations/trakt.py
+++ b/integrations/trakt.py
@@ -327,7 +327,7 @@ def _canonicalize_episode(
     if tvdb_ep_id:
       resolved = _tmdb.find_episode_by_tvdb_id(int(tvdb_ep_id))
       if resolved:
-        season, number, ep_title = resolved
+        season, number, ep_title, _ = resolved
 
   show_name = _vb.truncate_line(title.upper(), _vb.model.cols, 'word')
   return show_name, season, number, ep_title

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.33.1"
+version = "0.33.2"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_plex.py
+++ b/tests/core/test_plex.py
@@ -590,8 +590,12 @@ def test_credential_name_passed() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _episode_payload_with_guid(tmdb_id: int, show: str = 'Masterchef (US)') -> dict[str, Any]:
-  """Return an episode payload that includes a Plex Metadata.Guid array."""
+def _episode_payload_with_guid(tvdb_id: int, show: str = 'MasterChef (US)') -> dict[str, Any]:
+  """Return an episode payload with a Plex Metadata.Guid array.
+
+  Reflects the real Plex Series agent structure: tmdb:// is the episode-level
+  TMDb ID (not the series ID); tvdb:// is the TVDb episode ID used for lookup.
+  """
   return {
     'event': 'media.play',
     'Metadata': {
@@ -601,8 +605,8 @@ def _episode_payload_with_guid(tmdb_id: int, show: str = 'Masterchef (US)') -> d
       'index': 3,
       'title': 'The Dish',
       'Guid': [
-        {'id': f'tmdb://{tmdb_id}'},
-        {'id': 'tvdb://12345'},
+        {'id': 'tmdb://1800938'},  # episode-level TMDb ID — not the series ID
+        {'id': f'tvdb://{tvdb_id}'},
       ],
     },
   }
@@ -621,53 +625,58 @@ def _movie_payload_with_guid(tmdb_id: int, title: str = 'Inception') -> dict[str
 
 
 def test_handle_webhook_episode_uses_tmdb_canonical_show_name(monkeypatch: pytest.MonkeyPatch) -> None:
-  """When TMDb is configured and Guid is present, show_name uses the canonical TMDb title."""
+  """TVDb episode ID → find_episode_by_tvdb_id → show_id → get_show_title."""
   monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
-  calls: list[int] = []
+  # find returns (season, episode, title, show_id=40290)
+  monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: (1, 3, 'The Dish', 40290))
+  show_calls: list[int] = []
 
   def _mock_get_show_title(tmdb_id: int) -> str:
-    calls.append(tmdb_id)
+    show_calls.append(tmdb_id)
     return 'MasterChef'
 
   monkeypatch.setattr(_tmdb, 'get_show_title', _mock_get_show_title)
-  result = _plex.handle_webhook(_episode_payload_with_guid(tmdb_id=70814, show='Masterchef (US)'))
+  result = _plex.handle_webhook(_episode_payload_with_guid(tvdb_id=8765432, show='MasterChef (US)'))
 
   assert result is not None
-  assert calls == [70814]
+  assert show_calls == [40290]
   assert result.data['variables']['show_name'] == [['MASTERCHEF']]
 
 
 def test_handle_webhook_episode_falls_back_when_no_guid(monkeypatch: pytest.MonkeyPatch) -> None:
-  """When the payload has no Guid array, falls back to grandparentTitle."""
+  """When the payload has no Guid array, no TMDb lookup is attempted."""
   monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
-  calls: list[int] = []
+  find_calls: list[int] = []
+  monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: find_calls.append(tvdb_id) or None)
 
-  def _mock_get_show_title(tmdb_id: int) -> str | None:
-    calls.append(tmdb_id)
-    return None
-
-  monkeypatch.setattr(_tmdb, 'get_show_title', _mock_get_show_title)
   result = _plex.handle_webhook(_episode_payload('media.play', show='Masterchef'))
 
   assert result is not None
-  assert calls == []
+  assert find_calls == []
   assert result.data['variables']['show_name'] == [['MASTERCHEF']]
 
 
-def test_handle_webhook_episode_falls_back_when_tmdb_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
-  """When TMDb is not configured, falls back to grandparentTitle even with Guid."""
-  monkeypatch.setattr(_cfg, '_config', {})
-  calls: list[int] = []
+def test_handle_webhook_episode_falls_back_when_find_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+  """When find_episode_by_tvdb_id returns None, falls back to grandparentTitle."""
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: None)
 
-  def _mock_get_show_title(tmdb_id: int) -> str | None:
-    calls.append(tmdb_id)
-    return None
-
-  monkeypatch.setattr(_tmdb, 'get_show_title', _mock_get_show_title)
-  result = _plex.handle_webhook(_episode_payload_with_guid(tmdb_id=70814, show='Masterchef'))
+  result = _plex.handle_webhook(_episode_payload_with_guid(tvdb_id=12345, show='Clue'))
 
   assert result is not None
-  assert calls == []
+  assert result.data['variables']['show_name'] == [['CLUE']]
+
+
+def test_handle_webhook_episode_falls_back_when_tmdb_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
+  """When TMDb is not configured, no lookup is attempted even with Guid."""
+  monkeypatch.setattr(_cfg, '_config', {})
+  find_calls: list[int] = []
+  monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: find_calls.append(tvdb_id) or None)
+
+  result = _plex.handle_webhook(_episode_payload_with_guid(tvdb_id=8765432, show='Masterchef'))
+
+  assert result is not None
+  assert find_calls == []
   assert result.data['variables']['show_name'] == [['MASTERCHEF']]
 
 

--- a/tests/core/test_tmdb.py
+++ b/tests/core/test_tmdb.py
@@ -119,13 +119,13 @@ def test_find_episode_by_tvdb_id_returns_season_episode_title(monkeypatch: pytes
   mock_r = MagicMock()
   mock_r.status_code = 200
   mock_r.json.return_value = {
-    'tv_episode_results': [{'season_number': 4, 'episode_number': 16, 'name': 'Above and Below'}]
+    'tv_episode_results': [{'season_number': 4, 'episode_number': 16, 'name': 'Above and Below', 'show_id': 1429}]
   }
 
   with patch('integrations.tmdb.fetch_with_retry', return_value=mock_r):
     result = tmdb.find_episode_by_tvdb_id(8765432)
 
-  assert result == (4, 16, 'Above and Below')
+  assert result == (4, 16, 'Above and Below', 1429)
 
 
 def test_find_episode_by_tvdb_id_returns_none_on_empty_results(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -159,9 +159,11 @@ def test_find_episode_by_tvdb_id_empty_title_returns_empty_string(monkeypatch: p
   monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   mock_r = MagicMock()
   mock_r.status_code = 200
-  mock_r.json.return_value = {'tv_episode_results': [{'season_number': 2, 'episode_number': 3, 'name': None}]}
+  mock_r.json.return_value = {
+    'tv_episode_results': [{'season_number': 2, 'episode_number': 3, 'name': None, 'show_id': 999}]
+  }
 
   with patch('integrations.tmdb.fetch_with_retry', return_value=mock_r):
     result = tmdb.find_episode_by_tvdb_id(1111111)
 
-  assert result == (2, 3, '')
+  assert result == (2, 3, '', 999)

--- a/tests/core/test_trakt.py
+++ b/tests/core/test_trakt.py
@@ -622,7 +622,7 @@ def test_canonicalize_episode_with_tmdb_uses_canonical_data(monkeypatch: pytest.
 
   with (
     patch('integrations.tmdb.get_show_title', return_value='Attack on Titan') as mock_show,
-    patch('integrations.tmdb.find_episode_by_tvdb_id', return_value=(4, 16, 'Above and Below')) as mock_ep,
+    patch('integrations.tmdb.find_episode_by_tvdb_id', return_value=(4, 16, 'Above and Below', 1429)) as mock_ep,
   ):
     show_name, season, number, ep_title = trakt._canonicalize_episode(show_data, ep_data)  # noqa: SLF001
 

--- a/tests/integrations/test_tmdb_integration.py
+++ b/tests/integrations/test_tmdb_integration.py
@@ -55,12 +55,13 @@ def test_get_movie_title_live(require_env: None, monkeypatch: pytest.MonkeyPatch
 @pytest.mark.integration
 @pytest.mark.require_env('TMDB_API_READ_ACCESS_TOKEN')
 def test_find_episode_by_tvdb_id_live(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
-  """find_episode_by_tvdb_id() returns a valid (season, episode, title) tuple."""
+  """find_episode_by_tvdb_id() returns a valid (season, episode, title, show_id) tuple."""
   _patch_config(monkeypatch)
   # TVDb episode ID 5073066 = Attack on Titan S4E16 in TMDb ordering
   result = tmdb.find_episode_by_tvdb_id(5073066)
   if result is not None:
-    season, episode, title = result
+    season, episode, title, show_id = result
     assert isinstance(season, int) and season > 0
     assert isinstance(episode, int) and episode > 0
     assert isinstance(title, str)
+    assert isinstance(show_id, int) and show_id > 0

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.33.1"
+version = "0.33.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- **Root cause**: With the Plex Series agent, `Metadata.Guid` contains episode-level external IDs. The `tmdb://` entry is the TMDb *episode* ID (e.g. `tmdb://1800938`), not the series ID — so calling `get_show_title()` on it returns 404.
- **Fix**: For episodes, parse `tvdb://` from the Guid array instead and call `find_episode_by_tvdb_id()`, which uses TMDb's `/find` endpoint and returns `(season, episode, title, show_id)`. The `show_id` is the TMDb series ID, which is then passed to `get_show_title()`.
- **`find_episode_by_tvdb_id` return type** extended from `(season, episode, title)` to `(season, episode, title, show_id)` — `show_id` comes from `tv_episode_results[0].show_id` in the `/find` response. All callers updated.
- `_parse_tmdb_id_from_guids` replaced by `_parse_guid_id(guids, scheme)` to handle both `tmdb://` and `tvdb://` prefixes.

Observed in logs: `tmdb://1800938` → `GET /3/tv/1800938` → 404, `plex: tmdb lookup failed for id=1800938, using raw title 'MasterChef (US)'`.

## Test plan

- [x] `uv run pytest` — 734 passed
- [x] Live test: `find_episode_by_tvdb_id(8085638)` → `(4, 16, 'Above and Below', 1429)`, `get_show_title(1429)` → `'Attack on Titan'`
- [x] Ruff + pyright clean
