### PR TITLE
chore(dive_conditions): document env vars in .env.example and AGENTS.md

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,8 @@ DISCOGS_TOKEN=your-discogs-personal-access-token
 #
 # Required for TMDb integration tests:
 TMDB_API_READ_ACCESS_TOKEN=your-tmdb-api-read-access-token
+#
+# Required for Dive conditions integration tests (not secret — use as GitHub env vars):
+DIVE_CONDITIONS_NDBC_STATION=46042
+DIVE_CONDITIONS_LAT=36.785
+DIVE_CONDITIONS_LON=-122.396

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,6 +328,7 @@ come from GitHub secrets env vars directly.
   - BART: `BART_API_KEY`
   - Trakt: `TRAKT_CLIENT_ID`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`
   - Discogs: `DISCOGS_TOKEN`
+  - Dive conditions: `DIVE_CONDITIONS_NDBC_STATION`, `DIVE_CONDITIONS_LAT`, `DIVE_CONDITIONS_LON`
 - CI runs the `integration` job on `main` pushes only; it is advisory
   (`continue-on-error: true`) and not required by the branch ruleset
 - GitHub secrets/vars needed — store as **environment secrets** (or vars) on the
@@ -335,7 +336,7 @@ come from GitHub secrets env vars directly.
   branch; this scopes them tighter than repo secrets and prevents any PR branch
   from accessing them even if a workflow runs there:
   - Secrets: `VESTABOARD_VIRTUAL_API_KEY`, `CALENDAR_URL`, `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `DISCOGS_TOKEN`
-  - Variables: `TRAKT_CLIENT_ID` (non-sensitive; stored as an environment variable, not a secret)
+  - Variables: `TRAKT_CLIENT_ID` (non-sensitive); `DIVE_CONDITIONS_NDBC_STATION`, `DIVE_CONDITIONS_LAT`, `DIVE_CONDITIONS_LON` (public NOAA station and coordinates)
 - If any integration test is skipped, the pytest session exits with code 5
   (NO_TESTS_COLLECTED), making the advisory job visibly fail rather than silently pass
 - When adding a new integration, also add `tests/integrations/test_<name>_integration.py`
@@ -359,7 +360,7 @@ prevention here — not just a one-off fix. See #65 for extended notes.
    ```
    gh api repos/JasonPuglisi/e-note-ion/rulesets/13082160 --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
    ```
-9. **Integration test hygiene** — advisory CI job passing on `main`; GitHub environment secrets/vars present (`VESTABOARD_VIRTUAL_API_KEY`, `CALENDAR_URL`, `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD`, `CALENDAR_CARDDAV_URL`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `DISCOGS_TOKEN` as secrets; `TRAKT_CLIENT_ID` as a variable); new integrations have `test_<name>_integration.py` and env vars in `tests/integrations/conftest.py`
+9. **Integration test hygiene** — advisory CI job passing on `main`; GitHub environment secrets/vars present (`VESTABOARD_VIRTUAL_API_KEY`, `CALENDAR_URL`, `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD`, `CALENDAR_CARDDAV_URL`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `DISCOGS_TOKEN` as secrets; `TRAKT_CLIENT_ID`, `DIVE_CONDITIONS_NDBC_STATION`, `DIVE_CONDITIONS_LAT`, `DIVE_CONDITIONS_LON` as variables); new integrations have `test_<name>_integration.py` and env vars in `tests/integrations/conftest.py`
    - **`TRAKT_ACCESS_TOKEN` expires every ~90 days** — if the Trakt integration tests start failing with an auth error, copy the current `access_token` from `config.toml` (kept fresh by the prod refresh flow) into the `integration` environment secret
 10. **Issue/milestone hygiene**:
     - Every open issue has a milestone (no orphans); scope is right-sized


### PR DESCRIPTION
## Summary

- Documents `DIVE_CONDITIONS_NDBC_STATION`, `DIVE_CONDITIONS_LAT`, `DIVE_CONDITIONS_LON` in `.env.example` with sensible defaults (buoy 46042 / Monterey coordinates)
- Updates AGENTS.md to list all three as GitHub environment **variables** (not secrets) — they're public NOAA station IDs and coordinates with nothing sensitive

🤖 Generated with [Claude Code](https://claude.com/claude-code)