### PR TITLE
fix(plex,trakt,tmdb): imdb fallback for ep lookup, surface tmdb ep title

### DIFF
--- a/integrations/plex.py
+++ b/integrations/plex.py
@@ -86,49 +86,79 @@ def _parse_guid_id(guids: list[dict[str, Any]], scheme: str) -> int | None:
   return None
 
 
-def _canonicalize_plex_title(raw_title: str, guids: list[dict[str, Any]], media_type: str) -> str:
-  """Return the canonical title via TMDb if configured and a matching Guid is present.
+def _parse_guid_id_str(guids: list[dict[str, Any]], scheme: str) -> str | None:
+  """Extract a string ID for the given scheme from a Plex Metadata.Guid array."""
+  for guid in guids:
+    guid_id = guid.get('id', '')
+    if guid_id.startswith(scheme):
+      value = guid_id[len(scheme) :]
+      return value if value else None
+  return None
 
-  For episodes, Plex sends episode-level external IDs in the Guid array, so
-  the tmdb:// entry is the TMDb episode ID (not the series ID). The tvdb://
-  entry is the TVDb episode ID, which TMDb's /find endpoint can resolve to the
-  TMDb series ID via the tv_episode_results[].show_id field.
 
-  For movies, the tmdb:// entry is the TMDb movie ID and is used directly.
+def _canonicalize_plex_title(raw_title: str, guids: list[dict[str, Any]], media_type: str) -> tuple[str, str | None]:
+  """Return (canonical_title, tmdb_episode_title_or_None) from TMDb.
 
-  Falls back to raw_title if TMDb is unconfigured, the Guid array has no
-  usable entry, or any lookup fails.
+  For episodes, tries tvdb:// first then imdb:// as a fallback. Returns both
+  the canonical show name and the TMDb episode title when resolved. The episode
+  title is None for movies and when all lookups fail.
+
+  For movies, the tmdb:// entry is the TMDb movie ID used for the show name.
+  Episode title is always None for movies.
+
+  Falls back to (raw_title, None) when TMDb is unconfigured, the Guid array
+  has no usable entry, or all lookups fail.
 
   media_type must be 'episode' or 'movie'.
   """
   import integrations.tmdb as _tmdb
 
   if not _tmdb.is_configured():
-    return raw_title
+    return raw_title, None
 
   if media_type == 'episode':
     tvdb_id = _parse_guid_id(guids, 'tvdb://')
-    if tvdb_id is None:
-      logger.debug('plex: no tvdb:// guid for episode %r, using raw title', raw_title)
-      return raw_title
-    ep_result = _tmdb.find_episode_by_tvdb_id(tvdb_id)
-    if ep_result is None:
+    if tvdb_id is not None:
+      ep_result = _tmdb.find_episode_by_tvdb_id(tvdb_id)
+      if ep_result is not None:
+        _, _, ep_title, show_id, _ = ep_result
+        canonical = _tmdb.get_show_title(show_id)
+        if canonical:
+          logger.debug('plex: tmdb canonical %r -> %r', raw_title, canonical)
+        else:
+          logger.debug('plex: tmdb show lookup failed for id=%d, using raw title %r', show_id, raw_title)
+        return canonical if canonical else raw_title, ep_title or None
       logger.debug('plex: tvdb ep lookup failed for id=%d, using raw title %r', tvdb_id, raw_title)
-      return raw_title
-    _, _, _, show_id, _ = ep_result
-    canonical = _tmdb.get_show_title(show_id)
-  else:
+      return raw_title, None
+    # No tvdb:// guid — fall back to imdb://
+    logger.debug('plex: no tvdb:// guid for episode %r, trying imdb://', raw_title)
+    imdb_id = _parse_guid_id_str(guids, 'imdb://')
+    if imdb_id:
+      ep_result = _tmdb.find_episode_by_imdb_id(imdb_id)
+      if ep_result is not None:
+        _, _, ep_title, show_id, _ = ep_result
+        canonical = _tmdb.get_show_title(show_id)
+        if canonical:
+          logger.debug('plex: tmdb canonical (via imdb) %r -> %r', raw_title, canonical)
+        else:
+          logger.debug('plex: tmdb imdb lookup show %d title failed, using raw title %r', show_id, raw_title)
+        return canonical if canonical else raw_title, ep_title or None
+      logger.debug('plex: imdb ep lookup failed for %r, using raw title %r', imdb_id, raw_title)
+    else:
+      logger.debug('plex: no imdb:// guid for episode %r, using raw title', raw_title)
+    return raw_title, None
+
+  else:  # movie
     tmdb_id = _parse_guid_id(guids, 'tmdb://')
     if tmdb_id is None:
       logger.debug('plex: no tmdb:// guid for %r, using raw title', raw_title)
-      return raw_title
+      return raw_title, None
     canonical = _tmdb.get_movie_title(tmdb_id)
-
-  if canonical:
-    logger.debug('plex: tmdb canonical %r -> %r', raw_title, canonical)
-  else:
-    logger.debug('plex: tmdb lookup failed, using raw title %r', raw_title)
-  return canonical if canonical else raw_title
+    if canonical:
+      logger.debug('plex: tmdb canonical %r -> %r', raw_title, canonical)
+    else:
+      logger.debug('plex: tmdb lookup failed, using raw title %r', raw_title)
+    return canonical if canonical else raw_title, None
 
 
 def _load_template_config(template_name: str) -> dict[str, Any]:
@@ -245,14 +275,16 @@ def handle_webhook(payload: dict[str, Any], credential_name: str | None = None) 
 
     if media_type == 'episode' and metadata:
       guids: list[dict[str, Any]] = metadata.get('Guid') or []
-      raw_show = _canonicalize_plex_title(metadata['grandparentTitle'], guids, 'episode')
+      raw_show, tmdb_ep_title = _canonicalize_plex_title(metadata['grandparentTitle'], guids, 'episode')
       show_name = _vb.truncate_line(raw_show.upper(), _vb.model.cols, 'ellipsis')
       episode_ref = _media.format_episode_ref(metadata['parentIndex'], metadata['index'])
-      episode_detail = _media.strip_leading_article((metadata.get('title') or '').upper())
+      plex_ep_title = (metadata.get('title') or '').strip()
+      episode_title = tmdb_ep_title or plex_ep_title
+      episode_detail = _media.strip_leading_article(episode_title.upper())
       episode_line = f'{episode_ref} {episode_detail}'.strip()
     elif media_type == 'movie' and metadata:
       guids = metadata.get('Guid') or []
-      raw_movie = _canonicalize_plex_title(metadata['title'], guids, 'movie')
+      raw_movie, _ = _canonicalize_plex_title(metadata['title'], guids, 'movie')
       show_name = _vb.truncate_line(raw_movie.upper(), _vb.model.cols, 'ellipsis')
       episode_line = ''
     else:

--- a/integrations/tmdb.py
+++ b/integrations/tmdb.py
@@ -136,6 +136,49 @@ def find_episode_by_tvdb_id(tvdb_episode_id: int) -> tuple[int, int, str, int, i
   return None
 
 
+@functools.lru_cache(maxsize=512)
+def find_episode_by_imdb_id(imdb_id: str) -> tuple[int, int, str, int, int] | None:
+  """Return (season, episode, title, show_id, tmdb_episode_id) for an IMDb episode ID.
+
+  Uses TMDb's /find endpoint with external_source=imdb_id. Same return shape as
+  find_episode_by_tvdb_id; used as a fallback when no TVDb episode ID is available.
+
+  Result is cached in-memory by IMDb ID for the lifetime of the process.
+  Returns None if the lookup fails or returns no results.
+  """
+  try:
+    r = fetch_with_retry(
+      'GET',
+      f'{_TMDB_API_BASE}/find/{imdb_id}',
+      headers=_request_headers(),
+      params={'external_source': 'imdb_id'},
+      timeout=10,
+    )
+    r.raise_for_status()
+    results = r.json().get('tv_episode_results', [])
+    if results:
+      ep = results[0]
+      season = ep.get('season_number')
+      episode = ep.get('episode_number')
+      show_id = ep.get('show_id')
+      tmdb_episode_id = ep.get('id')
+      title: str = ep.get('name') or ''
+      if season is not None and episode is not None and show_id is not None and tmdb_episode_id is not None:
+        logger.debug(
+          'TMDb: imdb_ep %s → S%dE%d %r (show=%d, tmdb_ep=%d)',
+          imdb_id,
+          season,
+          episode,
+          title,
+          show_id,
+          tmdb_episode_id,
+        )
+        return (season, episode, title, show_id, tmdb_episode_id)
+  except Exception as e:  # noqa: BLE001
+    logger.debug('TMDb: find_episode_by_imdb_id(%r) failed — %s', imdb_id, e)
+  return None
+
+
 @functools.lru_cache(maxsize=128)
 def _get_type6_group_id(show_id: int) -> str | None:
   """Return the TMDb episode group ID for the type-6 (TV seasons) group, or None."""

--- a/integrations/trakt.py
+++ b/integrations/trakt.py
@@ -335,10 +335,32 @@ def _canonicalize_episode(
             int(tmdb_show_id),
           )
         else:
-          season, number, ep_title = res_season, res_number, res_ep_title
+          season, number = res_season, res_number
+          if res_ep_title:
+            ep_title = res_ep_title
           group_pos = _tmdb.get_episode_group_position(int(tmdb_show_id), res_tmdb_ep_id)
           if group_pos:
             season, number = group_pos
+    elif tmdb_show_id:
+      # No TVDb episode ID — try IMDb as fallback
+      imdb_ep_id = ep_data.get('ids', {}).get('imdb')
+      if imdb_ep_id:
+        resolved = _tmdb.find_episode_by_imdb_id(str(imdb_ep_id))
+        if resolved:
+          res_season, res_number, res_ep_title, res_show_id, res_tmdb_ep_id = resolved
+          if res_show_id != int(tmdb_show_id):
+            logger.debug(
+              'TMDb: imdb ep show_id mismatch (got %d, expected %d) — falling back to Trakt S/E',
+              res_show_id,
+              int(tmdb_show_id),
+            )
+          else:
+            season, number = res_season, res_number
+            if res_ep_title:
+              ep_title = res_ep_title
+            group_pos = _tmdb.get_episode_group_position(int(tmdb_show_id), res_tmdb_ep_id)
+            if group_pos:
+              season, number = group_pos
 
   show_name = _vb.truncate_line(title.upper(), _vb.model.cols, 'ellipsis')
   return show_name, season, number, ep_title

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.37.1"
+version = "0.37.2"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_plex.py
+++ b/tests/core/test_plex.py
@@ -56,6 +56,7 @@ def _clear_tmdb_caches() -> None:
   _tmdb.get_show_title.cache_clear()
   _tmdb.get_movie_title.cache_clear()
   _tmdb.find_episode_by_tvdb_id.cache_clear()
+  _tmdb.find_episode_by_imdb_id.cache_clear()
 
 
 @pytest.fixture(autouse=True)
@@ -708,3 +709,96 @@ def test_handle_webhook_movie_falls_back_when_tmdb_lookup_returns_none(monkeypat
 
   assert result is not None
   assert result.data['variables']['show_name'] == [['CLUE']]
+
+
+def _episode_payload_with_imdb_guid(imdb_id: str, show: str = 'Jujutsu Kaisen') -> dict[str, Any]:
+  """Return an episode payload with imdb:// guid but no tvdb:// guid."""
+  return {
+    'event': 'media.play',
+    'Metadata': {
+      'type': 'episode',
+      'grandparentTitle': show,
+      'parentIndex': 3,
+      'index': 4,
+      'title': 'Episode 4',
+      'Guid': [
+        {'id': 'tmdb://6827061'},
+        {'id': f'imdb://{imdb_id}'},
+      ],
+    },
+  }
+
+
+def test_handle_webhook_episode_uses_tmdb_episode_title(monkeypatch: pytest.MonkeyPatch) -> None:
+  """TMDb episode title is used instead of Plex's native episode title."""
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: (1, 51, 'Perfect Preparation', 95479, 6827061))
+  monkeypatch.setattr(_tmdb, 'get_show_title', lambda show_id: 'Jujutsu Kaisen')
+
+  result = _plex.handle_webhook(_episode_payload_with_guid(tvdb_id=11547510, show='JUJUTSU KAISEN'))
+
+  assert result is not None
+  # S/E ref is always from Plex metadata (parentIndex=1, index=3 in the fixture);
+  # only the episode title comes from TMDb.
+  assert result.data['variables']['episode_line'] == [['S1E3 PERFECT PREPARATION']]
+
+
+def test_handle_webhook_episode_falls_back_to_plex_title_when_no_tmdb_ep_title(
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  """When TMDb returns an empty episode title, Plex's native title is used."""
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  # empty string title from TMDb (episode exists but title not yet filled in)
+  monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: (1, 3, '', 40290, 99001))
+  monkeypatch.setattr(_tmdb, 'get_show_title', lambda show_id: 'MasterChef')
+
+  result = _plex.handle_webhook(_episode_payload_with_guid(tvdb_id=8765432, show='MasterChef (US)'))
+
+  assert result is not None
+  assert result.data['variables']['episode_line'] == [['S1E3 DISH']]  # 'THE' stripped by strip_leading_article
+
+
+def test_handle_webhook_episode_uses_imdb_fallback_when_no_tvdb_guid(monkeypatch: pytest.MonkeyPatch) -> None:
+  """When no tvdb:// guid is present, imdb:// is tried and the TMDb title is used."""
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  imdb_calls: list[str] = []
+
+  def _mock_find_imdb(imdb_id: str) -> tuple[int, int, str, int, int]:
+    imdb_calls.append(imdb_id)
+    return (1, 51, 'Perfect Preparation', 95479, 6827061)
+
+  monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: None)
+  monkeypatch.setattr(_tmdb, 'find_episode_by_imdb_id', _mock_find_imdb)
+  monkeypatch.setattr(_tmdb, 'get_show_title', lambda show_id: 'Jujutsu Kaisen')
+
+  result = _plex.handle_webhook(_episode_payload_with_imdb_guid('tt39370459', show='JUJUTSU KAISEN'))
+
+  assert result is not None
+  assert imdb_calls == ['tt39370459']
+  assert result.data['variables']['show_name'] == [['JUJUTSU KAISEN']]
+  assert result.data['variables']['episode_line'] == [['S3E4 PERFECT PREPARATION']]
+
+
+def test_handle_webhook_episode_falls_back_when_no_tvdb_and_no_imdb_guid(monkeypatch: pytest.MonkeyPatch) -> None:
+  """When no tvdb:// or imdb:// guid is present, falls back to Plex's raw title."""
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  imdb_calls: list[str] = []
+  monkeypatch.setattr(_tmdb, 'find_episode_by_imdb_id', lambda imdb_id: imdb_calls.append(imdb_id) or None)
+
+  payload = {
+    'event': 'media.play',
+    'Metadata': {
+      'type': 'episode',
+      'grandparentTitle': 'Jujutsu Kaisen',
+      'parentIndex': 3,
+      'index': 4,
+      'title': 'Episode 4',
+      'Guid': [{'id': 'tmdb://6827061'}],  # only tmdb://, no tvdb:// or imdb://
+    },
+  }
+  result = _plex.handle_webhook(payload)
+
+  assert result is not None
+  assert imdb_calls == []
+  assert result.data['variables']['show_name'] == [['JUJUTSU KAISEN']]
+  assert result.data['variables']['episode_line'] == [['S3E4 EPISODE 4']]

--- a/tests/core/test_tmdb.py
+++ b/tests/core/test_tmdb.py
@@ -173,6 +173,55 @@ def test_find_episode_by_tvdb_id_empty_title_returns_empty_string(monkeypatch: p
   assert result == (2, 3, '', 999, 77002)
 
 
+# --- find_episode_by_imdb_id ---
+
+
+def test_find_episode_by_imdb_id_returns_tuple(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  mock_r = MagicMock()
+  mock_r.status_code = 200
+  mock_r.json.return_value = {
+    'tv_episode_results': [
+      {'id': 6827061, 'season_number': 1, 'episode_number': 51, 'name': 'Perfect Preparation', 'show_id': 95479}
+    ]
+  }
+
+  with patch('integrations.tmdb.fetch_with_retry', return_value=mock_r) as mock_fetch:
+    result = tmdb.find_episode_by_imdb_id('tt39370459')
+
+  assert result == (1, 51, 'Perfect Preparation', 95479, 6827061)
+  call_args = mock_fetch.call_args
+  assert call_args.args[1].endswith('/find/tt39370459')
+  assert call_args.kwargs['params'] == {'external_source': 'imdb_id'}
+
+
+def test_find_episode_by_imdb_id_returns_none_on_empty_results(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  mock_r = MagicMock()
+  mock_r.status_code = 200
+  mock_r.json.return_value = {'tv_episode_results': []}
+
+  with patch('integrations.tmdb.fetch_with_retry', return_value=mock_r):
+    result = tmdb.find_episode_by_imdb_id('tt0000000')
+
+  assert result is None
+
+
+def test_find_episode_by_imdb_id_returns_none_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+
+  with patch('integrations.tmdb.fetch_with_retry', side_effect=Exception('timeout')):
+    result = tmdb.find_episode_by_imdb_id('tt99999999')
+
+  assert result is None
+
+
 # --- get_episode_group_position ---
 
 

--- a/tests/core/test_trakt.py
+++ b/tests/core/test_trakt.py
@@ -755,6 +755,80 @@ def test_canonicalize_episode_falls_back_to_tmdb_base_when_group_unavailable(mon
   assert number == 3
 
 
+def test_canonicalize_episode_tmdb_empty_ep_title_keeps_trakt_title(monkeypatch: pytest.MonkeyPatch) -> None:
+  """When TMDb returns an empty episode title, the Trakt title is kept."""
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+
+  show_data = {'title': 'Frieren', 'ids': {'tmdb': 209867}}
+  ep_data = {'season': 2, 'number': 9, 'title': 'Episode 9', 'ids': {'tvdb': 11447772}}
+
+  with (
+    patch('integrations.tmdb.get_show_title', return_value="Frieren: Beyond Journey's End"),
+    patch('integrations.tmdb.find_episode_by_tvdb_id', return_value=(1, 37, '', 209867, 6855842)),
+    patch('integrations.tmdb.get_episode_group_position', return_value=(2, 9)),
+  ):
+    show_name, season, number, ep_title = trakt._canonicalize_episode(show_data, ep_data)  # noqa: SLF001
+
+  assert season == 2
+  assert number == 9
+  assert ep_title == 'Episode 9'  # Trakt title preserved — TMDb title was empty
+
+
+def test_canonicalize_episode_uses_imdb_fallback_when_no_tvdb_id(monkeypatch: pytest.MonkeyPatch) -> None:
+  """When tvdb_ep_id is absent, imdb is tried as a fallback for S/E and title."""
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+
+  show_data = {'title': 'Jujutsu Kaisen', 'ids': {'tmdb': 95479}}
+  ep_data = {'season': 3, 'number': 4, 'title': 'Episode 4', 'ids': {'imdb': 'tt39370459'}}
+
+  with (
+    patch('integrations.tmdb.get_show_title', return_value='JUJUTSU KAISEN'),
+    patch('integrations.tmdb.find_episode_by_tvdb_id') as mock_tvdb,
+    patch(
+      'integrations.tmdb.find_episode_by_imdb_id',
+      return_value=(1, 51, 'Perfect Preparation', 95479, 6827061),
+    ) as mock_imdb,
+    patch('integrations.tmdb.get_episode_group_position', return_value=(3, 4)),
+  ):
+    show_name, season, number, ep_title = trakt._canonicalize_episode(show_data, ep_data)  # noqa: SLF001
+
+  mock_tvdb.assert_not_called()
+  mock_imdb.assert_called_once_with('tt39370459')
+  assert season == 3
+  assert number == 4
+  assert ep_title == 'Perfect Preparation'
+
+
+def test_canonicalize_episode_imdb_fallback_show_id_mismatch_keeps_trakt_se(
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  """When imdb fallback resolves a different show, Trakt S/E and title are kept."""
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+
+  show_data = {'title': 'My Anime', 'ids': {'tmdb': 1111}}
+  ep_data = {'season': 2, 'number': 3, 'title': 'Real Title', 'ids': {'imdb': 'tt99999999'}}
+
+  with (
+    patch('integrations.tmdb.get_show_title', return_value='My Anime'),
+    patch('integrations.tmdb.find_episode_by_tvdb_id') as mock_tvdb,
+    patch('integrations.tmdb.find_episode_by_imdb_id', return_value=(1, 5, 'Wrong Show Ep', 9999, 88001)),
+    patch('integrations.tmdb.get_episode_group_position') as mock_group,
+  ):
+    show_name, season, number, ep_title = trakt._canonicalize_episode(show_data, ep_data)  # noqa: SLF001
+
+  mock_tvdb.assert_not_called()
+  mock_group.assert_not_called()
+  assert season == 2
+  assert number == 3
+  assert ep_title == 'Real Title'
+
+
 # --- _canonicalize_movie ---
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.37.1"
+version = "0.37.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- **#409 (JJK TMDb lookup fails):** Plex's library entry for Jujutsu Kaisen S3 has no `tvdb://` GUID — only `imdb://`. Added `find_episode_by_imdb_id()` to `integrations/tmdb.py` (uses TMDb `/find?external_source=imdb_id`) and added an `imdb://` fallback in `_canonicalize_plex_title` in `integrations/plex.py`. Same fallback added to `_canonicalize_episode` in `integrations/trakt.py`.
- **#410 (Frieren S2 shows "EPISODE N"):** `find_episode_by_tvdb_id` was already returning the episode title in the tuple, but `plex.py` was discarding it. Fixed `_canonicalize_plex_title` to return `(show_name, ep_title | None)` and updated `handle_webhook` to use the TMDb episode title (falling back to the Plex-supplied title when TMDb has none).
- **Trakt ep-title bug:** `_canonicalize_episode` was unconditionally overwriting a valid Trakt episode title with an empty TMDb title. Fixed to only update when the TMDb title is non-empty.

## Test plan

- [ ] `uv run pytest` — 933 tests, all pass
- [ ] New unit tests cover `find_episode_by_imdb_id` (happy path, empty results, error)
- [ ] New plex tests cover: TMDb ep title surfaced, fallback to Plex title, `imdb://` fallback path, no-guid fallback
- [ ] New trakt tests cover: empty TMDb title preserved, `imdb://` fallback, show-id mismatch guard

Closes #409
Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)
