### PR TITLE
chore(docs): document quiet-hours behaviour for webhook interrupt model

### DIFF
--- a/content/README.md
+++ b/content/README.md
@@ -348,6 +348,21 @@ playback, they will show at the next natural pause. If no pause occurs within
 10 min the message expires — this is a deliberate trade-off that avoids
 disrupting media playback.
 
+**Quiet hours and the interrupt model:** The interrupt mechanism assumes content
+was successfully sent to the board. During quiet hours the board rejects writes
+with a locked error — the scheduler clears its hold state and re-enqueues the
+message, so from the scheduler's perspective the board is idle. Two
+consequences:
+
+- **Webhooks that queue (no board-displacement check):** messages pile up in
+  the queue and drain in priority order once quiet hours end. State may be
+  briefly stale until the queue catches up.
+- **Webhooks with a board-displacement check** (currently only `plex`): state-
+  change events (pause, stop) are silently discarded while the board appears
+  idle. After quiet hours end the display may show a stale state until the next
+  event arrives. Avoid testing Plex state transitions during quiet hours — the
+  behaviour is misleading and is not a bug in the integration.
+
 ### Priority reminder
 
 Priority controls queue order, not fire time. Two templates with the same

--- a/content/contrib/plex.md
+++ b/content/contrib/plex.md
@@ -101,6 +101,14 @@ suppresses the "stopped" card if a play or resume arrives within that many
 seconds — avoiding a brief flash of the stopped state between episodes. Set to
 `0` to disable debouncing and always show the stopped card immediately.
 
+**Testing during quiet hours:** Plex state transitions (play → pause → stop)
+will not work correctly during the board's quiet hours. Pause and stop events
+include a board-displacement check — they are silently discarded if no Plex
+content is currently showing. During quiet hours, writes fail and the scheduler
+sees the board as idle, so pause/stop events are discarded as if playback
+weren't active. If you observe play/pause/stop not interrupting each other,
+check whether you were testing during quiet hours before investigating further.
+
 ## Webhook setup
 
 ### 1. Enable and expose the webhook listener


### PR DESCRIPTION
— *Claude Code*

## Summary

- Adds a generic note to `content/README.md` webhook conventions explaining that the interrupt model assumes successful board writes — during quiet hours, hold state is cleared and the board appears idle
- Distinguishes two failure modes: non-displacement webhooks queue up and drain after unlock; Plex (which uses a board-displacement check) silently discards pause/stop events, leaving stale state
- Adds a Plex-specific callout in `content/contrib/plex.md` flagging quiet hours as the first thing to rule out when debugging state-transition issues

Closes #408

## Test plan

- [ ] Read both doc sections for clarity and accuracy