### PR TITLE
chore(dive_conditions): replace decommissioned 46042 with 46014 in docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,6 @@ DISCOGS_TOKEN=your-discogs-personal-access-token
 TMDB_API_READ_ACCESS_TOKEN=your-tmdb-api-read-access-token
 #
 # Required for Dive conditions integration tests (not secret — use as GitHub env vars):
-DIVE_CONDITIONS_NDBC_STATION=46042
+DIVE_CONDITIONS_NDBC_STATION=46014
 DIVE_CONDITIONS_LAT=36.785
 DIVE_CONDITIONS_LON=-122.396

--- a/config.example.toml
+++ b/config.example.toml
@@ -158,8 +158,8 @@ client_secret = "your-trakt-client-secret"
 
 # NDBC buoy station ID (recommended for US coastal sites — real measured data).
 # Find your nearest station at https://www.ndbc.noaa.gov/
-# Example: 46042 = Monterey offshore buoy (27 NM WNW of Monterey, CA)
-# ndbc_station_id = "46042"
+# Example: 46014 = Point Arena, CA
+# ndbc_station_id = "46014"
 
 # Open-Meteo fallback — use instead of ndbc_station_id for non-US sites or
 # locations without a nearby buoy. Accuracy near complex coastlines is limited.

--- a/content/contrib/dive_conditions.md
+++ b/content/contrib/dive_conditions.md
@@ -12,8 +12,8 @@ Add the following to your `config.toml`:
 [dive_conditions]
 # NDBC buoy station ID (recommended for US coastal sites — real measured data).
 # Find your nearest station at https://www.ndbc.noaa.gov/
-# Example: 46042 = Monterey offshore buoy (27 NM WNW of Monterey, CA)
-ndbc_station_id = "46042"
+# Example: 46014 = Point Arena, CA
+ndbc_station_id = "46014"
 
 # Open-Meteo fallback: use these instead of ndbc_station_id for non-US sites
 # or locations without a nearby buoy.
@@ -60,8 +60,8 @@ NOAA adds and decommissions buoys over time. Verify your station is still
 active and reporting:
 
 - Station list: https://www.ndbc.noaa.gov/to_station.shtml
-- Station page (replace ID): https://www.ndbc.noaa.gov/station_page.php?station=46042
-- Realtime data file: https://www.ndbc.noaa.gov/data/realtime2/46042.txt
+- Station page (replace ID): https://www.ndbc.noaa.gov/station_page.php?station=46014
+- Realtime data file: https://www.ndbc.noaa.gov/data/realtime2/46014.txt
 
 If a station stops reporting, check the NDBC station page for status. Nearby
 stations or the Open-Meteo fallback can substitute while a buoy is offline.


### PR DESCRIPTION
Station 46042 (Monterey offshore) is decommissioned (returns 404). Replaces all references in `.env.example`, `config.example.toml`, and `content/contrib/dive_conditions.md` with 46014 (Point Arena, CA), which has complete data and is used for integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)