### PR TITLE
feat(display): only strip leading articles when needed to fit the line

### DIFF
--- a/integrations/media.py
+++ b/integrations/media.py
@@ -13,6 +13,13 @@ def strip_leading_article(title: str) -> str:
   return title
 
 
+def strip_leading_article_if_needed(title: str, max_width: int, prefix: str = '') -> str:
+  """Strip a leading article only when prefix+title exceeds max_width."""
+  if len(prefix + title) <= max_width:
+    return title
+  return strip_leading_article(title)
+
+
 def format_episode_ref(season: int, episode: int) -> str:
   """Return a compact episode ref, e.g. S9E8 (no zero-padding)."""
   return f'S{season}E{episode}'

--- a/integrations/plex.py
+++ b/integrations/plex.py
@@ -344,7 +344,7 @@ def handle_webhook(payload: dict[str, Any], credential_name: str | None = None) 
       episode_ref = _media.format_episode_ref(metadata['parentIndex'], metadata['index'])
       plex_ep_title = (metadata.get('title') or '').strip()
       episode_title = tmdb_ep_title or plex_ep_title
-      episode_detail = _media.strip_leading_article(episode_title.upper())
+      episode_detail = _media.strip_leading_article_if_needed(episode_title.upper(), _vb.model.cols, f'{episode_ref} ')
       episode_line = f'{episode_ref} {episode_detail}'.strip()
     elif media_type == 'movie' and metadata:
       guids = metadata.get('Guid') or []

--- a/integrations/trakt.py
+++ b/integrations/trakt.py
@@ -436,7 +436,7 @@ def get_variables_calendar() -> dict[str, list[list[str]]]:
   ep = entry['episode']
   show_name, season, number, ep_title = _canonicalize_episode(entry['show'], ep)
   episode_ref = _media.format_episode_ref(season, number)
-  episode_title = _media.strip_leading_article(ep_title.upper())
+  episode_title = _media.strip_leading_article_if_needed(ep_title.upper(), _vb.model.cols, f'{episode_ref} ')
 
   # Convert UTC first_aired → display timezone (config [scheduler].timezone,
   # or system local if unset).
@@ -534,7 +534,7 @@ def get_variables_watching() -> dict[str, list[list[str]]]:
     ep = data['episode']
     show_name, season, number, ep_title = _canonicalize_episode(data['show'], ep)
     episode_ref = _media.format_episode_ref(season, number)
-    episode_title = _media.strip_leading_article(ep_title.upper())
+    episode_title = _media.strip_leading_article_if_needed(ep_title.upper(), _vb.model.cols, f'{episode_ref} ')
   elif media_type == 'movie':
     show_name = _vb.truncate_line(_canonicalize_movie(data['movie']).upper(), _vb.model.cols, 'ellipsis')
     episode_ref = 'MOVIE'
@@ -619,7 +619,7 @@ def get_variables_next_up() -> dict[str, list[list[str]]]:
     if ep is not None:
       show_name, season, number, ep_title = _canonicalize_episode(entry['show'], ep)
       episode_ref = _media.format_episode_ref(season, number)
-      episode_title = _media.strip_leading_article(ep_title.upper())
+      episode_title = _media.strip_leading_article_if_needed(ep_title.upper(), _vb.model.cols, f'{episode_ref} ')
       result = {
         'show_name': [[show_name]],
         'episode_ref': [[episode_ref]],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.37.4"
+version = "0.37.5"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_media.py
+++ b/tests/core/test_media.py
@@ -48,3 +48,34 @@ def test_strip_leading_article_word_starting_with_a() -> None:
 
 def test_strip_leading_article_empty() -> None:
   assert media.strip_leading_article('') == ''
+
+
+# --- strip_leading_article_if_needed ---
+
+
+def test_strip_if_needed_fits_with_article_no_strip() -> None:
+  # 'S1E3 THE DISH' = 13 chars, fits in 15 → no strip
+  assert media.strip_leading_article_if_needed('THE DISH', 15, 'S1E3 ') == 'THE DISH'
+
+
+def test_strip_if_needed_does_not_fit_strips_article() -> None:
+  # 'S1E12 THE LONGEST EPISODE TITLE' = 31 chars, exceeds 15 → strip
+  assert media.strip_leading_article_if_needed('THE LONGEST EPISODE TITLE', 15, 'S1E12 ') == 'LONGEST EPISODE TITLE'
+
+
+def test_strip_if_needed_still_too_long_after_strip() -> None:
+  # Stripping still leaves an overlong title; truncation handles the rest
+  assert media.strip_leading_article_if_needed('THE VERY VERY LONG', 10, 'S1E1 ') == 'VERY VERY LONG'
+
+
+def test_strip_if_needed_no_article_returns_unchanged() -> None:
+  assert media.strip_leading_article_if_needed('PILOT', 15, 'S1E1 ') == 'PILOT'
+
+
+def test_strip_if_needed_no_prefix_behaves_like_strip_when_overflowing() -> None:
+  # Without prefix, length check is on title alone
+  assert media.strip_leading_article_if_needed('THE DISH', 5) == 'DISH'
+
+
+def test_strip_if_needed_no_prefix_fits_no_strip() -> None:
+  assert media.strip_leading_article_if_needed('THE DISH', 15) == 'THE DISH'

--- a/tests/core/test_plex.py
+++ b/tests/core/test_plex.py
@@ -276,7 +276,7 @@ def test_handle_webhook_stop_timer_includes_episode_metadata(_plex_playing: None
     _fire_stop_timer()
   data = mock_enqueue.call_args.kwargs['data']
   assert data['variables']['show_name'] == [['THE BEAR']]
-  assert data['variables']['episode_line'] == [['S2E1 BEEF']]
+  assert data['variables']['episode_line'] == [['S2E1 THE BEEF']]
 
 
 def test_handle_webhook_stop_timer_includes_movie_metadata(_plex_playing: None) -> None:
@@ -481,14 +481,22 @@ def test_handle_webhook_episode_line_includes_season_episode_ref() -> None:
   """episode_line must include the S/E reference so it appears on the board."""
   result = _plex.handle_webhook(_episode_payload('media.play', title='The Beef'))
   assert result is not None
-  # parentIndex=2, index=1 → S2E1; article stripped from title → BEEF
-  assert result.data['variables']['episode_line'] == [['S2E1 BEEF']]
+  # parentIndex=2, index=1 → S2E1; 'S2E1 THE BEEF' = 13 chars fits in 15 → article kept
+  assert result.data['variables']['episode_line'] == [['S2E1 THE BEEF']]
 
 
-def test_handle_webhook_episode_strips_a_article_in_episode_line() -> None:
+def test_handle_webhook_episode_strips_article_when_too_long() -> None:
+  # 'S2E1 AN EXTRAORDINARY JOURNEY' = 29 chars > 15 cols → article stripped
+  result = _plex.handle_webhook(_episode_payload('media.play', title='An Extraordinary Journey'))
+  assert result is not None
+  assert result.data['variables']['episode_line'] == [['S2E1 EXTRAORDINARY JOURNEY']]
+
+
+def test_handle_webhook_episode_keeps_article_when_it_fits() -> None:
+  # 'S2E1 A NEW HOPE' = 15 chars, fits exactly in 15 cols → article kept
   result = _plex.handle_webhook(_episode_payload('media.play', title='A New Hope'))
   assert result is not None
-  assert result.data['variables']['episode_line'] == [['S2E1 NEW HOPE']]
+  assert result.data['variables']['episode_line'] == [['S2E1 A NEW HOPE']]
 
 
 def test_handle_webhook_show_name_preserves_article() -> None:
@@ -758,7 +766,7 @@ def test_handle_webhook_episode_falls_back_to_plex_title_when_no_tmdb_ep_title(
   result = _plex.handle_webhook(_episode_payload_with_guid(tvdb_id=8765432, show='MasterChef (US)'))
 
   assert result is not None
-  assert result.data['variables']['episode_line'] == [['S1E3 DISH']]  # 'THE' stripped by strip_leading_article
+  assert result.data['variables']['episode_line'] == [['S1E3 THE DISH']]  # fits in 15 cols — article kept
 
 
 def test_handle_webhook_episode_uses_imdb_fallback_when_no_tvdb_guid(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.37.4"
+version = "0.37.5"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- Adds `strip_leading_article_if_needed(title, max_width, prefix)` to `integrations/media.py` — strips only when `prefix + title` exceeds the board width
- Updates all call sites in `plex.py` (1) and `trakt.py` (3) to use the new helper, passing the episode-ref prefix and `_vb.model.cols`
- Existing `strip_leading_article` is unchanged (still used by its own tests)

Bumps version to 0.37.5. Closes #416.

## Test plan

- [ ] New `strip_leading_article_if_needed` tests in `tests/core/test_media.py`: fits with article → no strip, doesn't fit → strip, still too long after strip, no prefix, no article
- [ ] Updated plex tests: assertions corrected for titles that now keep their articles (fit within 15 cols); new test verifies stripping still fires when a title is genuinely too long

🤖 Generated with [Claude Code](https://claude.com/claude-code)
