### PR TITLE
fix(dive_conditions): relax wind KT assertion in integration test

### DIFF
--- a/tests/integrations/test_dive_conditions_integration.py
+++ b/tests/integrations/test_dive_conditions_integration.py
@@ -51,7 +51,9 @@ def test_ndbc_get_variables(require_env: None, monkeypatch: pytest.MonkeyPatch) 
 
   wind = result['wind'][0][0]
   assert wind.startswith('WIND'), f'unexpected wind format: {wind!r}'
-  assert 'KT' in wind, f'wind not in knots: {wind!r}'
+  # Some buoys lack anemometers — wind fields may be '--'; only assert KT when data present.
+  if '--' not in wind:
+    assert 'KT' in wind, f'wind not in knots: {wind!r}'
 
   dc._cache = None
 


### PR DESCRIPTION
Some NDBC buoys lack anemometers and report `WSPD`/`WDIR` as `MM`. The integration handles this correctly by rendering `WIND -- --`, but the integration test was unconditionally asserting `KT` in the wind string. Loosen to only assert when data is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)