### PR TITLE
feat(dive_conditions): scuba diving conditions via NOAA NDBC

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -151,6 +151,32 @@ client_secret = "your-trakt-client-secret"
 # Optional: number of days ahead to show in the calendar (default 7, max 33)
 # calendar_days = 7
 
+[dive_conditions]
+# Scuba diving conditions — wave height, swell period, wind, and water temperature.
+# Shows at 7:15am, 12:15pm, and 4:15pm. Color square in the header reflects
+# subjective dive condition quality (green/yellow/red).
+
+# NDBC buoy station ID (recommended for US coastal sites — real measured data).
+# Find your nearest station at https://www.ndbc.noaa.gov/
+# Example: 46042 = Monterey offshore buoy (27 NM WNW of Monterey, CA)
+# ndbc_station_id = "46042"
+
+# Open-Meteo fallback — use instead of ndbc_station_id for non-US sites or
+# locations without a nearby buoy. Accuracy near complex coastlines is limited.
+# latitude = 36.6
+# longitude = -121.9
+
+# Unit system: "imperial" (ft, °F, default) or "metric" (m, °C).
+# Wind is always displayed in knots regardless of this setting.
+# units = "imperial"
+
+# [dive_conditions.schedules.conditions]
+# cron = "15 7,12,16 * * *"
+# hold = 600
+# timeout = 1800
+# priority = 5
+# refresh_interval = 1800
+
 [tmdb]
 # Optional: canonical media metadata authority for the Plex and Trakt integrations.
 # When set, show/movie titles are resolved to their TMDb canonical form and Trakt

--- a/content/README.md
+++ b/content/README.md
@@ -178,6 +178,7 @@ template to keep everything playing nicely together.
 | Slot | Integration | Pri | Hold | Timeout | Notes |
 |---|---|---|---|---|---|
 | `:00` every hour | `weather` | 5 | 600s | 1800s | |
+| `:15` 07/12/16 | `dive_conditions` | 5 | 600s | 1800s | Refresh 1800s; avoids :00 weather slot |
 | `:00` every 4h | `trakt.calendar` | 4 | 1200s | 1800s | Private; queues behind weather |
 | `:30` every hour | `calendar` | 5 | 300s | 1800s | |
 | `8:30` daily | `discogs` | 5 | 600s | 3600s | Queues behind calendar at :30 |
@@ -252,3 +253,4 @@ Don't inflate priority to "win" — see the priority guidelines above.
 | [`plex.json`](contrib/plex.md) | Plex Media Server now-playing via webhook |
 | [`message.json`](contrib/message.md) | Friend messages via iOS Shortcuts → webhook |
 | [`notion.json`](contrib/notion.md) | Notion automation notifications via webhook |
+| [`dive_conditions.json`](contrib/dive_conditions.md) | Scuba diving conditions via NOAA NDBC buoy data or Open-Meteo |

--- a/content/contrib/dive_conditions.json
+++ b/content/contrib/dive_conditions.json
@@ -1,0 +1,23 @@
+{
+  "templates": {
+    "conditions": {
+      "schedule": {
+        "cron": "15 7,12,16 * * *",
+        "hold": 600,
+        "timeout": 1800,
+        "refresh_interval": 1800
+      },
+      "priority": 5,
+      "integration": "dive_conditions",
+      "templates": [
+        {
+          "format": [
+            "{header}",
+            "{swell}",
+            "{wind}"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/content/contrib/dive_conditions.md
+++ b/content/contrib/dive_conditions.md
@@ -1,0 +1,75 @@
+# dive_conditions.json
+
+Scuba diving conditions — wave height, swell period, wind, and water
+temperature. Shows at 7:15am, 12:15pm, and 4:15pm for pre-dive planning.
+A color square in the header indicates subjective dive condition quality.
+
+## Configuration
+
+Add the following to your `config.toml`:
+
+```toml
+[dive_conditions]
+# NDBC buoy station ID (recommended for US coastal sites — real measured data).
+# Find your nearest station at https://www.ndbc.noaa.gov/
+# Example: 46042 = Monterey offshore buoy (27 NM WNW of Monterey, CA)
+ndbc_station_id = "46042"
+
+# Open-Meteo fallback: use these instead of ndbc_station_id for non-US sites
+# or locations without a nearby buoy.
+# WARNING: Open-Meteo's own docs warn that accuracy near complex coastlines
+# is limited (8 km grid resolution). Use NDBC where possible.
+# latitude = 36.6
+# longitude = -121.9
+
+# Unit system: "imperial" (ft, °F, default) or "metric" (m, °C).
+# Wind is always displayed in knots regardless of this setting.
+# units = "imperial"
+```
+
+| Key | Required | Description |
+|---|---|---|
+| `ndbc_station_id` | Yes (or lat/lon) | NDBC buoy station ID |
+| `latitude` | Yes (if no NDBC) | Decimal latitude for Open-Meteo fallback |
+| `longitude` | Yes (if no NDBC) | Decimal longitude for Open-Meteo fallback |
+| `units` | No | `"imperial"` (default) or `"metric"` |
+
+## Condition scoring
+
+The header color square reflects subjective dive condition quality based on
+wave height and wind speed. The worst of the two determines the rating, with
+a period modifier that bumps marginal conditions to poor when waves are short
+and choppy (period / wave height < 2).
+
+| Color | Wave height | Wind speed |
+|---|---|---|
+| 🟩 Green | ≤ 2 ft | ≤ 10 kt |
+| 🟨 Yellow | ≤ 4 ft | ≤ 20 kt |
+| 🟥 Red | > 4 ft | > 20 kt |
+
+Thresholds are based on recreational dive operator consensus. Conditions that
+are yellow by height and wind but have a period-to-height ratio below 2 are
+shown as red (e.g. 3 ft waves at 5s period). Yellow is shown when key data
+fields are unavailable.
+
+## Keeping data current
+
+### NDBC stations
+
+NOAA adds and decommissions buoys over time. Verify your station is still
+active and reporting:
+
+- Station list: https://www.ndbc.noaa.gov/to_station.shtml
+- Station page (replace ID): https://www.ndbc.noaa.gov/station_page.php?station=46042
+- Realtime data file: https://www.ndbc.noaa.gov/data/realtime2/46042.txt
+
+If a station stops reporting, check the NDBC station page for status. Nearby
+stations or the Open-Meteo fallback can substitute while a buoy is offline.
+
+### Open-Meteo Marine API
+
+Open-Meteo updates their model data continuously. No action required unless
+the API endpoint or variable names change:
+
+- Marine API docs: https://open-meteo.com/en/docs/marine-weather-api
+- Forecast API docs: https://open-meteo.com/en/docs

--- a/integrations/dive_conditions.py
+++ b/integrations/dive_conditions.py
@@ -1,0 +1,304 @@
+# integrations/dive_conditions.py
+#
+# Scuba diving conditions integration.
+#
+# Fetches wave height, swell period, wind speed/direction, and water
+# temperature for a configured dive site. The header row shows a color square
+# reflecting subjective dive condition quality (green/yellow/red) scored from
+# wave height and wind speed with a swell period modifier.
+#
+# Primary source: NOAA NDBC (National Data Buoy Center) — real measured buoy
+# data, no API key, no quota. Recommended for US coastal dive sites. Find the
+# nearest station at https://www.ndbc.noaa.gov/
+#
+# Fallback source: Open-Meteo Marine + Forecast APIs — free, no key, global,
+# lat/lon configurable. Open-Meteo's own docs warn that accuracy near complex
+# coastlines is limited (8 km grid). Use NDBC where a nearby buoy exists.
+#
+# Required config.toml keys ([dive_conditions]):
+#   ndbc_station_id  — NDBC buoy station ID (e.g. "46042" for Monterey);
+#                      required unless latitude and longitude are set instead.
+#   latitude         — decimal latitude for Open-Meteo fallback
+#   longitude        — decimal longitude for Open-Meteo fallback
+#
+# Optional config.toml keys:
+#   units  — "imperial" (ft, °F, default) or "metric" (m, °C).
+#             Wind is always displayed in knots regardless of this setting.
+
+import logging
+from typing import Any
+
+import requests
+
+from exceptions import IntegrationDataUnavailableError
+from integrations.http import CacheEntry, fetch_with_retry, user_agent
+
+logger = logging.getLogger(__name__)
+
+_NDBC_BASE_URL = 'https://www.ndbc.noaa.gov/data/realtime2'
+_MARINE_URL = 'https://marine-api.open-meteo.com/v1/marine'
+_FORECAST_URL = 'https://api.open-meteo.com/v1/forecast'
+
+# TTL matches NDBC's ~hourly update cadence.
+_CACHE_TTL = 3600
+
+_cache: CacheEntry | None = None
+
+# Condition scoring thresholds based on recreational dive operator consensus.
+# Wave height in feet, wind speed in knots.
+_WAVE_GREEN_FT = 2.0
+_WAVE_YELLOW_FT = 4.0
+_WIND_GREEN_KT = 10.0
+_WIND_YELLOW_KT = 20.0
+
+# Period-to-height ratio below which a choppy sea bumps the rating one step
+# worse (e.g. 3 ft waves at 5s period: ratio 1.7 < 2.0 → bump to red).
+_PERIOD_RATIO_THRESHOLD = 2.0
+
+_CARDINALS = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW']
+
+
+def _degrees_to_cardinal(deg: float) -> str:
+  """Convert a compass bearing in degrees to an 8-point cardinal abbreviation."""
+  return _CARDINALS[round(deg / 45) % 8]
+
+
+def _fmt_wave(m: float, units: str) -> str:
+  """Format wave/swell height with unit suffix.
+
+  Uses one decimal place below 10 and no decimal at or above 10 to keep the
+  string within 6 characters (e.g. '9.9FT', '10FT', '1.2M', '10M').
+  """
+  if units == 'imperial':
+    ft = m * 3.28084
+    return f'{ft:.0f}FT' if ft >= 10 else f'{ft:.1f}FT'
+  return f'{m:.0f}M' if m >= 10 else f'{m:.1f}M'
+
+
+def _fmt_temp(c: float, units: str) -> str:
+  """Format water temperature with unit suffix."""
+  if units == 'imperial':
+    return f'{round(c * 9 / 5 + 32)}F'
+  return f'{round(c)}C'
+
+
+def _fmt_wind_kt(ms: float) -> str:
+  """Convert m/s wind speed to knots and format with KT suffix."""
+  return f'{round(ms * 1.94384)}KT'
+
+
+def _condition_color(
+  wave_m: float | None,
+  wind_ms: float | None,
+  period_s: float | None,
+) -> str:
+  """Return a color tag reflecting dive condition quality.
+
+  Scores wave height and wind speed independently, takes the worst result,
+  then applies a period modifier: if swell period / wave height (ft) < 2,
+  the rating is bumped one step worse (choppy, short-period seas are harder
+  than the height alone suggests).
+
+  Returns '[G]' (green), '[Y]' (yellow), or '[R]' (red). Falls back to
+  '[Y]' when key data fields are unavailable.
+  """
+  if wave_m is None or wind_ms is None:
+    return '[Y]'
+
+  wave_ft = wave_m * 3.28084
+  wind_kt = wind_ms * 1.94384
+
+  wave_score = 0 if wave_ft <= _WAVE_GREEN_FT else (1 if wave_ft <= _WAVE_YELLOW_FT else 2)
+  wind_score = 0 if wind_kt <= _WIND_GREEN_KT else (1 if wind_kt <= _WIND_YELLOW_KT else 2)
+  score = max(wave_score, wind_score)
+
+  if period_s is not None and wave_ft > 0 and period_s / wave_ft < _PERIOD_RATIO_THRESHOLD:
+    score = min(score + 1, 2)
+
+  return ('[G]', '[Y]', '[R]')[score]
+
+
+def _parse_ndbc(text: str) -> dict[str, float | None]:
+  """Parse NOAA NDBC standard meteorological text file.
+
+  Extracts the most recent data row (last non-comment line). Fields with
+  value 'MM' (NDBC's missing-data sentinel) are returned as None.
+
+  Returns a dict with keys: wave_height_m, period_s, wind_speed_ms,
+  wind_dir_deg, water_temp_c.
+  """
+  headers: list[str] | None = None
+  last_row: list[str] | None = None
+
+  for line in text.splitlines():
+    if line.startswith('#'):
+      if headers is None:
+        # First comment line contains column names; strip the leading '#'.
+        headers = line[1:].split()
+      # Second comment line is units — skip.
+      continue
+    if line.strip():
+      last_row = line.split()
+
+  if headers is None or last_row is None:
+    raise IntegrationDataUnavailableError('Dive conditions: could not parse NDBC data — unexpected file format')
+
+  row = dict(zip(headers, last_row))
+
+  def _field(key: str) -> float | None:
+    val = row.get(key, 'MM')
+    if val == 'MM':
+      return None
+    try:
+      return float(val)
+    except ValueError:
+      return None
+
+  return {
+    'wave_height_m': _field('WVHT'),
+    'period_s': _field('DPD'),
+    'wind_speed_ms': _field('WSPD'),
+    'wind_dir_deg': _field('WDIR'),
+    'water_temp_c': _field('WTMP'),
+  }
+
+
+def _fetch_ndbc(station_id: str) -> dict[str, float | None]:
+  """Fetch and parse the NDBC standard meteorological file for a station."""
+  url = f'{_NDBC_BASE_URL}/{station_id}.txt'
+  try:
+    r = fetch_with_retry('GET', url, headers={'User-Agent': user_agent()}, timeout=10)
+    r.raise_for_status()
+  except requests.RequestException as e:
+    raise IntegrationDataUnavailableError(f'Dive conditions: NDBC request failed — {e}') from None
+  logger.debug('Dive conditions: fetched NDBC station %s', station_id)
+  return _parse_ndbc(r.text)
+
+
+def _fetch_openmeteo(lat: float, lon: float) -> dict[str, float | None]:
+  """Fetch wave, temp, and wind data from Open-Meteo (fallback for non-NDBC).
+
+  Makes two requests: Marine API for wave height, period, and sea surface
+  temperature; Forecast API for wind speed and direction.
+  """
+
+  def _opt(data: dict[str, Any], key: str) -> float | None:
+    val = data.get(key)
+    return float(val) if val is not None else None
+
+  try:
+    r_marine = fetch_with_retry(
+      'GET',
+      _MARINE_URL,
+      headers={'User-Agent': user_agent()},
+      params={
+        'latitude': lat,
+        'longitude': lon,
+        'current': 'wave_height,wave_period,sea_surface_temperature',
+        'cell_selection': 'sea',
+      },
+      timeout=10,
+    )
+    r_marine.raise_for_status()
+  except requests.RequestException as e:
+    raise IntegrationDataUnavailableError(f'Dive conditions: Open-Meteo marine request failed — {e}') from None
+
+  try:
+    r_forecast = fetch_with_retry(
+      'GET',
+      _FORECAST_URL,
+      headers={'User-Agent': user_agent()},
+      params={
+        'latitude': lat,
+        'longitude': lon,
+        'current': 'wind_speed_10m,wind_direction_10m',
+        # Default wind unit is km/h; convert to m/s in _fmt_wind_kt.
+      },
+      timeout=10,
+    )
+    r_forecast.raise_for_status()
+  except requests.RequestException as e:
+    raise IntegrationDataUnavailableError(f'Dive conditions: Open-Meteo forecast request failed — {e}') from None
+
+  marine = r_marine.json().get('current', {})
+  forecast = r_forecast.json().get('current', {})
+
+  # Open-Meteo returns wind in km/h by default; convert to m/s.
+  wind_kmh = _opt(forecast, 'wind_speed_10m')
+  wind_ms = wind_kmh / 3.6 if wind_kmh is not None else None
+
+  logger.debug('Dive conditions: fetched Open-Meteo data at (%.4f, %.4f)', lat, lon)
+  return {
+    'wave_height_m': _opt(marine, 'wave_height'),
+    'period_s': _opt(marine, 'wave_period'),
+    'wind_speed_ms': wind_ms,
+    'wind_dir_deg': _opt(forecast, 'wind_direction_10m'),
+    'water_temp_c': _opt(marine, 'sea_surface_temperature'),
+  }
+
+
+def get_variables() -> dict[str, list[list[str]]]:
+  """Fetch dive conditions and return a variables dict for template rendering.
+
+  Returns keys: header, swell, wind.
+    header — color square (condition quality) + water temperature
+    swell  — wave height and dominant period
+    wind   — wind speed (kt) and direction
+
+  Uses NDBC if ndbc_station_id is configured, otherwise Open-Meteo (lat/lon).
+  Results are cached for _CACHE_TTL seconds. On transient failure, the last
+  cached result is returned if still valid; otherwise raises
+  IntegrationDataUnavailableError.
+  """
+  global _cache
+
+  import config as _cfg
+
+  station_id = _cfg.get_optional('dive_conditions', 'ndbc_station_id')
+  units = _cfg.get_optional('dive_conditions', 'units') or 'imperial'
+
+  if _cache is not None and _cache.is_valid(_CACHE_TTL):
+    logger.debug('Dive conditions: cache hit')
+    return _cache.value
+
+  try:
+    if station_id:
+      data = _fetch_ndbc(station_id)
+    else:
+      try:
+        lat = float(_cfg.get('dive_conditions', 'latitude'))
+        lon = float(_cfg.get('dive_conditions', 'longitude'))
+      except ValueError, KeyError:
+        raise IntegrationDataUnavailableError(
+          'Dive conditions: set ndbc_station_id or latitude/longitude in config.toml'
+        )
+      data = _fetch_openmeteo(lat, lon)
+  except IntegrationDataUnavailableError:
+    if _cache is not None:
+      logger.warning('Dive conditions: fetch failed — serving stale cache')
+      return _cache.value
+    raise
+
+  color = _condition_color(data['wave_height_m'], data['wind_speed_ms'], data['period_s'])
+
+  # Header row: condition color + water temperature.
+  temp = _fmt_temp(data['water_temp_c'], units) if data['water_temp_c'] is not None else '--'
+  header = f'{color} WATER {temp}'
+
+  # Swell row: wave height and dominant period.
+  wave = _fmt_wave(data['wave_height_m'], units) if data['wave_height_m'] is not None else '--'
+  period = f'{round(data["period_s"])}S' if data['period_s'] is not None else '--'
+  swell = f'SWELL {wave} {period}'
+
+  # Wind row: speed in knots and cardinal direction.
+  wind_spd = _fmt_wind_kt(data['wind_speed_ms']) if data['wind_speed_ms'] is not None else '--'
+  wind_dir = _degrees_to_cardinal(data['wind_dir_deg']) if data['wind_dir_deg'] is not None else '--'
+  wind = f'WIND {wind_spd} {wind_dir}'
+
+  result: dict[str, list[list[str]]] = {
+    'header': [[header]],
+    'swell': [[swell]],
+    'wind': [[wind]],
+  }
+  _cache = CacheEntry(result)
+  return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.34.0"
+version = "0.35.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -66,7 +66,7 @@ class _IndentedFormatter(logging.Formatter):
 # Allowlist of valid integration names. Must be extended when a new integration
 # is added to integrations/.
 _KNOWN_INTEGRATIONS: frozenset[str] = frozenset(
-  {'bart', 'calendar', 'discogs', 'message', 'moon', 'morning', 'notion', 'plex', 'trakt', 'weather'}
+  {'bart', 'calendar', 'discogs', 'dive_conditions', 'message', 'moon', 'morning', 'notion', 'plex', 'trakt', 'weather'}
 )
 
 # Cache of loaded integration modules, keyed by name.

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -16,6 +16,9 @@ _INTEGRATION_VARS: list[tuple[str, str]] = [
   ('TRAKT_ACCESS_TOKEN', 'Trakt integration'),
   ('DISCOGS_TOKEN', 'Discogs integration'),
   ('TMDB_API_READ_ACCESS_TOKEN', 'TMDb integration'),
+  ('DIVE_CONDITIONS_NDBC_STATION', 'Dive conditions integration (NDBC)'),
+  ('DIVE_CONDITIONS_LAT', 'Dive conditions integration (Open-Meteo fallback)'),
+  ('DIVE_CONDITIONS_LON', 'Dive conditions integration (Open-Meteo fallback)'),
 ]
 
 _skipped = 0

--- a/tests/integrations/test_dive_conditions_integration.py
+++ b/tests/integrations/test_dive_conditions_integration.py
@@ -1,0 +1,84 @@
+"""Integration tests for integrations/dive_conditions.py.
+
+All data sources are keyless — safe to run in CI on every main push.
+
+Run with: uv run pytest -m integration
+
+Required env vars:
+  DIVE_CONDITIONS_NDBC_STATION  — NDBC station ID (e.g. "46042" for Monterey)
+  DIVE_CONDITIONS_LAT           — decimal latitude for Open-Meteo fallback test
+  DIVE_CONDITIONS_LON           — decimal longitude for Open-Meteo fallback test
+"""
+
+import os
+
+import pytest
+
+import config as _cfg
+import integrations.dive_conditions as dc
+
+
+@pytest.mark.integration
+@pytest.mark.require_env('DIVE_CONDITIONS_NDBC_STATION')
+def test_ndbc_get_variables(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+  """get_variables() returns valid variables from the live NDBC API."""
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {
+      'dive_conditions': {
+        'ndbc_station_id': os.environ['DIVE_CONDITIONS_NDBC_STATION'],
+        'units': 'imperial',
+      }
+    },
+  )
+  dc._cache = None
+
+  result = dc.get_variables()
+
+  assert set(result.keys()) == {'header', 'swell', 'wind'}
+  for key in ('header', 'swell', 'wind'):
+    assert len(result[key]) == 1, f'{key}: expected 1 option'
+    assert len(result[key][0]) == 1, f'{key}: expected 1 line'
+    assert result[key][0][0], f'{key}: value is empty'
+
+  header = result['header'][0][0]
+  assert header.startswith('['), f'header missing color tag: {header!r}'
+  assert 'WATER' in header, f'header missing WATER label: {header!r}'
+
+  swell = result['swell'][0][0]
+  assert swell.startswith('SWELL'), f'unexpected swell format: {swell!r}'
+
+  wind = result['wind'][0][0]
+  assert wind.startswith('WIND'), f'unexpected wind format: {wind!r}'
+  assert 'KT' in wind, f'wind not in knots: {wind!r}'
+
+  dc._cache = None
+
+
+@pytest.mark.integration
+@pytest.mark.require_env('DIVE_CONDITIONS_LAT', 'DIVE_CONDITIONS_LON')
+def test_openmeteo_fallback_get_variables(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+  """get_variables() returns valid variables from the live Open-Meteo APIs."""
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {
+      'dive_conditions': {
+        'latitude': os.environ['DIVE_CONDITIONS_LAT'],
+        'longitude': os.environ['DIVE_CONDITIONS_LON'],
+        'units': 'imperial',
+      }
+    },
+  )
+  dc._cache = None
+
+  result = dc.get_variables()
+
+  assert set(result.keys()) == {'header', 'swell', 'wind'}
+  for key in ('header', 'swell', 'wind'):
+    assert result[key][0][0], f'{key}: value is empty'
+
+  assert 'KT' in result['wind'][0][0], 'wind not in knots'
+
+  dc._cache = None

--- a/tests/test_dive_conditions.py
+++ b/tests/test_dive_conditions.py
@@ -1,0 +1,509 @@
+"""Unit tests for integrations/dive_conditions.py."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import integrations.dive_conditions as dc
+from exceptions import IntegrationDataUnavailableError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NDBC_SAMPLE = """\
+#YY  MM DD hh mm WDIR WSPD GST  WVHT   DPD   APD MWD   PRES  ATMP  WTMP  DEWP  VIS PTDY  TIDE
+#yr  mo dy hr mn degT m/s  m/s     m   sec   sec degT   hPa  degC  degC  degC  nmi  hPa    ft
+2024 01 15 10 00  280  4.0  5.1   1.2  14.0   8.5 290 1015.2  12.5  12.8  10.2   MM   MM    MM
+2024 01 15 11 00  270  5.1  6.2   1.5  14.0   8.5 280 1015.5  12.3  13.0  10.1   MM   MM    MM
+"""
+
+_NDBC_MISSING_FIELDS = """\
+#YY  MM DD hh mm WDIR WSPD GST  WVHT   DPD   APD MWD   PRES  ATMP  WTMP  DEWP  VIS PTDY  TIDE
+#yr  mo dy hr mn degT m/s  m/s     m   sec   sec degT   hPa  degC  degC  degC  nmi  hPa    ft
+2024 01 15 12 00  270   MM   MM    MM    MM    MM  MM 1015.2  12.5    MM  10.2   MM   MM    MM
+"""
+
+_NDBC_ALL_MISSING = """\
+#YY  MM DD hh mm WDIR WSPD GST  WVHT   DPD   APD MWD   PRES  ATMP  WTMP  DEWP  VIS PTDY  TIDE
+#yr  mo dy hr mn degT m/s  m/s     m   sec   sec degT   hPa  degC  degC  degC  nmi  hPa    ft
+"""
+
+
+# ---------------------------------------------------------------------------
+# _degrees_to_cardinal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+  'deg,expected',
+  [
+    (0, 'N'),
+    (45, 'NE'),
+    (90, 'E'),
+    (135, 'SE'),
+    (180, 'S'),
+    (225, 'SW'),
+    (270, 'W'),
+    (315, 'NW'),
+    (360, 'N'),
+    (23, 'NE'),  # rounds to NE (45); boundary is 22.5°
+    (337, 'NW'),  # rounds to NW (315)
+  ],
+)
+def test_degrees_to_cardinal(deg: float, expected: str) -> None:
+  assert dc._degrees_to_cardinal(deg) == expected
+
+
+# ---------------------------------------------------------------------------
+# _fmt_wave
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+  'meters,units,expected',
+  [
+    (0.5, 'imperial', '1.6FT'),
+    (1.5, 'imperial', '4.9FT'),
+    (3.05, 'imperial', '10FT'),  # >= 10ft → no decimal
+    (0.5, 'metric', '0.5M'),
+    (9.5, 'metric', '9.5M'),
+    (10.0, 'metric', '10M'),  # >= 10m → no decimal
+  ],
+)
+def test_fmt_wave(meters: float, units: str, expected: str) -> None:
+  assert dc._fmt_wave(meters, units) == expected
+
+
+# ---------------------------------------------------------------------------
+# _fmt_temp
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+  'celsius,units,expected',
+  [
+    (13.0, 'imperial', '55F'),
+    (0.0, 'imperial', '32F'),
+    (13.0, 'metric', '13C'),
+    (13.6, 'metric', '14C'),
+  ],
+)
+def test_fmt_temp(celsius: float, units: str, expected: str) -> None:
+  assert dc._fmt_temp(celsius, units) == expected
+
+
+# ---------------------------------------------------------------------------
+# _fmt_wind_kt
+# ---------------------------------------------------------------------------
+
+
+def test_fmt_wind_kt_converts_from_ms() -> None:
+  # 5.144 m/s ≈ 10 kt
+  result = dc._fmt_wind_kt(5.144)
+  assert result == '10KT'
+
+
+def test_fmt_wind_kt_rounds() -> None:
+  result = dc._fmt_wind_kt(10.0)
+  assert result.endswith('KT')
+  assert result[:-2].isdigit()
+
+
+# ---------------------------------------------------------------------------
+# _condition_color
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+  'wave_m,wind_ms,period_s,expected',
+  [
+    # Both clearly green
+    (0.3, 2.0, 14.0, '[G]'),  # 1ft wave, 4kt wind
+    # Wave marginal, wind green → yellow
+    (0.9, 2.0, 14.0, '[Y]'),  # 3ft wave, 4kt wind
+    # Wind marginal, wave green → yellow
+    (0.3, 7.7, 14.0, '[Y]'),  # 1ft wave, 15kt wind
+    # Both marginal → yellow
+    (0.9, 7.7, 14.0, '[Y]'),  # 3ft wave, 15kt wind
+    # Wave red → red
+    (1.8, 2.0, 14.0, '[R]'),  # 6ft wave, 4kt wind
+    # Wind red → red
+    (0.3, 12.9, 14.0, '[R]'),  # 1ft wave, 25kt wind
+    # Both red → red
+    (1.8, 12.9, 14.0, '[R]'),
+    # Period modifier: green wave+wind but choppy period → yellow
+    # 0.45m ≈ 1.5ft; period 2.0s; ratio 2.0/1.5 = 1.33 < 2.0 → bump green→yellow
+    (0.45, 2.0, 2.0, '[Y]'),
+    # Period modifier: yellow → red
+    # 0.9m ≈ 3ft; period 5s; ratio 5/3 ≈ 1.67 < 2.0 → bump yellow→red
+    (0.9, 2.0, 5.0, '[R]'),
+    # Period modifier: already red → stays red (no over-bump)
+    (1.8, 2.0, 2.0, '[R]'),
+    # Period ratio exactly at threshold (= 2.0) → no bump
+    # 0.60m ≈ 1.97ft; period 4s; ratio 4/1.97 ≈ 2.03, not < 2.0 → no bump (green)
+    (0.60, 2.0, 4.0, '[G]'),
+    # Missing wave data → yellow
+    (None, 5.0, 14.0, '[Y]'),
+    # Missing wind data → yellow
+    (0.5, None, 14.0, '[Y]'),
+    # Missing period → no modifier applied
+    (0.3, 2.0, None, '[G]'),
+  ],
+)
+def test_condition_color(
+  wave_m: float | None,
+  wind_ms: float | None,
+  period_s: float | None,
+  expected: str,
+) -> None:
+  assert dc._condition_color(wave_m, wind_ms, period_s) == expected
+
+
+# ---------------------------------------------------------------------------
+# _parse_ndbc
+# ---------------------------------------------------------------------------
+
+
+def test_parse_ndbc_extracts_most_recent_row() -> None:
+  """Most recent (last) data row is returned."""
+  result = dc._parse_ndbc(_NDBC_SAMPLE)
+  # Last row: WVHT=1.5, DPD=14.0, WSPD=5.1, WDIR=270, WTMP=13.0
+  assert result['wave_height_m'] == pytest.approx(1.5)
+  assert result['period_s'] == pytest.approx(14.0)
+  assert result['wind_speed_ms'] == pytest.approx(5.1)
+  assert result['wind_dir_deg'] == pytest.approx(270.0)
+  assert result['water_temp_c'] == pytest.approx(13.0)
+
+
+def test_parse_ndbc_mm_fields_return_none() -> None:
+  result = dc._parse_ndbc(_NDBC_MISSING_FIELDS)
+  assert result['wave_height_m'] is None
+  assert result['period_s'] is None
+  assert result['wind_speed_ms'] is None
+  assert result['water_temp_c'] is None
+  # WDIR is not MM in this sample
+  assert result['wind_dir_deg'] == pytest.approx(270.0)
+
+
+def test_parse_ndbc_no_data_rows_raises() -> None:
+  with pytest.raises(IntegrationDataUnavailableError, match='could not parse NDBC data'):
+    dc._parse_ndbc(_NDBC_ALL_MISSING)
+
+
+def test_parse_ndbc_empty_raises() -> None:
+  with pytest.raises(IntegrationDataUnavailableError):
+    dc._parse_ndbc('')
+
+
+# ---------------------------------------------------------------------------
+# _fetch_ndbc (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_ndbc_success(monkeypatch: pytest.MonkeyPatch) -> None:
+  mock_resp = MagicMock()
+  mock_resp.text = _NDBC_SAMPLE
+  mock_resp.raise_for_status = MagicMock()
+
+  with patch('integrations.dive_conditions.fetch_with_retry', return_value=mock_resp):
+    result = dc._fetch_ndbc('46042')
+
+  assert result['wave_height_m'] == pytest.approx(1.5)
+
+
+def test_fetch_ndbc_http_error_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+  import requests as _requests
+
+  with patch(
+    'integrations.dive_conditions.fetch_with_retry',
+    side_effect=_requests.RequestException('timeout'),
+  ):
+    with pytest.raises(IntegrationDataUnavailableError, match='NDBC request failed'):
+      dc._fetch_ndbc('46042')
+
+
+# ---------------------------------------------------------------------------
+# _fetch_openmeteo (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+def _marine_response(wave_height: float = 1.5, wave_period: float = 12.0, sst: float = 13.0) -> MagicMock:
+  resp = MagicMock()
+  resp.json.return_value = {
+    'current': {
+      'wave_height': wave_height,
+      'wave_period': wave_period,
+      'sea_surface_temperature': sst,
+    }
+  }
+  resp.raise_for_status = MagicMock()
+  return resp
+
+
+def _forecast_response(wind_kmh: float = 18.0, wind_dir: float = 270.0) -> MagicMock:
+  resp = MagicMock()
+  resp.json.return_value = {
+    'current': {
+      'wind_speed_10m': wind_kmh,
+      'wind_direction_10m': wind_dir,
+    }
+  }
+  resp.raise_for_status = MagicMock()
+  return resp
+
+
+def test_fetch_openmeteo_success() -> None:
+  with patch(
+    'integrations.dive_conditions.fetch_with_retry',
+    side_effect=[_marine_response(), _forecast_response()],
+  ):
+    result = dc._fetch_openmeteo(36.6, -121.9)
+
+  assert result['wave_height_m'] == pytest.approx(1.5)
+  assert result['period_s'] == pytest.approx(12.0)
+  assert result['water_temp_c'] == pytest.approx(13.0)
+  # 18 km/h → 5.0 m/s
+  assert result['wind_speed_ms'] == pytest.approx(18.0 / 3.6)
+  assert result['wind_dir_deg'] == pytest.approx(270.0)
+
+
+def test_fetch_openmeteo_marine_failure_raises() -> None:
+  import requests as _requests
+
+  with patch(
+    'integrations.dive_conditions.fetch_with_retry',
+    side_effect=_requests.RequestException('timeout'),
+  ):
+    with pytest.raises(IntegrationDataUnavailableError, match='marine request failed'):
+      dc._fetch_openmeteo(36.6, -121.9)
+
+
+def test_fetch_openmeteo_forecast_failure_raises() -> None:
+  import requests as _requests
+
+  with patch(
+    'integrations.dive_conditions.fetch_with_retry',
+    side_effect=[_marine_response(), _requests.RequestException('timeout')],
+  ):
+    with pytest.raises(IntegrationDataUnavailableError, match='forecast request failed'):
+      dc._fetch_openmeteo(36.6, -121.9)
+
+
+# ---------------------------------------------------------------------------
+# Cache behaviour
+# ---------------------------------------------------------------------------
+
+
+def _patched_config(station_id: str = '46042', units: str = 'imperial') -> dict:
+  return {'dive_conditions': {'ndbc_station_id': station_id, 'units': units}}
+
+
+def test_cache_hit_avoids_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+
+  cached_value: dict = {'header': [['[G] WATER 55F']], 'swell': [['SWELL 1.5FT 14S']], 'wind': [['WIND 10KT W']]}
+  dc._cache = dc.CacheEntry(cached_value)  # type: ignore[attr-defined]
+
+  with patch('integrations.dive_conditions.fetch_with_retry') as mock_fetch:
+    result = dc.get_variables()
+    mock_fetch.assert_not_called()
+
+  assert result == cached_value
+  dc._cache = None
+
+
+def test_cache_miss_fetches(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  dc._cache = None
+
+  mock_resp = MagicMock()
+  mock_resp.text = _NDBC_SAMPLE
+  mock_resp.raise_for_status = MagicMock()
+
+  with patch('integrations.dive_conditions.fetch_with_retry', return_value=mock_resp):
+    result = dc.get_variables()
+
+  assert 'header' in result
+  assert 'swell' in result
+  assert 'wind' in result
+  dc._cache = None
+
+
+def test_expired_cache_fetches_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
+  import time
+
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+
+  stale_value: dict = {'header': [['[G] WATER 55F']], 'swell': [['SWELL 1.5FT 14S']], 'wind': [['WIND 10KT W']]}
+  dc._cache = dc.CacheEntry(stale_value)  # type: ignore[attr-defined]
+  # Force the cache to appear expired.
+  dc._cache.cached_at = time.monotonic() - dc._CACHE_TTL - 1
+
+  mock_resp = MagicMock()
+  mock_resp.text = _NDBC_SAMPLE
+  mock_resp.raise_for_status = MagicMock()
+
+  with patch('integrations.dive_conditions.fetch_with_retry', return_value=mock_resp) as mock_fetch:
+    dc.get_variables()
+    mock_fetch.assert_called_once()
+
+  dc._cache = None
+
+
+def test_stale_cache_served_on_fetch_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+  import time
+
+  import requests as _requests
+
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+
+  stale_value: dict = {'header': [['[Y] WATER 55F']], 'swell': [['SWELL 1.5FT 14S']], 'wind': [['WIND 10KT W']]}
+  dc._cache = dc.CacheEntry(stale_value)  # type: ignore[attr-defined]
+  dc._cache.cached_at = time.monotonic() - dc._CACHE_TTL - 1
+
+  with patch(
+    'integrations.dive_conditions.fetch_with_retry',
+    side_effect=_requests.RequestException('timeout'),
+  ):
+    result = dc.get_variables()
+
+  assert result == stale_value
+  dc._cache = None
+
+
+def test_no_cache_on_fetch_failure_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+  import requests as _requests
+
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  dc._cache = None
+
+  with patch(
+    'integrations.dive_conditions.fetch_with_retry',
+    side_effect=_requests.RequestException('timeout'),
+  ):
+    with pytest.raises(IntegrationDataUnavailableError):
+      dc.get_variables()
+
+
+# ---------------------------------------------------------------------------
+# get_variables — output shape and content
+# ---------------------------------------------------------------------------
+
+
+def test_get_variables_uses_openmeteo_when_no_station(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {'dive_conditions': {'latitude': '36.6', 'longitude': '-121.9', 'units': 'imperial'}},
+  )
+  dc._cache = None
+
+  with patch(
+    'integrations.dive_conditions.fetch_with_retry',
+    side_effect=[_marine_response(), _forecast_response()],
+  ):
+    result = dc.get_variables()
+
+  assert 'header' in result
+  dc._cache = None
+
+
+def test_get_variables_imperial_units(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config(units='imperial'))
+  dc._cache = None
+
+  mock_resp = MagicMock()
+  mock_resp.text = _NDBC_SAMPLE
+  mock_resp.raise_for_status = MagicMock()
+
+  with patch('integrations.dive_conditions.fetch_with_retry', return_value=mock_resp):
+    result = dc.get_variables()
+
+  header = result['header'][0][0]
+  # Header should contain 'F' (Fahrenheit) not 'C'
+  assert 'F' in header and 'C' not in header
+  # Swell row should contain 'FT'
+  assert 'FT' in result['swell'][0][0]
+  dc._cache = None
+
+
+def test_get_variables_metric_units(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config(units='metric'))
+  dc._cache = None
+
+  mock_resp = MagicMock()
+  mock_resp.text = _NDBC_SAMPLE
+  mock_resp.raise_for_status = MagicMock()
+
+  with patch('integrations.dive_conditions.fetch_with_retry', return_value=mock_resp):
+    result = dc.get_variables()
+
+  header = result['header'][0][0]
+  assert 'C' in header
+  assert 'M' in result['swell'][0][0]
+  dc._cache = None
+
+
+def test_get_variables_missing_data_shows_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  dc._cache = None
+
+  mock_resp = MagicMock()
+  mock_resp.text = _NDBC_MISSING_FIELDS
+  mock_resp.raise_for_status = MagicMock()
+
+  with patch('integrations.dive_conditions.fetch_with_retry', return_value=mock_resp):
+    result = dc.get_variables()
+
+  # Missing fields should render as '--'
+  assert '--' in result['header'][0][0]
+  assert '--' in result['swell'][0][0]
+  dc._cache = None
+
+
+def test_get_variables_wind_always_in_knots(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  for units in ('imperial', 'metric'):
+    monkeypatch.setattr(_cfg, '_config', _patched_config(units=units))
+    dc._cache = None
+
+    mock_resp = MagicMock()
+    mock_resp.text = _NDBC_SAMPLE
+    mock_resp.raise_for_status = MagicMock()
+
+    with patch('integrations.dive_conditions.fetch_with_retry', return_value=mock_resp):
+      result = dc.get_variables()
+
+    assert 'KT' in result['wind'][0][0], f'wind should be in KT for units={units}'
+    dc._cache = None
+
+
+def test_get_variables_missing_lat_lon_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'dive_conditions': {}})
+  dc._cache = None
+
+  with pytest.raises(IntegrationDataUnavailableError, match='ndbc_station_id or latitude/longitude'):
+    dc.get_variables()

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.34.0"
+version = "0.35.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- Adds `integrations/dive_conditions.py` — scuba diving conditions via NOAA NDBC buoy real-time data (no API key, no quota), with Open-Meteo Marine + Forecast APIs as a keyless fallback for non-US sites
- Displays wave height, swell period, wind speed/direction, and water temperature on the Note (3×15)
- Header colour square encodes subjective dive condition quality: 🟩 green (≤2ft/≤10kt), 🟨 yellow (≤4ft/≤20kt), 🟥 red (>4ft/>20kt), with a swell period modifier (period/height < 2 bumps one step worse)
- Fires at 7:15am, 12:15pm, 4:15pm; `:15` offset avoids conflicts with existing `:00` slots; `refresh_interval: 1800` keeps idle display current
- Adds `content/contrib/dive_conditions.json`, `content/contrib/dive_conditions.md`, config example, integration test, 57 unit tests, schedule table row, contrib table row

## Test plan

- [ ] `uv run pytest tests/test_dive_conditions.py` — 57 unit tests pass
- [ ] `uv run pytest` — full suite passes
- [ ] Integration test with real NDBC station 46042: `DIVE_CONDITIONS_NDBC_STATION=46042 uv run pytest -m integration tests/integrations/test_dive_conditions_integration.py -v`
- [ ] Integration test with Open-Meteo fallback: set `DIVE_CONDITIONS_LAT`/`DIVE_CONDITIONS_LON` and run same command
- [ ] Add `DIVE_CONDITIONS_NDBC_STATION`, `DIVE_CONDITIONS_LAT`, `DIVE_CONDITIONS_LON` to the `integration` GitHub environment secrets

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
