### PR TITLE
fix(trakt,tmdb): episode group S/E lookup, truncate_line word bug, ellipsis truncation

### DIFF
--- a/integrations/plex.py
+++ b/integrations/plex.py
@@ -115,7 +115,7 @@ def _canonicalize_plex_title(raw_title: str, guids: list[dict[str, Any]], media_
     if ep_result is None:
       logger.debug('plex: tvdb ep lookup failed for id=%d, using raw title %r', tvdb_id, raw_title)
       return raw_title
-    _, _, _, show_id = ep_result
+    _, _, _, show_id, _ = ep_result
     canonical = _tmdb.get_show_title(show_id)
   else:
     tmdb_id = _parse_guid_id(guids, 'tmdb://')
@@ -246,14 +246,14 @@ def handle_webhook(payload: dict[str, Any], credential_name: str | None = None) 
     if media_type == 'episode' and metadata:
       guids: list[dict[str, Any]] = metadata.get('Guid') or []
       raw_show = _canonicalize_plex_title(metadata['grandparentTitle'], guids, 'episode')
-      show_name = _vb.truncate_line(raw_show.upper(), _vb.model.cols, 'word')
+      show_name = _vb.truncate_line(raw_show.upper(), _vb.model.cols, 'ellipsis')
       episode_ref = _media.format_episode_ref(metadata['parentIndex'], metadata['index'])
       episode_detail = _media.strip_leading_article((metadata.get('title') or '').upper())
       episode_line = f'{episode_ref} {episode_detail}'.strip()
     elif media_type == 'movie' and metadata:
       guids = metadata.get('Guid') or []
       raw_movie = _canonicalize_plex_title(metadata['title'], guids, 'movie')
-      show_name = _vb.truncate_line(raw_movie.upper(), _vb.model.cols, 'word')
+      show_name = _vb.truncate_line(raw_movie.upper(), _vb.model.cols, 'ellipsis')
       episode_line = ''
     else:
       logger.debug('plex: no displayable metadata (type=%r)', media_type)

--- a/integrations/tmdb.py
+++ b/integrations/tmdb.py
@@ -90,14 +90,15 @@ def get_movie_title(tmdb_movie_id: int) -> str | None:
 
 
 @functools.lru_cache(maxsize=512)
-def find_episode_by_tvdb_id(tvdb_episode_id: int) -> tuple[int, int, str, int] | None:
-  """Return (season, episode, title, show_id) from TMDb for a TVDb episode ID.
+def find_episode_by_tvdb_id(tvdb_episode_id: int) -> tuple[int, int, str, int, int] | None:
+  """Return (season, episode, title, show_id, tmdb_episode_id) from TMDb for a TVDb episode ID.
 
   Uses TMDb's /find endpoint with external_source=tvdb_id to resolve the
   canonical TMDb season and episode numbers. This corrects Trakt's TVDb-based
   single-flat-season numbering for anime to the proper multi-season form.
   The returned show_id is the TMDb series ID and can be passed to
-  get_show_title() to retrieve the canonical show name.
+  get_show_title() to retrieve the canonical show name. The tmdb_episode_id
+  can be passed to get_episode_group_position() for a more precise S/E number.
 
   Result is cached in-memory by TVDb episode ID for the lifetime of the
   process. Returns None if the lookup fails or returns no results.
@@ -117,10 +118,94 @@ def find_episode_by_tvdb_id(tvdb_episode_id: int) -> tuple[int, int, str, int] |
       season = ep.get('season_number')
       episode = ep.get('episode_number')
       show_id = ep.get('show_id')
+      tmdb_episode_id = ep.get('id')
       title: str = ep.get('name') or ''
-      if season is not None and episode is not None and show_id is not None:
-        logger.debug('TMDb: tvdb_ep %d → S%dE%d %r (show=%d)', tvdb_episode_id, season, episode, title, show_id)
-        return (season, episode, title, show_id)
+      if season is not None and episode is not None and show_id is not None and tmdb_episode_id is not None:
+        logger.debug(
+          'TMDb: tvdb_ep %d → S%dE%d %r (show=%d, tmdb_ep=%d)',
+          tvdb_episode_id,
+          season,
+          episode,
+          title,
+          show_id,
+          tmdb_episode_id,
+        )
+        return (season, episode, title, show_id, tmdb_episode_id)
   except Exception as e:  # noqa: BLE001
     logger.debug('TMDb: find_episode_by_tvdb_id(%d) failed — %s', tvdb_episode_id, e)
+  return None
+
+
+@functools.lru_cache(maxsize=128)
+def _get_type6_group_id(show_id: int) -> str | None:
+  """Return the TMDb episode group ID for the type-6 (TV seasons) group, or None."""
+  try:
+    r = fetch_with_retry(
+      'GET',
+      f'{_TMDB_API_BASE}/tv/{show_id}/episode_groups',
+      headers=_request_headers(),
+      timeout=10,
+    )
+    r.raise_for_status()
+    for group in r.json().get('results', []):
+      if group.get('type') == 6:
+        return group['id']
+  except Exception as e:  # noqa: BLE001
+    logger.debug('TMDb: _get_type6_group_id(%d) failed — %s', show_id, e)
+  return None
+
+
+@functools.lru_cache(maxsize=128)
+def _get_episode_group(group_id: str) -> list[dict] | None:
+  """Return the groups list for a TMDb episode group ID, or None on failure."""
+  try:
+    r = fetch_with_retry(
+      'GET',
+      f'{_TMDB_API_BASE}/tv/episode_group/{group_id}',
+      headers=_request_headers(),
+      timeout=10,
+    )
+    r.raise_for_status()
+    return r.json().get('groups', [])
+  except Exception as e:  # noqa: BLE001
+    logger.debug('TMDb: _get_episode_group(%r) failed — %s', group_id, e)
+  return None
+
+
+def get_episode_group_position(show_id: int, tmdb_episode_id: int) -> tuple[int, int] | None:
+  """Return (season, episode) from the type-6 episode group for a TMDb episode.
+
+  Looks up the show's type-6 (TV broadcast seasons) episode group and finds
+  the episode by its TMDb ID. Returns (group.order, episode.order + 1) using
+  the group's positional order, skipping groups at order 0 (Specials).
+
+  This gives the canonical broadcast season/episode number for shows like
+  Frieren where TMDb's base data collapses all episodes into Season 1 but
+  the episode group correctly models them as separate seasons.
+
+  Result is not cached directly (callers cache via lru_cache on helpers).
+  Returns None if no type-6 group exists, the episode is not found, or
+  any request fails.
+  """
+  group_id = _get_type6_group_id(show_id)
+  if not group_id:
+    return None
+  groups = _get_episode_group(group_id)
+  if not groups:
+    return None
+  for group in groups:
+    group_order = group.get('order', 0)
+    if group_order == 0:
+      continue  # skip Specials
+    for ep in group.get('episodes', []):
+      if ep.get('id') == tmdb_episode_id:
+        episode_number = ep.get('order', 0) + 1
+        logger.debug(
+          'TMDb: episode group position for ep %d → S%dE%d (group %r)',
+          tmdb_episode_id,
+          group_order,
+          episode_number,
+          group_id,
+        )
+        return (group_order, episode_number)
   return None

--- a/integrations/trakt.py
+++ b/integrations/trakt.py
@@ -324,12 +324,23 @@ def _canonicalize_episode(
       if canonical:
         title = canonical
     tvdb_ep_id = ep_data.get('ids', {}).get('tvdb')
-    if tvdb_ep_id:
+    if tvdb_ep_id and tmdb_show_id:
       resolved = _tmdb.find_episode_by_tvdb_id(int(tvdb_ep_id))
       if resolved:
-        season, number, ep_title, _ = resolved
+        res_season, res_number, res_ep_title, res_show_id, res_tmdb_ep_id = resolved
+        if res_show_id != int(tmdb_show_id):
+          logger.debug(
+            'TMDb: episode show_id mismatch (got %d, expected %d) — falling back to Trakt S/E',
+            res_show_id,
+            int(tmdb_show_id),
+          )
+        else:
+          season, number, ep_title = res_season, res_number, res_ep_title
+          group_pos = _tmdb.get_episode_group_position(int(tmdb_show_id), res_tmdb_ep_id)
+          if group_pos:
+            season, number = group_pos
 
-  show_name = _vb.truncate_line(title.upper(), _vb.model.cols, 'word')
+  show_name = _vb.truncate_line(title.upper(), _vb.model.cols, 'ellipsis')
   return show_name, season, number, ep_title
 
 
@@ -503,7 +514,7 @@ def get_variables_watching() -> dict[str, list[list[str]]]:
     episode_ref = _media.format_episode_ref(season, number)
     episode_title = _media.strip_leading_article(ep_title.upper())
   elif media_type == 'movie':
-    show_name = _vb.truncate_line(_canonicalize_movie(data['movie']).upper(), _vb.model.cols, 'word')
+    show_name = _vb.truncate_line(_canonicalize_movie(data['movie']).upper(), _vb.model.cols, 'ellipsis')
     episode_ref = 'MOVIE'
     episode_title = ''
   else:

--- a/integrations/vestaboard.py
+++ b/integrations/vestaboard.py
@@ -430,6 +430,10 @@ def truncate_line(
     return ''.join(result).rstrip() + '...'
   if strategy == 'hard' or last_word_end < 0:
     return ''.join(result)
+  # If the loop exited right at a word boundary (next char is a space or end
+  # of text), the full result is valid — don't trim the last word.
+  if result and result[-1] != ' ' and (i >= len(text) or text[i] == ' '):
+    return ''.join(result)
   return ''.join(result[:last_word_end])
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.36.0"
+version = "0.37.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_plex.py
+++ b/tests/core/test_plex.py
@@ -503,15 +503,15 @@ def test_handle_webhook_movie_title_preserves_article() -> None:
 
 
 def test_handle_webhook_long_show_name_truncated_to_one_row() -> None:
-  """A show name longer than model.cols must be word-truncated, not left to wrap."""
+  """A show name longer than model.cols must be ellipsis-truncated, not left to wrap."""
   long_show = 'Star Trek The Next Generation'
   result = _plex.handle_webhook(_episode_payload(show=long_show))
   assert result is not None
   show_name = result.data['variables']['show_name'][0][0]
   upper = long_show.upper()
   assert _vb.display_len(show_name) <= _vb.model.cols
-  assert upper.startswith(show_name)
-  assert show_name == upper or upper[len(show_name)] == ' '
+  assert show_name.endswith('...')
+  assert upper.startswith(show_name[:-3])
 
 
 # ---------------------------------------------------------------------------
@@ -627,8 +627,8 @@ def _movie_payload_with_guid(tmdb_id: int, title: str = 'Inception') -> dict[str
 def test_handle_webhook_episode_uses_tmdb_canonical_show_name(monkeypatch: pytest.MonkeyPatch) -> None:
   """TVDb episode ID → find_episode_by_tvdb_id → show_id → get_show_title."""
   monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
-  # find returns (season, episode, title, show_id=40290)
-  monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: (1, 3, 'The Dish', 40290))
+  # find returns (season, episode, title, show_id=40290, tmdb_episode_id=99001)
+  monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: (1, 3, 'The Dish', 40290, 99001))
   show_calls: list[int] = []
 
   def _mock_get_show_title(tmdb_id: int) -> str:

--- a/tests/core/test_tmdb.py
+++ b/tests/core/test_tmdb.py
@@ -13,6 +13,8 @@ def _clear_lru_caches() -> None:
   tmdb.get_show_title.cache_clear()
   tmdb.get_movie_title.cache_clear()
   tmdb.find_episode_by_tvdb_id.cache_clear()
+  tmdb._get_type6_group_id.cache_clear()  # noqa: SLF001
+  tmdb._get_episode_group.cache_clear()  # noqa: SLF001
 
 
 # --- is_configured ---
@@ -119,13 +121,15 @@ def test_find_episode_by_tvdb_id_returns_season_episode_title(monkeypatch: pytes
   mock_r = MagicMock()
   mock_r.status_code = 200
   mock_r.json.return_value = {
-    'tv_episode_results': [{'season_number': 4, 'episode_number': 16, 'name': 'Above and Below', 'show_id': 1429}]
+    'tv_episode_results': [
+      {'id': 99001, 'season_number': 4, 'episode_number': 16, 'name': 'Above and Below', 'show_id': 1429}
+    ]
   }
 
   with patch('integrations.tmdb.fetch_with_retry', return_value=mock_r):
     result = tmdb.find_episode_by_tvdb_id(8765432)
 
-  assert result == (4, 16, 'Above and Below', 1429)
+  assert result == (4, 16, 'Above and Below', 1429, 99001)
 
 
 def test_find_episode_by_tvdb_id_returns_none_on_empty_results(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -160,10 +164,87 @@ def test_find_episode_by_tvdb_id_empty_title_returns_empty_string(monkeypatch: p
   mock_r = MagicMock()
   mock_r.status_code = 200
   mock_r.json.return_value = {
-    'tv_episode_results': [{'season_number': 2, 'episode_number': 3, 'name': None, 'show_id': 999}]
+    'tv_episode_results': [{'id': 77002, 'season_number': 2, 'episode_number': 3, 'name': None, 'show_id': 999}]
   }
 
   with patch('integrations.tmdb.fetch_with_retry', return_value=mock_r):
     result = tmdb.find_episode_by_tvdb_id(1111111)
 
-  assert result == (2, 3, '', 999)
+  assert result == (2, 3, '', 999, 77002)
+
+
+# --- get_episode_group_position ---
+
+
+def test_get_episode_group_position_returns_correct_season_episode(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+
+  groups_r = MagicMock()
+  groups_r.status_code = 200
+  groups_r.json.return_value = {'results': [{'id': 'grp-abc', 'type': 6}]}
+
+  group_r = MagicMock()
+  group_r.status_code = 200
+  group_r.json.return_value = {
+    'groups': [
+      {'order': 0, 'name': 'Specials', 'episodes': [{'id': 9001, 'order': 0}]},
+      {'order': 1, 'name': 'Season 1', 'episodes': [{'id': 9002, 'order': 0}, {'id': 9003, 'order': 1}]},
+      {'order': 2, 'name': 'Season 2', 'episodes': [{'id': 9004, 'order': 0}, {'id': 9005, 'order': 7}]},
+    ]
+  }
+
+  with patch('integrations.tmdb.fetch_with_retry', side_effect=[groups_r, group_r]):
+    result = tmdb.get_episode_group_position(209867, 9005)
+
+  assert result == (2, 8)
+
+
+def test_get_episode_group_position_skips_specials_group(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+
+  groups_r = MagicMock()
+  groups_r.status_code = 200
+  groups_r.json.return_value = {'results': [{'id': 'grp-abc', 'type': 6}]}
+
+  group_r = MagicMock()
+  group_r.status_code = 200
+  group_r.json.return_value = {
+    'groups': [
+      {'order': 0, 'name': 'Specials', 'episodes': [{'id': 9001, 'order': 0}]},
+    ]
+  }
+
+  with patch('integrations.tmdb.fetch_with_retry', side_effect=[groups_r, group_r]):
+    result = tmdb.get_episode_group_position(209867, 9001)
+
+  assert result is None
+
+
+def test_get_episode_group_position_no_type6_group(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+
+  groups_r = MagicMock()
+  groups_r.status_code = 200
+  groups_r.json.return_value = {'results': [{'id': 'grp-xyz', 'type': 5}]}
+
+  with patch('integrations.tmdb.fetch_with_retry', return_value=groups_r):
+    result = tmdb.get_episode_group_position(12345, 9999)
+
+  assert result is None
+
+
+def test_get_episode_group_position_returns_none_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+
+  with patch('integrations.tmdb.fetch_with_retry', side_effect=Exception('timeout')):
+    result = tmdb.get_episode_group_position(209867, 9005)
+
+  assert result is None

--- a/tests/core/test_trakt.py
+++ b/tests/core/test_trakt.py
@@ -622,7 +622,8 @@ def test_canonicalize_episode_with_tmdb_uses_canonical_data(monkeypatch: pytest.
 
   with (
     patch('integrations.tmdb.get_show_title', return_value='Attack on Titan') as mock_show,
-    patch('integrations.tmdb.find_episode_by_tvdb_id', return_value=(4, 16, 'Above and Below', 1429)) as mock_ep,
+    patch('integrations.tmdb.find_episode_by_tvdb_id', return_value=(4, 16, 'Above and Below', 1429, 99001)) as mock_ep,
+    patch('integrations.tmdb.get_episode_group_position', return_value=None),
   ):
     show_name, season, number, ep_title = trakt._canonicalize_episode(show_data, ep_data)  # noqa: SLF001
 
@@ -671,6 +672,87 @@ def test_canonicalize_episode_missing_ids_skips_tmdb(monkeypatch: pytest.MonkeyP
   assert show_name == 'GREAT SHOW'
   assert season == 2
   assert number == 5
+
+
+def test_canonicalize_episode_show_id_mismatch_uses_trakt_se(monkeypatch: pytest.MonkeyPatch) -> None:
+  """When resolved show_id doesn't match, falls back to Trakt S/E."""
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+
+  show_data = {'title': 'My Anime', 'ids': {'tmdb': 1111}}
+  ep_data = {'season': 1, 'number': 5, 'title': 'Episode Five', 'ids': {'tvdb': 5555555}}
+
+  with (
+    patch('integrations.tmdb.get_show_title', return_value='My Anime'),
+    patch('integrations.tmdb.find_episode_by_tvdb_id', return_value=(3, 7, 'Wrong Show Ep', 9999, 88001)),
+    patch('integrations.tmdb.get_episode_group_position') as mock_group,
+  ):
+    show_name, season, number, ep_title = trakt._canonicalize_episode(show_data, ep_data)  # noqa: SLF001
+
+  mock_group.assert_not_called()
+  assert season == 1
+  assert number == 5
+  assert ep_title == 'Episode Five'
+
+
+def test_canonicalize_episode_missing_tmdb_show_id_skips_episode_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+  """When show has no tmdb ID, episode resolution via TVDb is skipped."""
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+
+  show_data = {'title': 'No TMDb Show', 'ids': {'trakt': 42}}
+  ep_data = {'season': 2, 'number': 3, 'title': 'An Episode', 'ids': {'tvdb': 7777777}}
+
+  with patch('integrations.tmdb.find_episode_by_tvdb_id') as mock_ep:
+    show_name, season, number, ep_title = trakt._canonicalize_episode(show_data, ep_data)  # noqa: SLF001
+
+  mock_ep.assert_not_called()
+  assert season == 2
+  assert number == 3
+
+
+def test_canonicalize_episode_uses_episode_group_position(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Episode group position overrides base TMDb S/E when available."""
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+
+  show_data = {'title': 'Frieren', 'ids': {'tmdb': 209867}}
+  ep_data = {'season': 1, 'number': 36, 'title': 'A Magnificent End', 'ids': {'tvdb': 11447771}}
+
+  with (
+    patch('integrations.tmdb.get_show_title', return_value="Frieren: Beyond Journey's End"),
+    patch('integrations.tmdb.find_episode_by_tvdb_id', return_value=(1, 36, 'A Magnificent End', 209867, 6855841)),
+    patch('integrations.tmdb.get_episode_group_position', return_value=(2, 8)) as mock_group,
+  ):
+    show_name, season, number, ep_title = trakt._canonicalize_episode(show_data, ep_data)  # noqa: SLF001
+
+  mock_group.assert_called_once_with(209867, 6855841)
+  assert season == 2
+  assert number == 8
+  assert ep_title == 'A Magnificent End'
+
+
+def test_canonicalize_episode_falls_back_to_tmdb_base_when_group_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+  """When episode group returns None, uses base TMDb S/E."""
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+
+  show_data = {'title': 'Some Show', 'ids': {'tmdb': 5555}}
+  ep_data = {'season': 1, 'number': 10, 'title': 'Ep Ten', 'ids': {'tvdb': 1234567}}
+
+  with (
+    patch('integrations.tmdb.get_show_title', return_value='Some Show'),
+    patch('integrations.tmdb.find_episode_by_tvdb_id', return_value=(2, 3, 'Ep Ten', 5555, 77777)),
+    patch('integrations.tmdb.get_episode_group_position', return_value=None),
+  ):
+    show_name, season, number, ep_title = trakt._canonicalize_episode(show_data, ep_data)  # noqa: SLF001
+
+  assert season == 2
+  assert number == 3
 
 
 # --- _canonicalize_movie ---
@@ -1024,7 +1106,7 @@ def test_get_variables_watching_http_error_does_not_leak_client_id(
 def test_get_variables_calendar_long_show_name_truncated(
   config_with_tokens: Path,
 ) -> None:
-  """A show name longer than model.cols must be word-truncated, not left to wrap."""
+  """A show name longer than model.cols must be ellipsis-truncated, not left to wrap."""
   long_title = 'Star Trek The Next Generation'
   long_response = [
     {
@@ -1043,14 +1125,14 @@ def test_get_variables_calendar_long_show_name_truncated(
   show_name = result['show_name'][0][0]
   upper = long_title.upper()
   assert vb.display_len(show_name) <= vb.model.cols
-  assert upper.startswith(show_name)
-  assert show_name == upper or upper[len(show_name)] == ' '
+  assert show_name.endswith('...')
+  assert upper.startswith(show_name[:-3])
 
 
 def test_get_variables_watching_long_show_name_truncated(
   config_with_tokens: Path,
 ) -> None:
-  """A show name longer than model.cols must be word-truncated, not left to wrap."""
+  """A show name longer than model.cols must be ellipsis-truncated, not left to wrap."""
   long_title = 'Star Trek The Next Generation'
   mock_response = MagicMock()
   mock_response.status_code = 200
@@ -1066,8 +1148,8 @@ def test_get_variables_watching_long_show_name_truncated(
   show_name = result['show_name'][0][0]
   upper = long_title.upper()
   assert vb.display_len(show_name) <= vb.model.cols
-  assert upper.startswith(show_name)
-  assert show_name == upper or upper[len(show_name)] == ' '
+  assert show_name.endswith('...')
+  assert upper.startswith(show_name[:-3])
 
 
 # --- calendar cache ---
@@ -1250,8 +1332,8 @@ def test_get_variables_next_up_long_show_name_truncated(config_with_tokens: Path
   show_name = result['show_name'][0][0]
   upper = long_title.upper()
   assert vb.display_len(show_name) <= vb.model.cols
-  assert upper.startswith(show_name)
-  assert show_name == upper or upper[len(show_name)] == ' '
+  assert show_name.endswith('...')
+  assert upper.startswith(show_name[:-3])
 
 
 def test_get_variables_next_up_does_not_leak_credentials(config_with_tokens: Path) -> None:

--- a/tests/core/test_vestaboard.py
+++ b/tests/core/test_vestaboard.py
@@ -162,6 +162,12 @@ def test_truncate_word_no_space_falls_back_to_hard() -> None:
   assert vb.truncate_line('HELLOWORLD', 5, 'word') == 'HELLO'
 
 
+def test_truncate_word_last_word_fits_exactly() -> None:
+  # Last word ends exactly at the column limit — must include it, not trim back
+  # (regression: was returning 'AB' instead of 'AB CD')
+  assert vb.truncate_line('AB CD EF', 5, 'word') == 'AB CD'
+
+
 def test_truncate_preserves_color_tag() -> None:
   # Truncating to 1 display char should return the full [G] token, not split it
   assert vb.truncate_line('[G]AB', 1) == '[G]'

--- a/tests/integrations/test_tmdb_integration.py
+++ b/tests/integrations/test_tmdb_integration.py
@@ -55,13 +55,14 @@ def test_get_movie_title_live(require_env: None, monkeypatch: pytest.MonkeyPatch
 @pytest.mark.integration
 @pytest.mark.require_env('TMDB_API_READ_ACCESS_TOKEN')
 def test_find_episode_by_tvdb_id_live(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
-  """find_episode_by_tvdb_id() returns a valid (season, episode, title, show_id) tuple."""
+  """find_episode_by_tvdb_id() returns a valid (season, episode, title, show_id, tmdb_episode_id) tuple."""
   _patch_config(monkeypatch)
   # TVDb episode ID 5073066 = Attack on Titan S4E16 in TMDb ordering
   result = tmdb.find_episode_by_tvdb_id(5073066)
   if result is not None:
-    season, episode, title, show_id = result
+    season, episode, title, show_id, tmdb_episode_id = result
     assert isinstance(season, int) and season > 0
     assert isinstance(episode, int) and episode > 0
     assert isinstance(title, str)
     assert isinstance(show_id, int) and show_id > 0
+    assert isinstance(tmdb_episode_id, int) and tmdb_episode_id > 0

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.36.0"
+version = "0.37.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- **Fix `truncate_line` word boundary bug** — `'word'` strategy was cutting one word short when the last word fit exactly at the column limit. "FRIEREN: BEYOND" at 15 cols was returning "FRIEREN:" instead of "FRIEREN: BEYOND"
- **Ellipsis truncation for show/movie names** — trakt.py and plex.py switched from `'word'` to `'ellipsis'` so more of a long title is visible (e.g. "FRIEREN: BEY..." instead of a hard word-boundary cut)
- **TMDb episode group lookup** — after resolving a TVDb episode ID to a base TMDb S/E, checks the show's type-6 (TV broadcast seasons) episode group for the canonical season/episode. Fixes Frieren showing as S1E36 instead of S2E8 (TMDb collapses Part 1 + Part 2 into a flat Season 1, but the episode group correctly models them as separate seasons)
- **Show_id validation** — `_canonicalize_episode` now verifies that the `show_id` returned by `find_episode_by_tvdb_id` matches the expected TMDb show ID before using the resolved S/E, preventing cross-show contamination
- **`find_episode_by_tvdb_id` return type** — extended from 4-tuple to 5-tuple, adding `tmdb_episode_id` needed for the episode group lookup

Closes #403

## Test plan

- [x] `test_truncate_word_last_word_fits_exactly` — new regression test for word boundary bug (`'AB CD EF'` at 5 cols → `'AB CD'`)
- [x] `test_get_episode_group_position_*` — four new tests covering correct lookup, specials skip, no type-6 group, and request failure
- [x] `test_canonicalize_episode_show_id_mismatch_uses_trakt_se` — mismatched show_id falls back to Trakt S/E
- [x] `test_canonicalize_episode_missing_tmdb_show_id_skips_episode_resolution` — no TMDb show ID skips episode resolution
- [x] `test_canonicalize_episode_uses_episode_group_position` — group lookup overrides base TMDb S/E (Frieren scenario)
- [x] `test_canonicalize_episode_falls_back_to_tmdb_base_when_group_unavailable` — group returns None → base TMDb used
- [x] Updated existing truncation tests in test_trakt.py and test_plex.py to assert ellipsis behavior
- [x] All 817 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
