### PR TITLE
feat(calendar): self-birthday detection via iCloud me-card

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Key `[scheduler]` settings:
 |---|---|---|
 | `model` | `"note"` | Display model: `"note"` (3×15) or `"flagship"` (6×22) |
 | `public` | `false` | When `true`, skip templates marked `private = true` (for shared/guest-visible spaces) |
-| `content_enabled` | _(absent)_ | Content filter for both `user/` and `contrib/`: absent = all user loads, no contrib; `["*"]` = all user + all contrib; `["bart", "my_quotes"]` = only matching stems from either directory |
+| `content_enabled` | _(absent)_ | Content filter for cron-scheduled templates in both `user/` and `contrib/`: absent = all user loads, no contrib; `["*"]` = all user + all contrib; `["bart", "my_quotes"]` = only matching stems from either directory. **Webhook-only integrations (`plex`, `message`, `notion`) are unaffected — their webhooks fire regardless of this setting.** |
 | `timezone` | system TZ | IANA timezone for cron job scheduling (e.g. `"America/Los_Angeles"`) |
 | `min_hold` | `60` | Minimum seconds any message stays on display before a high-priority (≥8) queued message can interrupt it. Set to `0` to disable (not recommended for physical displays). |
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -90,6 +90,7 @@ city = "San Francisco"
 # CardDAV mode — iCloud Contacts birthdays (birthdays.json).
 # Uses the same username and password as CalDAV mode above.
 # Omit carddav_url to disable the birthdays integration entirely.
+# The self-birthday template (birthdays.json/self) requires iCloud CardDAV.
 # carddav_url = "https://contacts.icloud.com/"
 # birthdays_lookahead_days = 7  # optional; default: 7
 

--- a/content/README.md
+++ b/content/README.md
@@ -30,6 +30,11 @@ content_enabled = ["my_quotes"]      # only my_quotes.json from content/user/
 When the key is absent, user files always load and no contrib files load.
 When the key is set, the filter applies to both `user/` and `contrib/`.
 
+This filter only affects **cron-scheduled** templates. Webhook-only
+integrations (`plex`, `message`, `notion`) route incoming webhook events
+directly through the webhook listener — their `.json` files never need to be
+in `content_enabled` for webhooks to work.
+
 ## Content file format
 
 Each JSON file can contain multiple named templates, each with its own
@@ -239,7 +244,7 @@ Don't inflate priority to "win" — see the priority guidelines above.
 |---|---|
 | [`weather.json`](contrib/weather.md) | Current weather conditions via Open-Meteo |
 | [`calendar.json`](contrib/calendar.md) | Today's calendar events (ICS and iCloud CalDAV) |
-| [`birthdays.json`](contrib/birthdays.md) | Upcoming birthdays from iCloud Contacts |
+| [`birthdays.json`](contrib/birthdays.md) | Upcoming birthdays from iCloud Contacts; prominent self-birthday display |
 | [`bart.json`](contrib/bart.md) | BART real-time departure board |
 | [`discogs.json`](contrib/discogs.md) | Daily vinyl suggestion from your Discogs collection |
 | [`trakt.json`](contrib/trakt.md) | Trakt.tv upcoming calendar and now-playing |

--- a/content/contrib/birthdays.json
+++ b/content/contrib/birthdays.json
@@ -18,6 +18,25 @@
           ]
         }
       ]
+    },
+    "self": {
+      "schedule": {
+        "cron": "0 8 * * *",
+        "hold": 3600,
+        "timeout": 7200
+      },
+      "priority": 9,
+      "truncation": "word",
+      "integration": "calendar",
+      "integration_fn": "get_variables_self_birthday",
+      "templates": [
+        {
+          "format": [
+            "HAPPY BIRTHDAY",
+            "{name}! \u2764\ufe0f"
+          ]
+        }
+      ]
     }
   }
 }

--- a/content/contrib/birthdays.md
+++ b/content/contrib/birthdays.md
@@ -1,15 +1,15 @@
 # birthdays.json
 
-Upcoming birthdays from iCloud Contacts, shown once daily at 9am. Displays
-contacts whose birthday falls today or within the lookahead window, one per
-line. Requires the same iCloud app-specific password as the CalDAV calendar
-integration.
+Two birthday templates, both requiring iCloud CardDAV:
 
-Omit `carddav_url` from `[calendar]` to disable this integration entirely.
+- **`today`** — upcoming birthdays from contacts, shown once daily at 9am
+- **`self`** — prominent happy birthday display on the board owner's own
+  birthday, shown at 8am (priority 9). The owner is suppressed from the
+  `today` list — their birthday is shown exclusively via `self`.
+
+Omit `carddav_url` from `[calendar]` to disable both templates entirely.
 
 ## Configuration
-
-Add the following to your `[calendar]` section in `config.toml`:
 
 ```toml
 [calendar]
@@ -24,13 +24,18 @@ password = "xxxx-xxxx-xxxx-xxxx"
 | `carddav_url` | Yes | CardDAV server URL. iCloud: `https://contacts.icloud.com/` |
 | `username` | Yes | Apple ID email address (shared with CalDAV mode if both are enabled) |
 | `password` | Yes | App-specific password. Generate at https://appleid.apple.com → Security → App-Specific Passwords. |
-| `birthdays_lookahead_days` | No | How many days ahead to show birthdays. Default: `7`. |
+| `birthdays_lookahead_days` | No | How many days ahead to show birthdays in `today`. Default: `7`. |
 
 The `username` and `password` keys are shared with CalDAV calendar mode — if
 both are configured under `[calendar]`, one set of credentials serves both.
 
+The `self` template requires iCloud CardDAV specifically — it uses Apple's
+CalendarServer me-card extension (`{http://calendarserver.org/ns/}me-card`)
+to identify the board owner. See issue #393 for planned Google support.
+
 ## Display format
 
+**`today` template:**
 ```
 ❤️ BIRTHDAYS
 ADAM TODAY
@@ -40,6 +45,15 @@ BRIANNA FRI
 Each line shows the contact's first name and either `TODAY` or a 3-letter
 weekday abbreviation (`MON`–`SUN`). Lines are sorted: today first, then
 ascending days ahead, then alphabetically by name.
+
+**`self` template:**
+```
+HAPPY BIRTHDAY
+YOURNAME! ❤️
+```
+
+On the Note (3×15), both lines fit for most first names. If your name and `!`
+fill the full row, `❤️` wraps to row 3.
 
 ## Keeping data current
 

--- a/content/contrib/message.md
+++ b/content/contrib/message.md
@@ -25,12 +25,9 @@ and color automatically.
 
 ## Configuration
 
-Enable the webhook listener and message content:
+Enable the webhook listener:
 
 ```toml
-[scheduler]
-content_enabled = ["message"]
-
 [webhook]
 ```
 

--- a/content/contrib/notion.md
+++ b/content/contrib/notion.md
@@ -18,12 +18,9 @@ directly to the webhook listener. You only need:
 
 ## Configuration
 
-Enable the webhook listener and the notion content, and create a named credential:
+Enable the webhook listener and create a named credential:
 
 ```toml
-[scheduler]
-content_enabled = ["notion"]
-
 [webhook]
 
 [webhook.credentials.notion]

--- a/content/contrib/plex.md
+++ b/content/contrib/plex.md
@@ -15,12 +15,9 @@ must have an active Plex Pass subscription to send webhooks.
 
 ## Configuration
 
-Enable the webhook listener and the plex content, and create a named credential:
+Enable the webhook listener and create a named credential:
 
 ```toml
-[scheduler]
-content_enabled = ["plex"]
-
 [webhook]
 # Bind to 0.0.0.0 so Plex (which may run in a separate container) can reach it.
 # port defaults to 8080 (container-internal); map it to a host port in Docker/Unraid.

--- a/integrations/calendar.py
+++ b/integrations/calendar.py
@@ -80,10 +80,17 @@ _caldav_cache: list[tuple[Any, str | None]] | None = None
 # CardDAV addressbook URL cache (process lifetime — URL structure never changes).
 _carddav_addressbook_url: str | None = None
 
+# CardDAV home URL cache (process lifetime — populated alongside addressbook URL).
+_carddav_home_url: str | None = None
+
 # Birthday contacts cache: (contacts, monotonic_fetch_time) or None.
 # contacts is a list of (first_name, month, day).
 _birthday_cache: tuple[list[tuple[str, int, int]], float] | None = None
 _BIRTHDAY_CACHE_TTL = 24 * 60 * 60  # 24 hours
+
+# Self contact cache: (first_name, month, day) or None (process lifetime).
+# Populated by _resolve_self_contact(); BDAY never changes in practice.
+_self_contact_cache: tuple[str, int, int] | None = None
 
 
 # ── Color helpers ──────────────────────────────────────────────────────────────
@@ -473,7 +480,7 @@ def _get_addressbook_url(carddav_url: str, username: str, password: str) -> str:
   addressbook-home → first addressbook collection.
   Raises IntegrationDataUnavailableError on failure.
   """
-  global _carddav_addressbook_url
+  global _carddav_addressbook_url, _carddav_home_url
 
   if _carddav_addressbook_url is not None:
     logger.debug('calendar: CardDAV addressbook cache hit')
@@ -551,6 +558,7 @@ def _get_addressbook_url(carddav_url: str, username: str, password: str) -> str:
     raise IntegrationDataUnavailableError(f'calendar: CardDAV discovery failed — {e}') from None
 
   logger.debug('calendar: CardDAV addressbook discovered: %r', addressbook_url)
+  _carddav_home_url = home_url
   _carddav_addressbook_url = addressbook_url
   return addressbook_url
 
@@ -624,6 +632,92 @@ def _fetch_birthday_contacts(
   logger.debug('calendar: fetched %d birthday contact(s)', len(contacts))
   _birthday_cache = (contacts, time.monotonic())
   return contacts
+
+
+def _resolve_self_contact(
+  carddav_url: str,
+  username: str,
+  password: str,
+) -> tuple[str, int, int] | None:
+  """Resolve the owner's contact as (first_name, birth_month, birth_day).
+
+  Uses the CalendarServer me-card extension: PROPFIND on the CardDAV home
+  with {http://calendarserver.org/ns/}me-card to get the self vCard href,
+  then GET the vCard and parse FN and BDAY.
+
+  Returns None on any failure (property absent, server doesn't support the
+  extension, network error, no BDAY set). Caches for process lifetime.
+  Only supported for iCloud (calendarserver.org extension required).
+  """
+  global _self_contact_cache
+
+  if _self_contact_cache is not None:
+    return _self_contact_cache
+
+  try:
+    # Ensure home URL is populated (triggers discovery if not yet done).
+    _get_addressbook_url(carddav_url, username, password)
+    if not _carddav_home_url:
+      return None
+
+    auth = (username, password)
+    ns = {
+      'd': 'DAV:',
+      'cs': 'http://calendarserver.org/ns/',
+    }
+
+    # Step 1: PROPFIND home for me-card href.
+    r = requests.request(
+      'PROPFIND',
+      _carddav_home_url,
+      headers={'Depth': '0', 'Content-Type': 'application/xml'},
+      data=(
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<propfind xmlns="DAV:" xmlns:cs="http://calendarserver.org/ns/">'
+        '<prop><cs:me-card/></prop></propfind>'
+      ),
+      auth=auth,
+      timeout=15,
+    )
+    r.raise_for_status()
+    root = ET.fromstring(r.content)  # nosec B314 — XML from authenticated Apple API
+    me_card_href = root.findtext('.//cs:me-card/d:href', namespaces=ns)
+    if not me_card_href:
+      logger.debug('calendar: me-card property absent — self-birthday unavailable')
+      return None
+
+    vcard_url = urljoin(_carddav_home_url, me_card_href)
+
+    # Step 2: GET the self vCard.
+    r = requests.get(vcard_url, auth=auth, timeout=15)
+    r.raise_for_status()
+
+    fn: str | None = None
+    bday_raw: str | None = None
+    for line in r.text.splitlines():
+      upper = line.upper()
+      if upper.startswith('FN:'):
+        fn = line[3:].strip()
+      elif upper.startswith('BDAY') and ':' in line:
+        bday_raw = line.split(':', 1)[1].strip()
+
+    if not fn or not bday_raw:
+      logger.debug('calendar: me-card missing FN or BDAY — self-birthday unavailable')
+      return None
+
+    parsed = _parse_bday(bday_raw)
+    if parsed is None:
+      logger.debug('calendar: me-card BDAY unparseable — self-birthday unavailable')
+      return None
+
+    first_name = fn.split()[0].upper()
+    _self_contact_cache = (first_name, parsed[0], parsed[1])
+    logger.debug('calendar: self contact resolved')
+    return _self_contact_cache
+
+  except Exception:  # noqa: BLE001  # nosec B112 — broad catch; me-card is best-effort
+    logger.debug('calendar: me-card discovery failed — self-birthday unavailable')
+    return None
 
 
 # ── Sorting and formatting ─────────────────────────────────────────────────────
@@ -749,8 +843,12 @@ def get_variables_birthdays() -> dict[str, list[list[str]]]:
   addressbook_url = _get_addressbook_url(carddav_url, username, password)
   contacts = _fetch_birthday_contacts(addressbook_url, username, password)
 
+  self_contact = _resolve_self_contact(carddav_url, username, password)
+
   entries: list[tuple[int, str, str]] = []  # (days_ahead, first_name, line)
   for first_name, month, day in contacts:
+    if self_contact and (first_name, month, day) == self_contact:
+      continue  # shown exclusively via birthday_self.json
     try:
       candidate = today.replace(month=month, day=day)
     except ValueError:
@@ -771,3 +869,44 @@ def get_variables_birthdays() -> dict[str, list[list[str]]]:
 
   entries.sort(key=lambda x: (x[0], x[1]))
   return {'birthdays': [[line for _, _, line in entries]]}
+
+
+def get_variables_self_birthday() -> dict[str, list[list[str]]]:
+  """Return the owner's first name when today is their birthday.
+
+  Returns key 'name' for use in birthday_self.json format strings.
+  Requires carddav_url in [calendar] config and iCloud CardDAV (me-card
+  CalendarServer extension). Raises IntegrationDataUnavailableError when
+  not configured, me-card unavailable, or today is not the owner's birthday.
+  """
+  import config as _cfg
+
+  cal_cfg: dict[str, Any] = _cfg._config.get('calendar', {})
+  carddav_url = cal_cfg.get('carddav_url', '')
+  username = cal_cfg.get('username', '')
+  password = cal_cfg.get('password', '')
+
+  if not carddav_url:
+    raise IntegrationDataUnavailableError('calendar: self-birthday requires carddav_url in [calendar] config')
+  if not username or not password:
+    raise IntegrationDataUnavailableError('calendar: self-birthday requires username and password in [calendar] config')
+
+  self_contact = _resolve_self_contact(carddav_url, username, password)
+  if self_contact is None:
+    raise IntegrationDataUnavailableError('calendar: self contact could not be resolved (iCloud me-card required)')
+
+  first_name, month, day = self_contact
+
+  tz = _display_tz()
+  now = _get_now(tz)
+  today = now.date()
+
+  try:
+    birthday_this_year = today.replace(month=month, day=day)
+  except ValueError:
+    raise IntegrationDataUnavailableError('calendar: self birthday (Feb 29) skipped on non-leap year') from None
+
+  if today != birthday_this_year:
+    raise IntegrationDataUnavailableError("calendar: today is not the owner's birthday")
+
+  return {'name': [[first_name]]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.33.2"
+version = "0.34.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_calendar.py
+++ b/tests/core/test_calendar.py
@@ -526,10 +526,14 @@ _BDAY_TODAY = _FIXED_NOW.date()
 @pytest.fixture(autouse=True)
 def reset_birthday_caches() -> Generator[None, None, None]:
   calendar._carddav_addressbook_url = None
+  calendar._carddav_home_url = None
   calendar._birthday_cache = None
+  calendar._self_contact_cache = None
   yield
   calendar._carddav_addressbook_url = None
+  calendar._carddav_home_url = None
   calendar._birthday_cache = None
+  calendar._self_contact_cache = None
 
 
 def _patch_birthdays(
@@ -656,3 +660,151 @@ def test_parse_bday_formats() -> None:
   assert calendar._parse_bday('--03-10') == (3, 10)
   assert calendar._parse_bday('--0310') == (3, 10)
   assert calendar._parse_bday('not-a-date') is None
+
+
+# ── Self-birthday tests ────────────────────────────────────────────────────────
+
+_SELF_BDAY_TODAY = _BDAY_TODAY  # reuse the fixed date: 2026-01-15
+
+# Minimal vCard for the self contact, with BDAY matching _SELF_BDAY_TODAY.
+_SELF_VCARD = (
+  'BEGIN:VCARD\r\n'
+  'VERSION:3.0\r\n'
+  'FN:Alex Smith\r\n'
+  f'BDAY;value=date:{_SELF_BDAY_TODAY.year}-{_SELF_BDAY_TODAY.month:02d}-{_SELF_BDAY_TODAY.day:02d}\r\n'
+  'END:VCARD\r\n'
+)
+
+_SELF_ME_CARD_PROPFIND_RESPONSE = (
+  '<?xml version="1.0"?>'
+  '<multistatus xmlns="DAV:">'
+  '<response><href>/home/</href>'
+  '<propstat><prop>'
+  '<me-card xmlns="http://calendarserver.org/ns/">'
+  '<href xmlns="DAV:">/home/card/self.vcf</href>'
+  '</me-card>'
+  '</prop><status>HTTP/1.1 200 OK</status></propstat>'
+  '</response>'
+  '</multistatus>'
+)
+
+
+def _patch_self_birthday(
+  monkeypatch: pytest.MonkeyPatch,
+  vcard_text: str = _SELF_VCARD,
+  config: dict | None = None,
+) -> None:
+  """Patch config, home URL, and _get_now for self-birthday unit tests.
+
+  Mocks the me-card PROPFIND and vCard GET so no real HTTP is made.
+  """
+  from unittest.mock import MagicMock
+
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', config or _BDAY_CONFIG)
+  monkeypatch.setattr(calendar, '_carddav_addressbook_url', 'https://fake/ab/')
+  monkeypatch.setattr(calendar, '_carddav_home_url', 'https://fake/home/')
+  monkeypatch.setattr(calendar, '_display_tz', lambda: _UTC)
+  monkeypatch.setattr(calendar, '_get_now', lambda tz: _FIXED_NOW)
+
+  propfind_resp = MagicMock()
+  propfind_resp.content = _SELF_ME_CARD_PROPFIND_RESPONSE.encode()
+  propfind_resp.raise_for_status = lambda: None
+
+  vcard_resp = MagicMock()
+  vcard_resp.text = vcard_text
+  vcard_resp.raise_for_status = lambda: None
+
+  def _mock_request(method: str, url: str, **kwargs: object) -> MagicMock:
+    if method == 'PROPFIND':
+      return propfind_resp
+    return vcard_resp
+
+  monkeypatch.setattr(calendar.requests, 'request', _mock_request)
+  monkeypatch.setattr(calendar.requests, 'get', lambda url, **kw: vcard_resp)
+
+
+def test_self_birthday_today(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Birthday matches today → returns {'name': [['ALEX']]}."""
+  _patch_self_birthday(monkeypatch)
+  result = calendar.get_variables_self_birthday()
+  assert result == {'name': [['ALEX']]}
+
+
+def test_self_birthday_not_today(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Birthday is not today → raises IntegrationDataUnavailableError."""
+  tomorrow = _SELF_BDAY_TODAY + timedelta(days=1)
+  vcard = (
+    'BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Alex Smith\r\n'
+    f'BDAY;value=date:{tomorrow.year}-{tomorrow.month:02d}-{tomorrow.day:02d}\r\n'
+    'END:VCARD\r\n'
+  )
+  _patch_self_birthday(monkeypatch, vcard_text=vcard)
+  with pytest.raises(IntegrationDataUnavailableError, match='not the owner'):
+    calendar.get_variables_self_birthday()
+
+
+def test_self_birthday_no_carddav_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Missing carddav_url → raises immediately."""
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'calendar': {}, 'scheduler': {}})
+  with pytest.raises(IntegrationDataUnavailableError, match='carddav_url'):
+    calendar.get_variables_self_birthday()
+
+
+def test_self_birthday_no_bday_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+  """me-card vCard has no BDAY → raises."""
+  vcard = 'BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Alex Smith\r\nEND:VCARD\r\n'
+  _patch_self_birthday(monkeypatch, vcard_text=vcard)
+  with pytest.raises(IntegrationDataUnavailableError, match='could not be resolved'):
+    calendar.get_variables_self_birthday()
+
+
+def test_self_birthday_cache_hit(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Cached self contact is returned without any HTTP request."""
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _BDAY_CONFIG)
+  monkeypatch.setattr(calendar, '_display_tz', lambda: _UTC)
+  monkeypatch.setattr(calendar, '_get_now', lambda tz: _FIXED_NOW)
+  monkeypatch.setattr(
+    calendar,
+    '_self_contact_cache',
+    ('ALEX', _SELF_BDAY_TODAY.month, _SELF_BDAY_TODAY.day),
+  )
+  with patch('integrations.calendar.requests.request') as mock_req:
+    result = calendar.get_variables_self_birthday()
+    mock_req.assert_not_called()
+  assert result == {'name': [['ALEX']]}
+
+
+def test_self_birthday_me_card_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Full me-card PROPFIND + vCard GET path populates _self_contact_cache."""
+  _patch_self_birthday(monkeypatch)
+  assert calendar._self_contact_cache is None
+  calendar.get_variables_self_birthday()
+  assert calendar._self_contact_cache == ('ALEX', _SELF_BDAY_TODAY.month, _SELF_BDAY_TODAY.day)
+
+
+def test_birthdays_suppresses_self(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Self contact is excluded from get_variables_birthdays() results."""
+  # Pre-populate self contact cache so _resolve_self_contact() returns it.
+  monkeypatch.setattr(
+    calendar,
+    '_self_contact_cache',
+    ('ALEX', _SELF_BDAY_TODAY.month, _SELF_BDAY_TODAY.day),
+  )
+  # Contacts include self (ALEX) and one other (BLAKE, also today).
+  _patch_birthdays(
+    monkeypatch,
+    [
+      ('ALEX', _SELF_BDAY_TODAY.month, _SELF_BDAY_TODAY.day),
+      ('BLAKE', _SELF_BDAY_TODAY.month, _SELF_BDAY_TODAY.day),
+    ],
+  )
+  result = calendar.get_variables_birthdays()
+  names = [line.split()[0] for line in result['birthdays'][0]]
+  assert 'ALEX' not in names
+  assert 'BLAKE' in names

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.33.2"
+version = "0.34.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- Adds `get_variables_self_birthday()` to `integrations/calendar.py` using the CalendarServer `{http://calendarserver.org/ns/}me-card` CardDAV extension to resolve the board owner's contact and birthday unambiguously (iCloud only; see #393 for planned Google support)
- Adds a `self` template to `content/contrib/birthdays.json` (alongside the existing `today` template) — fires at priority 9 on the owner's birthday, holds for 1 hour
- Suppresses the owner's own birthday from the regular `today` upcoming list — shown exclusively via the `self` display
- Caches `_carddav_home_url` and `_self_contact_cache` at process lifetime; me-card resolution is best-effort (failure returns `None` and gracefully skips filtering/raising)
- Fixes docs for webhook-only integrations (`plex`, `message`, `notion`): `content_enabled` is not required — webhook routing is independent of content file loading

Closes #392

## Test plan

- [ ] 7 new unit tests in `tests/core/test_calendar.py` covering: today match, not-today skip, no CardDAV config, no BDAY, cache hit, me-card discovery path, and self suppression from birthdays list
- [ ] All 741 tests pass
- [ ] Full check suite clean (ruff, pyright, bandit, pip-audit, pre-commit)
- [ ] Live Vestaboard test sent and visually confirmed before PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
