### PR TITLE
fix: PyPI metadata — banner image, classifiers, homepage URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # E•NOTE•ION
 
-![E•NOTE•ION](assets/social-preview.png)
+![E•NOTE•ION](https://raw.githubusercontent.com/JasonPuglisi/e-note-ion/main/assets/social-preview.png)
 
 [![CI](https://github.com/JasonPuglisi/e-note-ion/actions/workflows/ci.yml/badge.svg)](https://github.com/JasonPuglisi/e-note-ion/actions/workflows/ci.yml)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "0.38.0"
+version = "0.38.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [
@@ -13,6 +13,15 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE.txt"]
 requires-python = ">=3.14"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: End Users/Desktop",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Topic :: Home Automation",
+    "Topic :: Utilities",
+]
 dependencies = [
     "apscheduler>=3.11.2",
     "argon2-cffi>=23.1.0",
@@ -40,6 +49,7 @@ py-modules = ["scheduler", "config", "exceptions"]
 include = ["integrations*"]
 
 [project.urls]
+Homepage = "https://github.com/JasonPuglisi/e-note-ion"
 Repository = "https://github.com/JasonPuglisi/e-note-ion"
 Issues = "https://github.com/JasonPuglisi/e-note-ion/issues"
 

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "0.38.0"
+version = "0.38.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary
- Fix broken banner image on PyPI — relative `assets/social-preview.png` → absolute raw GitHub URL
- Add PyPI classifiers (Beta, Console, End Users, OS Independent, Python 3, Home Automation)
- Add Homepage to `project_urls`
- Remove `License :: OSI Approved :: MIT License` classifier (conflicts with PEP 639 `license = "MIT"` expression already in pyproject.toml)

## Test plan
- [ ] Banner image renders on PyPI after publish
- [ ] Classifiers appear on PyPI sidebar
- [ ] Homepage link appears in project links

Part of #16 (Phase 2). Bumps to 0.38.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
