### PR TITLE
fix(plex,tmdb): title-search fallback when episode has no external guids

### DIFF
--- a/integrations/plex.py
+++ b/integrations/plex.py
@@ -96,14 +96,24 @@ def _parse_guid_id_str(guids: list[dict[str, Any]], scheme: str) -> str | None:
   return None
 
 
-def _canonicalize_plex_title(raw_title: str, guids: list[dict[str, Any]], media_type: str) -> tuple[str, str | None]:
+def _canonicalize_plex_title(
+  raw_title: str,
+  guids: list[dict[str, Any]],
+  media_type: str,
+  season: int | None = None,
+  episode: int | None = None,
+) -> tuple[str, str | None]:
   """Return (canonical_title, tmdb_episode_title_or_None) from TMDb.
 
-  For episodes, tries tvdb:// first then imdb:// as a fallback. Returns both
-  the canonical show name and the TMDb episode title when resolved. The episode
-  title is None for movies and when all lookups fail.
+  For episodes, tries in order:
+    1. tvdb:// guid (episode-level TVDb ID)
+    2. imdb:// guid (episode-level IMDb ID)
+    3. TMDb title search + S/E lookup (when season and episode are provided)
 
-  For movies, the tmdb:// entry is the TMDb movie ID used for the show name.
+  Returns both the canonical show name and the TMDb episode title when
+  resolved. The episode title is None for movies and when all lookups fail.
+
+  For movies, the tmdb:// entry is the TMDb movie ID.
   Episode title is always None for movies.
 
   Falls back to (raw_title, None) when TMDb is unconfigured, the Guid array
@@ -145,7 +155,28 @@ def _canonicalize_plex_title(raw_title: str, guids: list[dict[str, Any]], media_
         return canonical if canonical else raw_title, ep_title or None
       logger.debug('plex: imdb ep lookup failed for %r, using raw title %r', imdb_id, raw_title)
     else:
-      logger.debug('plex: no imdb:// guid for episode %r, using raw title', raw_title)
+      logger.debug('plex: no imdb:// guid for episode %r, trying title search', raw_title)
+    # Last resort: search TMDb by show title + S/E numbers
+    if season is not None and episode is not None:
+      show_id = _tmdb.search_show_by_title(raw_title)
+      if show_id is not None:
+        ep_result_se = _tmdb.get_episode_by_number(show_id, season, episode)
+        if ep_result_se is not None:
+          ep_title, tmdb_ep_id = ep_result_se
+          group_pos = _tmdb.get_episode_group_position(show_id, tmdb_ep_id)
+          if group_pos:
+            season, episode = group_pos
+          canonical = _tmdb.get_show_title(show_id)
+          logger.debug(
+            'plex: tmdb title-search %r -> show=%d S%dE%d %r',
+            raw_title,
+            show_id,
+            season,
+            episode,
+            ep_title,
+          )
+          return canonical if canonical else raw_title, ep_title or None
+      logger.debug('plex: title search for %r found nothing', raw_title)
     return raw_title, None
 
   else:  # movie
@@ -275,7 +306,19 @@ def handle_webhook(payload: dict[str, Any], credential_name: str | None = None) 
 
     if media_type == 'episode' and metadata:
       guids: list[dict[str, Any]] = metadata.get('Guid') or []
-      raw_show, tmdb_ep_title = _canonicalize_plex_title(metadata['grandparentTitle'], guids, 'episode')
+      logger.debug(
+        'plex: episode guids=%r guid=%r grandparentGuid=%r',
+        guids,
+        metadata.get('guid'),
+        metadata.get('grandparentGuid'),
+      )
+      raw_show, tmdb_ep_title = _canonicalize_plex_title(
+        metadata['grandparentTitle'],
+        guids,
+        'episode',
+        season=metadata.get('parentIndex'),
+        episode=metadata.get('index'),
+      )
       show_name = _vb.truncate_line(raw_show.upper(), _vb.model.cols, 'ellipsis')
       episode_ref = _media.format_episode_ref(metadata['parentIndex'], metadata['index'])
       plex_ep_title = (metadata.get('title') or '').strip()

--- a/integrations/tmdb.py
+++ b/integrations/tmdb.py
@@ -215,6 +215,64 @@ def _get_episode_group(group_id: str) -> list[dict] | None:
   return None
 
 
+@functools.lru_cache(maxsize=256)
+def search_show_by_title(title: str) -> int | None:
+  """Return the TMDb show ID for the best-matching show by title, or None.
+
+  Uses TMDb's /search/tv endpoint. Takes the first result, which TMDb ranks
+  by relevance. Used as a last-resort fallback when no external IDs are
+  available (e.g. empty Guid array in Plex webhook payload).
+
+  Result is cached in-memory by title for the lifetime of the process.
+  """
+  try:
+    r = fetch_with_retry(
+      'GET',
+      f'{_TMDB_API_BASE}/search/tv',
+      headers=_request_headers(),
+      params={'query': title},
+      timeout=10,
+    )
+    r.raise_for_status()
+    results = r.json().get('results', [])
+    if results:
+      show_id: int = results[0]['id']
+      logger.debug('TMDb: search %r → show %d (%r)', title, show_id, results[0].get('name'))
+      return show_id
+  except Exception as e:  # noqa: BLE001
+    logger.debug('TMDb: search_show_by_title(%r) failed — %s', title, e)
+  return None
+
+
+@functools.lru_cache(maxsize=512)
+def get_episode_by_number(show_id: int, season: int, episode: int) -> tuple[str, int] | None:
+  """Return (episode_title, tmdb_episode_id) for a show/season/episode triple.
+
+  Uses TMDb's /tv/{show_id}/season/{season}/episode/{episode} endpoint.
+  Used as a last-resort fallback when only S/E numbers are available.
+
+  Result is cached in-memory by (show_id, season, episode) for the lifetime
+  of the process. Returns None if the lookup fails.
+  """
+  try:
+    r = fetch_with_retry(
+      'GET',
+      f'{_TMDB_API_BASE}/tv/{show_id}/season/{season}/episode/{episode}',
+      headers=_request_headers(),
+      timeout=10,
+    )
+    r.raise_for_status()
+    data = r.json()
+    tmdb_ep_id: int | None = data.get('id')
+    title: str = data.get('name') or ''
+    if tmdb_ep_id is not None:
+      logger.debug('TMDb: show=%d S%dE%d → ep %d %r', show_id, season, episode, tmdb_ep_id, title)
+      return (title, tmdb_ep_id)
+  except Exception as e:  # noqa: BLE001
+    logger.debug('TMDb: get_episode_by_number(%d, %d, %d) failed — %s', show_id, season, episode, e)
+  return None
+
+
 def get_episode_group_position(show_id: int, tmdb_episode_id: int) -> tuple[int, int] | None:
   """Return (season, episode) from the type-6 episode group for a TMDb episode.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.37.2"
+version = "0.37.3"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_plex.py
+++ b/tests/core/test_plex.py
@@ -57,6 +57,8 @@ def _clear_tmdb_caches() -> None:
   _tmdb.get_movie_title.cache_clear()
   _tmdb.find_episode_by_tvdb_id.cache_clear()
   _tmdb.find_episode_by_imdb_id.cache_clear()
+  _tmdb.search_show_by_title.cache_clear()
+  _tmdb.get_episode_by_number.cache_clear()
 
 
 @pytest.fixture(autouse=True)
@@ -645,10 +647,11 @@ def test_handle_webhook_episode_uses_tmdb_canonical_show_name(monkeypatch: pytes
 
 
 def test_handle_webhook_episode_falls_back_when_no_guid(monkeypatch: pytest.MonkeyPatch) -> None:
-  """When the payload has no Guid array, no TMDb lookup is attempted."""
+  """When the payload has no Guid array and title search fails, falls back to grandparentTitle."""
   monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   find_calls: list[int] = []
   monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: find_calls.append(tvdb_id) or None)
+  monkeypatch.setattr(_tmdb, 'search_show_by_title', lambda title: None)
 
   result = _plex.handle_webhook(_episode_payload('media.play', show='Masterchef'))
 
@@ -780,10 +783,11 @@ def test_handle_webhook_episode_uses_imdb_fallback_when_no_tvdb_guid(monkeypatch
 
 
 def test_handle_webhook_episode_falls_back_when_no_tvdb_and_no_imdb_guid(monkeypatch: pytest.MonkeyPatch) -> None:
-  """When no tvdb:// or imdb:// guid is present, falls back to Plex's raw title."""
+  """When no tvdb://, imdb://, and title search all fail, falls back to Plex's raw title."""
   monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   imdb_calls: list[str] = []
   monkeypatch.setattr(_tmdb, 'find_episode_by_imdb_id', lambda imdb_id: imdb_calls.append(imdb_id) or None)
+  monkeypatch.setattr(_tmdb, 'search_show_by_title', lambda title: None)
 
   payload = {
     'event': 'media.play',
@@ -802,3 +806,29 @@ def test_handle_webhook_episode_falls_back_when_no_tvdb_and_no_imdb_guid(monkeyp
   assert imdb_calls == []
   assert result.data['variables']['show_name'] == [['JUJUTSU KAISEN']]
   assert result.data['variables']['episode_line'] == [['S3E4 EPISODE 4']]
+
+
+def test_handle_webhook_episode_uses_title_search_when_no_guid(monkeypatch: pytest.MonkeyPatch) -> None:
+  """When no external guid is present, title search + S/E lookup returns TMDb episode title."""
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_tmdb, 'search_show_by_title', lambda title: 95479)
+  monkeypatch.setattr(_tmdb, 'get_episode_by_number', lambda show_id, s, e: ('Perfect Preparation', 6827061))
+  monkeypatch.setattr(_tmdb, 'get_episode_group_position', lambda show_id, ep_id: None)
+  monkeypatch.setattr(_tmdb, 'get_show_title', lambda show_id: 'Jujutsu Kaisen')
+
+  payload = {
+    'event': 'media.play',
+    'Metadata': {
+      'type': 'episode',
+      'grandparentTitle': 'JUJUTSU KAISEN',
+      'parentIndex': 3,
+      'index': 4,
+      'title': 'Episode 4',
+      'Guid': [],
+    },
+  }
+  result = _plex.handle_webhook(payload)
+
+  assert result is not None
+  assert result.data['variables']['show_name'] == [['JUJUTSU KAISEN']]
+  assert result.data['variables']['episode_line'] == [['S3E4 PERFECT PREPARATION']]

--- a/tests/core/test_tmdb.py
+++ b/tests/core/test_tmdb.py
@@ -13,6 +13,9 @@ def _clear_lru_caches() -> None:
   tmdb.get_show_title.cache_clear()
   tmdb.get_movie_title.cache_clear()
   tmdb.find_episode_by_tvdb_id.cache_clear()
+  tmdb.find_episode_by_imdb_id.cache_clear()
+  tmdb.search_show_by_title.cache_clear()
+  tmdb.get_episode_by_number.cache_clear()
   tmdb._get_type6_group_id.cache_clear()  # noqa: SLF001
   tmdb._get_episode_group.cache_clear()  # noqa: SLF001
 
@@ -218,6 +221,78 @@ def test_find_episode_by_imdb_id_returns_none_on_error(monkeypatch: pytest.Monke
 
   with patch('integrations.tmdb.fetch_with_retry', side_effect=Exception('timeout')):
     result = tmdb.find_episode_by_imdb_id('tt99999999')
+
+  assert result is None
+
+
+# --- search_show_by_title ---
+
+
+def test_search_show_by_title_returns_show_id(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  mock_r = MagicMock()
+  mock_r.status_code = 200
+  mock_r.json.return_value = {'results': [{'id': 95479, 'name': 'Jujutsu Kaisen'}]}
+
+  with patch('integrations.tmdb.fetch_with_retry', return_value=mock_r) as mock_fetch:
+    result = tmdb.search_show_by_title('JUJUTSU KAISEN')
+
+  assert result == 95479
+  assert mock_fetch.call_args.kwargs['params'] == {'query': 'JUJUTSU KAISEN'}
+
+
+def test_search_show_by_title_returns_none_on_empty_results(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  mock_r = MagicMock()
+  mock_r.status_code = 200
+  mock_r.json.return_value = {'results': []}
+
+  with patch('integrations.tmdb.fetch_with_retry', return_value=mock_r):
+    result = tmdb.search_show_by_title('Nonexistent Show')
+
+  assert result is None
+
+
+def test_search_show_by_title_returns_none_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+
+  with patch('integrations.tmdb.fetch_with_retry', side_effect=Exception('timeout')):
+    result = tmdb.search_show_by_title('Frieren')
+
+  assert result is None
+
+
+# --- get_episode_by_number ---
+
+
+def test_get_episode_by_number_returns_title_and_id(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  mock_r = MagicMock()
+  mock_r.status_code = 200
+  mock_r.json.return_value = {'id': 6827061, 'name': 'Perfect Preparation'}
+
+  with patch('integrations.tmdb.fetch_with_retry', return_value=mock_r) as mock_fetch:
+    result = tmdb.get_episode_by_number(95479, 3, 4)
+
+  assert result == ('Perfect Preparation', 6827061)
+  assert mock_fetch.call_args.args[1].endswith('/tv/95479/season/3/episode/4')
+
+
+def test_get_episode_by_number_returns_none_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+
+  with patch('integrations.tmdb.fetch_with_retry', side_effect=Exception('404')):
+    result = tmdb.get_episode_by_number(95479, 99, 1)
 
   assert result is None
 

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.37.2"
+version = "0.37.3"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

The previous fix (#415) added `imdb://` fallback, but Plex sometimes sends webhook payloads with *no* external guids at all (only a `tmdb://` episode-level ID, which isn't useful for lookup). This was the case for both JJK and Frieren in the latest test run:

```
plex: no tvdb:// guid for episode "Frieren: Beyond Journey's End", trying imdb://
plex: no imdb:// guid for episode "Frieren: Beyond Journey's End", using raw title
```

This PR adds a final fallback: **TMDb title search + S/E lookup**.

When both `tvdb://` and `imdb://` fail, `_canonicalize_plex_title` now:
1. Calls `tmdb.search_show_by_title(grandparentTitle)` → TMDb show ID
2. Calls `tmdb.get_episode_by_number(show_id, plex_season, plex_episode)` → episode title + TMDb ep ID
3. Applies episode-group correction if a type-6 group exists
4. Returns the canonical show title + TMDb episode title

This works when Plex's season/episode numbers match TMDb's base data numbering. For shows where they don't match (e.g. Frieren if Plex uses group-corrected numbers but TMDb base data has different numbering), the fallback may still return "EPISODE N" — which is no worse than before.

Also added a `DEBUG` log line emitting the full `Guid` array + `guid`/`grandparentGuid` fields on every episode webhook, making future diagnosis much easier without needing to add temporary logging.

## New TMDb functions

- `search_show_by_title(title)` — `/search/tv?query=<title>`, cached by title
- `get_episode_by_number(show_id, season, episode)` — `/tv/{id}/season/{s}/episode/{e}`, cached by triple

## Test plan

- [ ] `uv run pytest` — 939 tests, all pass
- [ ] New tmdb tests: `search_show_by_title` happy path + empty results + error; `get_episode_by_number` happy path + error
- [ ] New plex test: `test_handle_webhook_episode_uses_title_search_when_no_guid` — mocks search + episode lookup and verifies TMDb title used
- [ ] Updated plex tests: `_falls_back_when_no_guid` and `_falls_back_when_no_tvdb_and_no_imdb_guid` now mock `search_show_by_title` to return None to isolate fallback behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
