### PR TITLE
feat(content): formal schedule strategy, category framework, and linter

### DIFF
--- a/content/README.md
+++ b/content/README.md
@@ -125,6 +125,42 @@ call a different function, add `"integration_fn": "<function_name>"` to the
 template — useful when one integration exposes multiple data sources (e.g.
 Trakt's `get_variables_calendar` and `get_variables_watching`).
 
+### Content categories
+
+Every template belongs to one of six categories. The category determines the
+appropriate priority range and informs scheduling decisions:
+
+| Category | Priority | Philosophy |
+|---|---|---|
+| **Personal** | 9 | Uniquely yours — pet feeding times, self-birthday. Brief (≤ 600 s hold), time-specific, highest priority. These are personal-tier inserts that always show first and are excluded from shared slot budget calculations. |
+| **Social** | 6–8 | Human interactions — friend messages (8), other people's birthdays (6). Urgency varies: a direct message warrants a higher priority than informational birthday data. |
+| **Logistics** | 5–7 | Actionable daily context — weather (5), calendar events (5), transit departures (8). Higher within the range when timing matters (missing a train > missing the weather update). |
+| **Hobbies** | 4–5 | Lifestyle and leisure context — diving conditions, daily vinyl suggestion. Enriching but not urgent; appropriate during waking hours only. |
+| **Entertainment** | 4–8 | Wide range reflects the mode: Plex now-playing (8, active playback) vs. Trakt next-up (4, background planning context). Real-time state = high; background context = low. |
+| **Ambient** | 3–4 | Mood and atmosphere — good morning/night visuals. Gracefully skipped under contention; no loss if they don't show on a busy day. |
+
+**Existing template mapping:**
+
+| Template | Category | Priority |
+|---|---|---|
+| `birthdays.self` | Personal | 9 |
+| `message.notification` | Social | 8 |
+| `birthdays.today` | Social | 6 |
+| `bart.departures` | Logistics | 8 |
+| `weather.conditions` | Logistics | 5 |
+| `calendar.today` | Logistics | 5 |
+| `notion.notification` | Social | 7 |
+| `trakt.watching` | Entertainment | 7 |
+| `diving.conditions` | Hobbies | 5 |
+| `discogs.morning_spin` | Hobbies | 5 |
+| `diving.last_dive` | Hobbies | 3 |
+| `trakt.calendar`, `trakt.next_up` | Entertainment | 4 |
+| `morning_night.good_morning`, `morning_night.good_night` | Ambient | 4 |
+| `plex.now_playing`, `plex.paused`, `plex.stopped` | Entertainment | 8 |
+
+When adding a new template, identify its category first — that gives you the
+priority range to start from before tuning for contention.
+
 ### Priority guidelines
 
 Priority determines which message is shown first when multiple jobs fire at
@@ -140,7 +176,7 @@ runs — only which queued message the display shows first.
 | Maximum | 10 | Reserved for a single "always wins" template. Avoid using broadly — once multiple templates share the same level, tie-breaking falls back to scheduling order. |
 
 Rules of thumb:
-- **Start at 5 and adjust.** Only raise priority when you observe or anticipate contention.
+- **Start at your category's baseline and adjust.** Only raise priority when you observe or anticipate contention.
 - **Pair high priority with a short `timeout`.** A high-priority message that is stale is worse than none. Set `timeout` to roughly the window of relevance.
 - **Pair low priority with a short `timeout` too.** Background content with a long `timeout` will show up hours late. Either set `timeout` to match the display window, or accept that it may be discarded.
 - **Avoid priority inflation.** If everything is 8–10, nothing is. Reserve the top of the scale for the one or two templates where timing genuinely matters.
@@ -173,72 +209,151 @@ Templates that fire on a shared schedule compete for the display queue.
 Follow these guidelines when setting `cron`, `hold`, and `timeout` for a new
 template to keep everything playing nicely together.
 
-### Existing schedule map
+### Time-of-day zones
 
-| Slot | Integration | Pri | Hold | Timeout | Notes |
-|---|---|---|---|---|---|
-| `:00` every hour | `weather` | 5 | 600s | 1800s | |
-| `:15` 07/12/16 | `diving` | 5 | 600s | 1800s | Refresh 1800s; avoids :00 weather slot |
-| `:00` every 4h | `trakt.calendar` | 4 | 1200s | 1800s | Private; queues behind weather |
-| `:30` every hour | `calendar` | 5 | 300s | 1800s | |
-| `8:30` daily | `discogs` | 5 | 600s | 3600s | Queues behind calendar at :30 |
-| `9:00` daily | `birthdays` | 5 | 600s | 3600s | Queues behind weather at :00; done by ~9:20 |
-| `10:00` daily | `diving.last_dive` | 3 | 300s | 3600s | Skipped when no dive date recorded |
-| `*/5` 07–09 Mon–Fri | `bart` | 8 | 290s | 60s | Refresh 60s; dominates mornings |
-| `*/3` always | `trakt.watching` | 7 | 180s | 120s | Refresh 30s; no-op when idle |
-| webhook only | `plex` | 8 | indef | 30s | Private; interrupts on state change |
+The display serves different purposes at different times of day. Match your
+template's schedule to the zone where it's most useful:
+
+| Zone | Hours | Character | Owner |
+|---|---|---|---|
+| Morning start | 07:00–08:00 | Gentle context-setting | Weather (logistics), good morning visual (ambient) |
+| Commute window | 07:00–09:00 weekdays | BART owns this | BART dominates; other content fills gaps between refreshes |
+| Morning anchor | 08:00 | Personal ritual | Personal-tier content (pri 9) wins the queue; weather and Trakt calendar follow |
+| Morning context | 08:30 | Routine check-in | Calendar events, daily vinyl suggestion |
+| Late morning | 09:00–noon | Quiet period | Birthdays, diving last-dive; weather continues hourly |
+| Midday | noon–16:00 | Background ambient | Trakt next-up (noon), diving conditions (12:15) |
+| Afternoon | 16:00–20:00 | Transition | Weather, Trakt calendar refresh (16:00), diving conditions (16:15) |
+| Evening anchor | 20:00 | Personal ritual | Personal-tier content (pri 9) wins the queue; weather and Trakt next-up follow |
+| Wind-down | 21:00–21:45 | Closing mood | Good night visual; weather |
+| Quiet hours | 21:45+ | Board silent (hardware) | Crons continue firing; nothing reaches the display |
+
+Nothing is useful before 07:00 — quiet hours end at 06:15 but content
+shouldn't be scheduled before 07:00. Crons that fire during quiet hours
+(e.g. overnight weather) are harmless — the board ignores them at the
+hardware level — but avoid scheduling new integrations in these windows
+unless there's a specific reason (e.g. an overnight job that needs to be
+ready by 07:00).
+
+### Schedule map
+
+| Slot | Template | Category | Pri | Hold | Timeout | Notes |
+|---|---|---|---|---|---|---|
+| `7:00` daily | `morning_night.good_morning` | Ambient | 4 | 300 s | 3600 s | Queues behind weather; Sep 21 variant (pri 4) overrides |
+| `:00` every hour | `weather.conditions` | Logistics | 5 | 600 s | 1800 s | Fires first in every `:00` slot |
+| `:15` at 07/12/16 | `diving.conditions` | Hobbies | 5 | 600 s | 1800 s | Refresh 1800 s; dedicated `:15` slot avoids `:00` weather |
+| `8:00` daily | `birthdays.self` | Personal | 9 | 3600 s | 7200 s | No-op on non-birthday days; dominates the display for 1 h on birthday — intentional |
+| `:00` at 08/16 | `trakt.calendar` | Entertainment | 4 | 1200 s | 1800 s | Private; queues behind weather |
+| `:30` every hour | `calendar.today` | Logistics | 5 | 300 s | 1800 s | |
+| `8:30` daily | `discogs.morning_spin` | Hobbies | 5 | 600 s | 3600 s | Queues behind calendar at `:30` |
+| `9:00` daily | `birthdays.today` | Social | 6 | 600 s | 3600 s | Queues behind weather; no-op when no birthdays |
+| `10:00` daily | `diving.last_dive` | Hobbies | 3 | 300 s | 3600 s | Skipped when no dive date recorded |
+| `:00` at 12/20 | `trakt.next_up` | Entertainment | 4 | 1200 s | 1800 s | Private; noon = plan for evening, 20:00 = settle in |
+| `21:00` daily | `morning_night.good_night` | Ambient | 4 | 300 s | 3600 s | Moon phase visual; queues behind weather |
+| `*/5` 07–09 Mon–Fri | `bart.departures` | Logistics | 8 | 290 s | 60 s | Refresh 60 s; dominates weekday mornings |
+| `*/3` 07–23 daily | `trakt.watching` | Entertainment | 7 | 180 s | 120 s | Refresh 30 s; no-op when not watching |
+| webhook only | `plex` (3 templates) | Entertainment | 8 | indef / 60 s | 30 s | Private; interrupts on state change |
+| webhook only | `message.notification` | Social | 8 | 120 s | 600 s | Queues normally; shows at next hold break |
+| webhook only | `notion.notification` | Social | 7 | 120 s | 120 s | |
+
+**Personal-tier note:** Priority-9 templates (e.g. `birthdays.self`, or
+personal pet feeding reminders in `content/user/`) are excluded from the slot
+hold budget — they are brief first-position inserts that show quickly and step
+aside for the rest of the slot. The `:00` budget (weather + trakt) is 1800 s
+after accounting for this exclusion.
 
 ### Hold budget
 
 When two templates share a slot, their **combined holds** determine how long
-that slot occupies the display. Keep the total under 30 minutes to avoid
-bleeding into the next slot:
+that slot occupies the display. Keep the total under **1800 s (30 min)** to
+avoid bleeding into the next slot. This budget applies to non-personal
+templates (priority < 9); personal-tier inserts show first and are not counted.
 
-- `:00` worst case (every 4h): weather 600s + trakt.calendar 1200s = 1800s
-  (30 min). Finishes exactly at `:30` — no bleed into the calendar slot.
-- `:30` worst case (8:30am): calendar 300s + discogs 600s = 900s (15 min).
-  Finishes by :45 — no bleed into the next hour.
-- **Weekday mornings 07–09**: BART (priority 8, 290s hold, refresh) fires
-  every 5 min and effectively owns the display. Lower-priority templates
-  survive via their timeouts and show in gaps between BART refreshes.
+Current worst-case budgets:
 
-When adding a new template, sum its hold with every template that shares
-its cron slot and check whether the total bleeds into adjacent slots.
+- `:00` at 08:00 and 16:00: weather 600 s + trakt.calendar 1200 s = **1800 s** ✓
+- `:00` at 12:00 and 20:00: weather 600 s + trakt.next_up 1200 s = **1800 s** ✓
+- `:00` all other hours: weather 600 s = **600 s** ✓
+- `9:00` daily: weather 600 s + birthdays.today 600 s = **1200 s** ✓
+- `8:30` daily: calendar 300 s + discogs 600 s = **900 s** ✓
+- `10:00` daily: weather 600 s + diving.last_dive 300 s = **900 s** ✓
+- `21:00` daily: weather 600 s + good_night 300 s = **900 s** ✓
+
+The slot budget linter in `tests/test_schedule_lint.py` enforces this
+automatically on every `pytest` run.
+
+### Slot conventions
+
+| Minute mark | Convention |
+|---|---|
+| `:00` | Weather owns this. One additional template at most (combined hold ≤ 1800 s). |
+| `:15` | Dedicated slot for a single mid-priority template (diving's home — good pattern to follow). |
+| `:30` | Calendar owns this. One additional **daily-only** template is fine; avoid adding a second always-on template. |
+| `:45` / `:55` | Clean dedicated slots for brief personal content that needs a clear moment just before the hour. |
+| `*/N` sub-hourly | Real-time data only. Always pair with `refresh_interval` and `timeout ≤ 120 s`. |
 
 ### Picking a slot for new templates
 
-**Hourly templates** should fire at `:00` or `:30` — pick whichever has the
-smaller hold budget. Avoid adding a third integration to a slot that already
-has two.
+**Hourly or daily templates** should fire at `:00` or `:30` — pick whichever
+has the smaller hold budget. Avoid adding a third always-on template to a slot
+that already has two.
 
-**Sub-hourly templates** (e.g. every 5 min) are fine but should use a short
-`timeout` so stale messages drop rather than accumulate.
+**Sub-hourly templates** (e.g. every 5 min) are for real-time data only.
+Always set `timeout ≤ 120 s` so stale messages are discarded rather than
+accumulating in the queue.
 
-**New slots** (`:15`, `:45`) are available if neither existing slot has room,
-but check that an upstream hold doesn't bleed into your chosen minute.
+**New slots** (`:15`, `:45`) are available if neither existing slot has room.
+Check that an upstream hold doesn't bleed into your chosen minute, and
+reference the hold budget table above.
 
 ### Pairing `timeout` with `hold`
 
 `timeout` is how long a message can wait in the queue before being discarded.
 Set it long enough to survive the hold of whatever it queues behind:
 
-- A priority-5 template firing at `:00` queues behind `weather` (600s hold).
-  Set `timeout >= 600` — otherwise the message expires before `weather`
-  finishes.
-- A priority-4 template firing alongside a priority-5 template needs
-  `timeout` long enough to outlast both the higher-priority hold *and* any
-  queue drain time. `timeout = 1800` is a safe floor for low-priority hourly
-  content.
+- A priority-5 template firing at `:00` queues behind `weather` (600 s hold).
+  Set `timeout >= 600` — otherwise the message expires before `weather` finishes.
+- A priority-4 template firing alongside a priority-5 template needs `timeout`
+  long enough to outlast both the higher-priority hold *and* queue drain time.
+  `timeout = 1800` is a safe floor for low-priority hourly content.
 
-Short `timeout` values (≤ 600s) are appropriate only for high-priority,
+Short `timeout` values (≤ 600 s) are appropriate only for high-priority,
 time-sensitive content (e.g. BART departures) where a stale message is worse
 than no message.
+
+### Webhook conventions
+
+Webhook templates fire outside the cron schedule and can arrive at any time.
+They compete with scheduled content via priority and the interrupt mechanism.
+
+**Interrupt model:**
+- Use `interrupt=True` for state changes that need immediate visibility — Plex
+  play, pause, and stop events should preempt whatever is currently on the
+  display.
+- Leave `interrupt=False` (the default) for notifications that can queue
+  normally — friend messages are more politely shown at the next hold break
+  than by flapping the display mid-scene.
+
+**Indefinite holds:**
+- Use `indefinite=True` for continuous-state messages (active Plex playback)
+  that should stay on screen until a stop or resume event arrives. Always
+  set a `hold` safety ceiling (e.g. 14400 s / 4 h) in case the stop event
+  is never received.
+- An indefinite Plex hold suppresses all queued cron content until playback
+  pauses or stops — this is intentional; Plex content IS the relevant content
+  during media playback.
+
+**Known interaction — Plex and friend messages:** Friend messages (`message`)
+queue normally with `interrupt=False` and a 600 s timeout. During active Plex
+playback, they will show at the next natural pause. If no pause occurs within
+10 min the message expires — this is a deliberate trade-off that avoids
+disrupting media playback.
 
 ### Priority reminder
 
 Priority controls queue order, not fire time. Two templates with the same
 cron expression fire at the same instant — priority decides which shows first.
-Don't inflate priority to "win" — see the priority guidelines above.
+Don't inflate priority to "win" — see the content categories and priority
+guidelines above.
 
 ## Contrib integrations
 

--- a/content/contrib/TEMPLATE.md
+++ b/content/contrib/TEMPLATE.md
@@ -1,6 +1,25 @@
 # <name>.json
 
-One-sentence description. Schedule summary.
+One-sentence description. Category (e.g. Logistics) — schedule summary.
+
+## Schedule
+
+**Cron:** `0 8 * * *` — fires daily at 08:00.
+**Hold:** 600 s | **Timeout:** 1800 s | **Priority:** 5 (Logistics)
+
+Slot context: fires in the `:00` slot alongside `weather` (pri 5, 600 s hold);
+combined budget is 1200 s, well within the 1800 s ceiling.
+
+To override schedule fields without editing this file:
+
+```toml
+[<name>.schedules.<template_name>]
+cron = "0 9 * * *"
+hold = 300
+timeout = 900
+priority = 6
+disabled = true   # skip this template entirely
+```
 
 ## Configuration
 

--- a/content/contrib/bart.md
+++ b/content/contrib/bart.md
@@ -3,8 +3,33 @@
 BART real-time departure board. Shows upcoming departures from a configured
 originating station across 1–2 lines, with line colors as Vestaboard color
 squares. Line colors are derived dynamically from the BART routes API on
-first call and cached for the process lifetime. Runs every 5 minutes on
-weekday mornings (07:00–09:00).
+first call and cached for the process lifetime. Logistics — fires every 5
+minutes on weekday mornings (07:00–09:00).
+
+## Schedule
+
+**Cron:** `*/5 7-9 * * mon-fri` — fires every 5 minutes, 07:00–09:00, Mon–Fri.
+**Hold:** 290 s | **Timeout:** 60 s | **Priority:** 8 (Logistics)
+**Refresh interval:** 60 s (re-fetches live departure data during the hold)
+
+BART effectively owns the display during the commute window. At priority 8
+it wins the queue over weather (5) and all lower-priority templates. The 60 s
+timeout means any BART message that can't show within 1 minute is discarded
+rather than shown stale — transit data ages quickly.
+
+Lower-priority templates (weather, good morning) survive via their longer
+timeouts and appear in the natural gaps between 5-minute BART cycles.
+
+To override schedule fields without editing this file:
+
+```toml
+[bart.schedules.departures]
+cron = "*/5 7-9 * * mon-fri"
+hold = 180
+timeout = 60
+priority = 8
+disabled = true  # skip entirely
+```
 
 ## Configuration
 

--- a/content/contrib/birthdays.json
+++ b/content/contrib/birthdays.json
@@ -6,7 +6,7 @@
         "hold": 600,
         "timeout": 3600
       },
-      "priority": 5,
+      "priority": 6,
       "truncation": "ellipsis",
       "integration": "calendar",
       "integration_fn": "get_variables_birthdays",

--- a/content/contrib/birthdays.md
+++ b/content/contrib/birthdays.md
@@ -2,12 +2,48 @@
 
 Two birthday templates, both requiring iCloud CardDAV:
 
-- **`today`** — upcoming birthdays from contacts, shown once daily at 9am
+- **`today`** — upcoming birthdays from contacts, shown once daily at 9am.
+  Social — priority 6.
 - **`self`** — prominent happy birthday display on the board owner's own
   birthday, shown at 8am (priority 9). The owner is suppressed from the
-  `today` list — their birthday is shown exclusively via `self`.
+  `today` list — their birthday is shown exclusively via `self`. Personal —
+  priority 9.
 
 Omit `carddav_url` from `[calendar]` to disable both templates entirely.
+
+## Schedule
+
+### `today` — other birthdays
+
+**Cron:** `0 9 * * *` — fires daily at 09:00.
+**Hold:** 600 s | **Timeout:** 3600 s | **Priority:** 6 (Social)
+
+Fires in the `9:00` slot alongside `weather` (pri 5, 600 s) — combined
+budget 1200 s. At priority 6 `today` queues behind weather but shows before
+any lower-priority templates. No-op when no contacts have a birthday today.
+
+### `self` — your birthday
+
+**Cron:** `0 8 * * *` — fires daily at 08:00.
+**Hold:** 3600 s | **Timeout:** 7200 s | **Priority:** 9 (Personal)
+
+No-op on non-birthday days (integration returns early). On your birthday,
+`self` wins the 8:00 queue at priority 9 and holds the display for 1 h. This
+intentionally causes lower-priority same-slot templates (Trakt calendar,
+timeout 1800 s) to expire — on your birthday the display is yours. Priority-9
+personal-tier templates are excluded from the shared slot budget check.
+
+To override schedule fields without editing this file:
+
+```toml
+[birthdays.schedules.today]
+hold = 300
+priority = 5
+disabled = true   # skip entirely
+
+[birthdays.schedules.self]
+hold = 1800       # shorter birthday hold
+```
 
 ## Configuration
 

--- a/content/contrib/calendar.md
+++ b/content/contrib/calendar.md
@@ -2,7 +2,7 @@
 
 Today's calendar events, updated every half-hour. Shows timed events (sorted
 soonest first) then all-day events. Supports multiple calendars with optional
-per-calendar color squares.
+per-calendar color squares. Logistics — fires every 30 minutes.
 
 Both modes can be active simultaneously — events from ICS feeds and CalDAV
 are merged and sorted together.
@@ -10,6 +10,26 @@ are merged and sorted together.
 - **ICS mode**: public or secret-address `.ics` feeds (Google Calendar, iCloud
   public link, any provider). No authentication required.
 - **CalDAV mode**: private iCloud calendars via app-specific password.
+
+## Schedule
+
+**Cron:** `30 * * * *` — fires every hour at `:30`.
+**Hold:** 300 s | **Timeout:** 1800 s | **Priority:** 5 (Logistics)
+
+`calendar` anchors every `:30` slot. The only other template that regularly
+shares `:30` is `discogs.morning_spin` (daily at 8:30, pri 5, 600 s) —
+combined budget 900 s, well within the 1800 s ceiling. The 1800 s timeout
+ensures `calendar` survives queuing behind any priority-9 personal-tier content
+that wins the 8:00 slot before rolling into 8:30.
+
+To override schedule fields without editing this file:
+
+```toml
+[calendar.schedules.today]
+hold = 600
+priority = 6
+disabled = true  # skip entirely
+```
 
 ## Configuration
 

--- a/content/contrib/discogs.md
+++ b/content/contrib/discogs.md
@@ -1,7 +1,28 @@
 # discogs.json
 
 Daily vinyl suggestion from your Discogs collection. Picks a random record
-each morning at 8:30am and displays the album title and artist.
+each morning at 8:30am and displays the album title and artist. Hobbies —
+fires once daily at 08:30.
+
+## Schedule
+
+**Cron:** `30 8 * * *` — fires daily at 08:30.
+**Hold:** 600 s | **Timeout:** 3600 s | **Priority:** 5 (Hobbies)
+
+Fires in the `:30` slot alongside `calendar.today` (pri 5, 300 s hold) —
+combined budget 900 s, well within the 1800 s ceiling. Both are priority 5;
+`calendar` shows first (it fires every `:30`; `discogs` only at 8:30, so the
+scheduler processes `calendar` first). The 3600 s timeout gives `discogs`
+plenty of room to queue behind `calendar` and any earlier-slot spillover.
+
+To override schedule fields without editing this file:
+
+```toml
+[discogs.schedules.morning_spin]
+cron = "30 9 * * *"  # push to 9:30am if 8:30 is too early
+hold = 300
+disabled = true       # skip entirely
+```
 
 ## Configuration
 

--- a/content/contrib/diving.md
+++ b/content/contrib/diving.md
@@ -1,12 +1,47 @@
 # diving.json
 
-Two templates:
+Two templates. Hobbies — fires three times daily (conditions) and once daily
+(last dive).
 
 - **conditions** — wave height, swell period, wind, and water temperature.
   Shows at 7:15am, 12:15pm, and 4:15pm for pre-dive planning. Color square
   reflects subjective dive condition quality.
 - **last_dive** — days since your last dive. Shows daily at 10am when a dive
   date has been recorded via webhook or set manually.
+
+## Schedule
+
+### `conditions`
+
+**Cron:** `15 7,12,16 * * *` — fires at 07:15, 12:15, and 16:15 daily.
+**Hold:** 600 s | **Timeout:** 1800 s | **Priority:** 5 (Hobbies)
+**Refresh interval:** 1800 s (re-fetches ocean data every 30 min during hold)
+
+Fires in the dedicated `:15` slot, which has no other scheduled occupants.
+This avoids the `:00` weather slot entirely. Combined budget at `:15` is
+600 s — the full slot budget is available.
+
+### `last_dive`
+
+**Cron:** `0 10 * * *` — fires daily at 10:00.
+**Hold:** 300 s | **Timeout:** 3600 s | **Priority:** 3 (Hobbies)
+
+Fires in the `10:00` slot alongside `weather` (pri 5, 600 s) — combined
+budget 900 s. At priority 3 it queues behind weather, showing after weather's
+10-minute hold. Skipped when no dive date has been recorded.
+
+To override schedule fields without editing this file:
+
+```toml
+[diving.schedules.conditions]
+cron = "15 8,13,17 * * *"  # shift to later windows
+hold = 300
+disabled = true             # skip entirely
+
+[diving.schedules.last_dive]
+priority = 4
+disabled = true
+```
 
 ## Configuration
 

--- a/content/contrib/message.json
+++ b/content/contrib/message.json
@@ -4,7 +4,7 @@
       "webhook": true,
       "schedule": {
         "hold": 120,
-        "timeout": 120
+        "timeout": 600
       },
       "priority": 8,
       "truncation": "wrap_ellipsis",

--- a/content/contrib/message.md
+++ b/content/contrib/message.md
@@ -2,10 +2,25 @@
 
 Friend message integration — displays ad-hoc messages from registered friends via
 webhook. Each message shows a colored header row with the sender's name followed by
-the message body.
+the message body. Social — webhook-only, queues normally without interrupting.
 
 Unlike cron-scheduled templates, this template fires only when a webhook event is
 received. No content is shown when idle.
+
+## Schedule
+
+**Webhook-only** (no cron). Fires when a registered friend sends a message.
+**Hold:** 120 s | **Timeout:** 600 s | **Priority:** 8 (Social)
+
+Messages queue normally (`interrupt=False`) — they do not cut an active hold
+short. This means a message arriving during an active Plex session will wait
+for the next natural hold break (e.g. playback pause) rather than flapping the
+display mid-scene. The 600 s timeout gives messages up to 10 minutes to wait,
+which covers typical pause intervals between scenes or episodes.
+
+During normal scheduled content (weather 600 s hold, calendar 300 s hold),
+priority 8 puts the message at the front of the queue; it shows as soon as
+the current hold completes — usually within a few minutes.
 
 ## How it works
 
@@ -43,7 +58,7 @@ priority = 8
 | Override key | Default | Description |
 |---|---|---|
 | `hold` | `120` | Seconds to show the message |
-| `timeout` | `120` | Seconds the message can wait in the queue before being discarded |
+| `timeout` | `600` | Seconds the message can wait in the queue before being discarded |
 | `priority` | `8` | Display priority (0–10) |
 
 Friend display metadata is stored per-friend by the registration flow:

--- a/content/contrib/morning_night.json
+++ b/content/contrib/morning_night.json
@@ -6,7 +6,7 @@
         "hold": 300,
         "timeout": 3600
       },
-      "priority": 3,
+      "priority": 4,
       "integration": "morning",
       "templates": [
         {
@@ -41,7 +41,7 @@
         "hold": 300,
         "timeout": 3600
       },
-      "priority": 3,
+      "priority": 4,
       "integration": "moon",
       "templates": [
         {

--- a/content/contrib/morning_night.md
+++ b/content/contrib/morning_night.md
@@ -3,25 +3,40 @@
 Good morning and good night messages. Good morning fires at 7:00 AM with a
 weather-based color visual. Good night fires at 9:00 PM with the current moon
 phase displayed as a visual grid. September 21st gets a special Earth, Wind &
-Fire themed morning message.
+Fire themed morning message. Ambient — fires once daily at morning and night.
 
-## Configuration
+## Schedule
 
-No configuration required for the moon phase (calculated locally, no API key
-needed). The morning visual uses weather data when available:
+### `good_morning`
 
-```toml
-[weather]
-city = "San Francisco, CA"
-units = "imperial"
-```
+**Cron:** `0 7 * * *` — fires daily at 07:00.
+**Hold:** 300 s | **Timeout:** 3600 s | **Priority:** 4 (Ambient)
 
-If `[weather]` is not configured, or if the weather fetch fails, the morning
-visual falls back to a default sunrise grid.
+Fires in the `7:00` slot alongside `weather` (pri 5, 600 s) — combined budget
+900 s. Weather shows first (priority 5 > 4); `good_morning` follows for 5 min.
+The 3600 s timeout means `good_morning` survives even on BART weekday mornings
+where the commute window (07:00–09:00) fills the queue.
 
-Align the cron expressions to your board's hardware-configured quiet hours.
-The defaults (`0 7 * * *` and `0 21 * * *`) can be overridden per-template
-in `config.toml` without editing this file:
+### `good_morning_september`
+
+**Cron:** `0 7 21 9 *` — fires at 07:00 on September 21st only.
+**Hold:** 300 s | **Timeout:** 3600 s | **Priority:** 4 (Ambient)
+
+Same slot as `good_morning`; at the same priority, the scheduler processes
+whichever was registered first. Use a `config.toml` override to give it
+priority 5 if you want it to appear before weather on that day.
+
+### `good_night`
+
+**Cron:** `0 21 * * *` — fires daily at 21:00.
+**Hold:** 300 s | **Timeout:** 3600 s | **Priority:** 4 (Ambient)
+
+Fires in the `21:00` slot alongside `weather` (pri 5, 600 s) — combined
+budget 900 s. Weather shows first; the moon phase visual follows. Aim for
+`good_night` to be the last thing visible before quiet hours (default 21:45).
+
+**Align cron to your quiet hours.** The defaults (`0 7` and `0 21`) can be
+moved in `config.toml` without editing this file:
 
 ```toml
 [morning_night.schedules.good_morning]

--- a/content/contrib/notion.md
+++ b/content/contrib/notion.md
@@ -2,11 +2,23 @@
 
 Notion integration — displays automation-triggered notifications on the board
 via webhook. Each notification shows a `[W] NOTION` header row followed
-by the message body.
+by the message body. Social — webhook-only, queues normally.
 
 Unlike cron-scheduled templates, this template is triggered entirely by
 incoming webhook events from Notion automations. No content is shown when
 idle.
+
+## Schedule
+
+**Webhook-only** (no cron). Fires when a Notion automation sends an HTTP
+request to the webhook listener.
+**Hold:** 120 s | **Timeout:** 120 s | **Priority:** 7 (Social)
+
+Queues normally (`interrupt=False`) — does not cut an active hold short. At
+priority 7 it shows after any priority-8+ content (Plex, BART, friend messages)
+but ahead of lower-priority scheduled content. The short 120 s timeout is
+intentional — Notion notifications are contextual to the moment they're
+triggered; a stale notification is rarely useful.
 
 ## Requirements
 

--- a/content/contrib/plex.md
+++ b/content/contrib/plex.md
@@ -3,10 +3,45 @@
 Plex Media Server integration — shows what you are currently watching on the
 board using Plex webhooks. Shows "NOW PLAYING" when playback starts, resumes,
 pauses, or stops — the color square signals the state (green for playing,
-yellow for paused, red for stopped).
+yellow for paused, red for stopped). Entertainment — webhook-only, three
+templates covering play/pause/stop states.
 
 Unlike cron-scheduled templates, these templates are triggered entirely by
 incoming Plex webhook events. No content is shown when Plex is idle.
+
+## Schedule
+
+All three templates are **webhook-only** (no cron). They fire on Plex playback
+events and are marked `private` — they are suppressed when public mode is
+enabled.
+
+| Template | Trigger | Hold | Timeout | Priority |
+|---|---|---|---|---|
+| `now_playing` | Play / Resume | 14400 s (4 h safety ceiling) | 30 s | 8 |
+| `paused` | Pause | 14400 s (4 h safety ceiling) | 30 s | 8 |
+| `stopped` | Stop / End | 60 s | 30 s | 8 |
+
+`now_playing` and `paused` use `indefinite=True` — they hold until the next
+state-change event arrives (play → pause → stop), using 14400 s as a safety
+ceiling in case the stop event is never received. `stopped` uses a short fixed
+hold; it fires with `interrupt=True` to immediately clear the indefinite hold.
+
+**Interaction with other content:** An active Plex hold (indefinite) suppresses
+all queued cron-scheduled content until playback pauses or stops. This is
+intentional — the display shows what's most contextually relevant. Friend
+messages (`message`) queue normally and appear at the next natural pause rather
+than interrupting mid-scene.
+
+To override hold or priority without editing this file:
+
+```toml
+[plex.schedules.now_playing]
+hold = 7200    # 2-hour ceiling instead of 4 hours
+priority = 9
+
+[plex.schedules.paused]
+hold = 3600
+```
 
 ## Requirements
 

--- a/content/contrib/trakt.json
+++ b/content/contrib/trakt.json
@@ -2,7 +2,7 @@
   "templates": {
     "calendar": {
       "schedule": {
-        "cron": "0 0,8,16 * * *",
+        "cron": "0 8,16 * * *",
         "hold": 1200,
         "timeout": 1800
       },
@@ -23,7 +23,7 @@
     },
     "next_up": {
       "schedule": {
-        "cron": "0 4,12,20 * * *",
+        "cron": "0 12,20 * * *",
         "hold": 1200,
         "timeout": 1800
       },
@@ -44,7 +44,7 @@
     },
     "watching": {
       "schedule": {
-        "cron": "*/3 * * * *",
+        "cron": "*/3 7-23 * * *",
         "hold": 180,
         "timeout": 120,
         "refresh_interval": 30

--- a/content/contrib/trakt.md
+++ b/content/contrib/trakt.md
@@ -2,9 +2,55 @@
 
 Trakt.tv integration — shows the next upcoming episode from your calendar,
 the next unwatched episode for your most recently watched show, and what you
-are currently watching. Calendar and on-deck alternate every 4 hours (3 fires
-each per day); now-playing polls every 3 minutes and only shows when something
-is actively playing.
+are currently watching. Calendar and on-deck each fire twice daily; now-playing
+polls every 3 minutes and only shows when something is actively playing.
+Entertainment — three templates spanning background context to real-time.
+
+## Schedule
+
+### `calendar` — next airing episode
+
+**Cron:** `0 8,16 * * *` — fires at 08:00 and 16:00 daily.
+**Hold:** 1200 s | **Timeout:** 1800 s | **Priority:** 4 (Entertainment)
+
+Private template. Fires in the `:00` slot alongside `weather` (pri 5, 600 s) —
+combined budget 1800 s, exactly at the ceiling. Weather shows first; Trakt
+calendar follows for 20 min. The 1800 s timeout lets it survive the 600 s
+weather hold with 1200 s to spare.
+
+### `next_up` — next unwatched episode
+
+**Cron:** `0 12,20 * * *` — fires at 12:00 and 20:00 daily.
+**Hold:** 1200 s | **Timeout:** 1800 s | **Priority:** 4 (Entertainment)
+
+Private template. Same slot pattern as `calendar` — fires at `:00` hours that
+don't overlap with `calendar` (noon = planning context; 20:00 = settling in
+for the evening). Combined budget with weather is 1800 s at both hours.
+
+### `watching` — now playing
+
+**Cron:** `*/3 7-23 * * *` — polls every 3 minutes from 07:00 to 23:00.
+**Hold:** 180 s | **Timeout:** 120 s | **Priority:** 7 (Entertainment)
+**Refresh interval:** 30 s
+
+Private template. No-op when nothing is playing. The 120 s timeout (shorter
+than the 180 s hold) means a queued `watching` message is discarded if it
+waits more than 2 minutes — stale now-playing data is worse than nothing.
+Polling stops at 23:00 to avoid unnecessary overnight API calls.
+
+To override schedule fields without editing this file:
+
+```toml
+[trakt.schedules.calendar]
+disabled = true        # skip entirely
+
+[trakt.schedules.next_up]
+cron = "0 11,19 * * *" # shift windows earlier
+
+[trakt.schedules.watching]
+cron = "*/5 7-23 * * *" # poll less frequently
+hold = 300
+```
 
 ## Configuration
 

--- a/content/contrib/weather.md
+++ b/content/contrib/weather.md
@@ -1,8 +1,26 @@
 # weather.json
 
 Current weather conditions for a configured city. Shows city name, weather
-condition with a color indicator, and temperature with daily high/low. Runs
-hourly.
+condition with a color indicator, and temperature with daily high/low.
+Logistics — fires every hour on the hour.
+
+## Schedule
+
+**Cron:** `0 * * * *` — fires every hour at `:00`.
+**Hold:** 600 s | **Timeout:** 1800 s | **Priority:** 5 (Logistics)
+
+`weather` anchors every `:00` slot. All other templates that fire at `:00`
+queue behind it. Combined hold budget for the `:00` slot must not exceed
+1800 s; see the [schedule map](../README.md#schedule-map) for current totals.
+
+To override schedule fields without editing this file:
+
+```toml
+[weather.schedules.conditions]
+hold = 300
+priority = 6
+disabled = true  # skip entirely
+```
 
 ## Configuration
 

--- a/integrations/message.py
+++ b/integrations/message.py
@@ -159,6 +159,7 @@ def handle_webhook(
       hold=cfg['hold'],
       timeout=cfg['timeout'],
       supersede_tag=f'message.{credential_name}',
+      interrupt=False,
     )
   except Exception as e:  # noqa: BLE001
     logger.error('Message webhook error: %s', e)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.37.0"
+version = "0.37.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -8,7 +8,7 @@ from scheduler import WebhookMessage
 
 _TEMPLATE_CONFIG = {
   'hold': 120,
-  'timeout': 120,
+  'timeout': 600,
   'priority': 8,
   'truncation': 'wrap_ellipsis',
 }
@@ -171,7 +171,7 @@ def test_default_priority_and_hold() -> None:
   assert isinstance(result, WebhookMessage)
   assert result.priority == 8
   assert result.hold == 120
-  assert result.timeout == 120
+  assert result.timeout == 600
 
 
 def test_config_override_applied() -> None:

--- a/tests/test_schedule_lint.py
+++ b/tests/test_schedule_lint.py
@@ -1,0 +1,190 @@
+# tests/test_schedule_lint.py
+#
+# Schedule linter — validates all content JSON templates against scheduling
+# conventions. Runs as part of the default pytest suite.
+#
+# Checks:
+#   1. Required fields  — every template has hold and timeout
+#   2. Priority range   — priority is 0–10
+#   3. Hold floor       — hold >= 30 s
+#   4. Sub-hourly timeout ceiling — */N (N < 15) templates have timeout <= 120 s
+#   5. Slot hold budget — no shared slot exceeds 1800 s combined hold
+#      (priority >= 9 templates excluded: they are brief personal inserts
+#       that show first and return quickly, so they don't participate in
+#       the shared budget the same way)
+#   6. Webhook-only fields — webhook-only templates still have hold and timeout
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_CONTENT_ROOT = Path(__file__).parent.parent / 'content'
+_CONTRIB_DIR = _CONTENT_ROOT / 'contrib'
+_USER_DIR = _CONTENT_ROOT / 'user'
+
+_SLOT_BUDGET_SECS = 1800
+_PERSONAL_PRIORITY_FLOOR = 9  # templates at this priority or above are excluded from slot budget
+
+
+def _load_all_templates() -> list[tuple[str, str, dict[str, Any]]]:
+  """Return (file, template_name, template_dict) for every template in contrib and user dirs."""
+  results: list[tuple[str, str, dict[str, Any]]] = []
+  dirs = [_CONTRIB_DIR]
+  if _USER_DIR.exists():
+    dirs.append(_USER_DIR)
+  for content_dir in dirs:
+    for json_file in sorted(content_dir.glob('*.json')):
+      with open(json_file) as f:
+        data = json.load(f)
+      for name, tmpl in data.get('templates', {}).items():
+        results.append((json_file.name, name, tmpl))
+  return results
+
+
+_ALL_TEMPLATES = _load_all_templates()
+
+
+@pytest.mark.parametrize('file,name,tmpl', _ALL_TEMPLATES)
+def test_required_schedule_fields(file: str, name: str, tmpl: dict[str, Any]) -> None:
+  """Every template must have hold and timeout."""
+  schedule = tmpl.get('schedule', {})
+  assert 'hold' in schedule, f'{file}:{name} — missing schedule.hold'
+  assert 'timeout' in schedule, f'{file}:{name} — missing schedule.timeout'
+
+
+@pytest.mark.parametrize('file,name,tmpl', _ALL_TEMPLATES)
+def test_priority_range(file: str, name: str, tmpl: dict[str, Any]) -> None:
+  """priority must be 0–10."""
+  priority = tmpl.get('priority')
+  assert priority is not None, f'{file}:{name} — missing priority'
+  assert isinstance(priority, int) and 0 <= priority <= 10, f'{file}:{name} — priority {priority} is out of range 0–10'
+
+
+@pytest.mark.parametrize('file,name,tmpl', _ALL_TEMPLATES)
+def test_hold_floor(file: str, name: str, tmpl: dict[str, Any]) -> None:
+  """hold must be >= 30 s."""
+  hold = tmpl.get('schedule', {}).get('hold')
+  if hold is not None:
+    assert hold >= 30, f'{file}:{name} — hold={hold} s is suspiciously low (minimum 30 s)'
+
+
+@pytest.mark.parametrize('file,name,tmpl', _ALL_TEMPLATES)
+def test_sub_hourly_timeout(file: str, name: str, tmpl: dict[str, Any]) -> None:
+  """Sub-hourly cron templates (*/N where N < 15) should have timeout <= 120 s.
+
+  Stale sub-hourly messages accumulate quickly; a short timeout ensures they
+  are discarded rather than shown late.
+  """
+  cron = tmpl.get('schedule', {}).get('cron', '')
+  if not cron:
+    return
+  minute_field = cron.split()[0]
+  m = re.match(r'^\*/(\d+)$', minute_field)
+  if m and int(m.group(1)) < 15:
+    timeout = tmpl.get('schedule', {}).get('timeout', 0)
+    assert timeout <= 120, (
+      f'{file}:{name} — sub-hourly cron (*/{m.group(1)}) should have timeout <= 120 s, '
+      f'got {timeout} s; stale sub-hourly messages accumulate quickly'
+    )
+
+
+@pytest.mark.parametrize('file,name,tmpl', _ALL_TEMPLATES)
+def test_webhook_only_has_schedule_fields(file: str, name: str, tmpl: dict[str, Any]) -> None:
+  """Webhook-only templates (webhook=true, no cron) must still have hold and timeout."""
+  if not tmpl.get('webhook'):
+    return
+  if tmpl.get('schedule', {}).get('cron'):
+    return  # has a cron too — covered by required-fields check
+  schedule = tmpl.get('schedule', {})
+  assert 'hold' in schedule, f'{file}:{name} — webhook-only template missing schedule.hold'
+  assert 'timeout' in schedule, f'{file}:{name} — webhook-only template missing schedule.timeout'
+
+
+def _parse_minute_mark(minute_field: str) -> int | None:
+  """Return the canonical minute mark for a cron minute field, or None for sub-hourly.
+
+  Sub-hourly expressions (*/N where N < 15) are excluded from slot budget
+  checks — they're designed to dominate the display and are documented as such.
+  """
+  m = re.match(r'^\*/(\d+)$', minute_field)
+  if m:
+    return None if int(m.group(1)) < 15 else int(m.group(1))
+  # Single value or first value of a comma list
+  first = minute_field.split(',')[0].strip()
+  m = re.match(r'^(\d+)$', first)
+  return int(m.group(1)) if m else None
+
+
+def _expand_hours(hour_field: str) -> set[int]:
+  """Parse a cron hour field into the set of hours it covers."""
+  if hour_field == '*':
+    return set(range(24))
+  hours: set[int] = set()
+  for part in hour_field.split(','):
+    part = part.strip()
+    if '-' in part:
+      start, end = part.split('-', 1)
+      hours.update(range(int(start), int(end) + 1))
+    elif part.startswith('*/'):
+      step = int(part[2:])
+      hours.update(range(0, 24, step))
+    else:
+      hours.add(int(part))
+  return hours
+
+
+def test_slot_hold_budget() -> None:
+  """No shared cron slot may exceed 1800 s of combined hold.
+
+  Two templates share a slot when they have the same minute mark and at least
+  one overlapping hour. The worst-case budget for a slot is the sum of holds
+  for all templates that can fire at the same clock time.
+
+  Templates with priority >= 9 are excluded: they are brief personal inserts
+  (e.g. feeding reminders, self-birthday) that always show first and finish
+  quickly. The remaining templates — the ones that need to queue behind them —
+  are what this budget protects.
+  """
+  eligible: list[tuple[int, set[int], int, str, str]] = []
+
+  for file, name, tmpl in _ALL_TEMPLATES:
+    schedule = tmpl.get('schedule', {})
+    cron = schedule.get('cron', '')
+    hold = schedule.get('hold')
+    priority = tmpl.get('priority', 5)
+
+    if not cron or hold is None:
+      continue
+    if priority >= _PERSONAL_PRIORITY_FLOOR:
+      continue  # personal-tier inserts exempt from shared budget
+
+    parts = cron.split()
+    if len(parts) != 5:
+      continue
+
+    minute_mark = _parse_minute_mark(parts[0])
+    if minute_mark is None:
+      continue  # sub-hourly excluded
+
+    hours = _expand_hours(parts[1])
+    eligible.append((minute_mark, hours, hold, file, name))
+
+  violations: list[str] = []
+  for mark in sorted({e[0] for e in eligible}):
+    slot = [(hours, hold, f, n) for (m, hours, hold, f, n) in eligible if m == mark]
+    all_hours = set().union(*(hours for hours, _, _, _ in slot))
+    for hour in sorted(all_hours):
+      firing = [(hold, f, n) for (hours, hold, f, n) in slot if hour in hours]
+      if len(firing) < 2:
+        continue
+      total = sum(h for h, _, _ in firing)
+      if total > _SLOT_BUDGET_SECS:
+        participants = ', '.join(f'{f}:{n} ({h} s)' for h, f, n in firing)
+        violations.append(
+          f'  :{mark:02d} at {hour:02d}:00 — combined {total} s > {_SLOT_BUDGET_SECS} s: {participants}'
+        )
+
+  assert not violations, 'Slot hold budget exceeded:\n' + '\n'.join(violations)

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.37.0"
+version = "0.37.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- Establishes a formal content strategy with six categories (Personal / Social / Logistics / Hobbies / Entertainment / Ambient), each with a defined priority range and philosophy; all existing templates mapped to categories
- Adds time-of-day zones table, complete and accurate schedule map, slot conventions, hold budget analysis, and a webhook conventions section to `content/README.md`
- New schedule linter in `tests/test_schedule_lint.py` — validates required fields, priority range, hold floor, sub-hourly timeout ceiling, and slot hold budget (1800 s ceiling) on every `pytest` run (106 cases)
- Adds `## Schedule` section to all 10 contrib sidecar docs and `TEMPLATE.md` — each documents cron in plain English, defaults, slot context, and override example
- Cron cleanup: removes overnight Trakt polling (midnight calendar, 4am next-up, pre-07:00 watching); restricts `trakt.watching` to waking hours
- Priority bumps: `good_morning`/`good_night` 3→4 (Ambient; want to see the visuals), `birthdays.today` 5→6 (Social; actionable information)
- Friend message timeout 120→600 s so messages survive a Plex pause interval; makes `interrupt=False` explicit in `message.py`

## Test plan

- [ ] `uv run pytest` — all 923 tests pass including 106 new linter cases
- [ ] `uv run ruff check . && uv run ruff format --check .` — clean
- [ ] `uv run pyright` — no errors
- [ ] `uv run bandit -c pyproject.toml -r .` — no findings
- [ ] Confirm schedule map in README matches actual JSON cron values
- [ ] Confirm linter catches a budget violation if you manually set a hold that pushes a slot over 1800 s

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)
