### PR TITLE
chore: sort config, template mapping, and pyproject sections

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -50,19 +50,26 @@
 # Read/Write API key from https://store.vestaboard.com/pages/read-write-api
 api_key = "your-vestaboard-read-write-api-key"
 
-[weather]
-# City to display weather for. Geocoded via Open-Meteo on first call; no API
-# key required.
-city = "San Francisco"
+[bart]
+# Free API key — register at https://api.bart.gov/api/register.aspx
+api_key = "your-bart-api-key"
 
-# Unit system: "imperial" (°F, mph, default) or "metric" (°C, km/h).
-# units = "imperial"
+# Originating station abbreviation code.
+# See full list: https://api.bart.gov/docs/overview/abbrev.aspx
+station = "MLPT"
 
-# [weather.schedules.conditions]
-# cron = "0 * * * *"
-# hold = 600
-# timeout = 1800
-# priority = 5
+# Destination abbreviation code for the first departure line (required).
+line1_dest = "DALY"
+
+# Second departure line (optional — remove or leave blank for one line).
+# line2_dest = "BERY"
+
+# [bart.schedules.departures]
+# cron = "*/5 7-9 * * 1-5"
+# hold = 290
+# timeout = 60
+# priority = 8
+# refresh_interval = 60  # re-fetch departure times every 60s during the hold (min 30)
 
 [calendar]
 # Fetch today's events from ICS feeds and/or a private iCloud account.
@@ -100,27 +107,6 @@ city = "San Francisco"
 # timeout = 1800
 # priority = 5
 
-[bart]
-# Free API key — register at https://api.bart.gov/api/register.aspx
-api_key = "your-bart-api-key"
-
-# Originating station abbreviation code.
-# See full list: https://api.bart.gov/docs/overview/abbrev.aspx
-station = "MLPT"
-
-# Destination abbreviation code for the first departure line (required).
-line1_dest = "DALY"
-
-# Second departure line (optional — remove or leave blank for one line).
-# line2_dest = "BERY"
-
-# [bart.schedules.departures]
-# cron = "*/5 7-9 * * 1-5"
-# hold = 290
-# timeout = 60
-# priority = 8
-# refresh_interval = 60  # re-fetch departure times every 60s during the hold (min 30)
-
 [discogs]
 # Personal access token (read-only) — generate at https://www.discogs.com/settings/developers
 # Your username is resolved automatically from the token; no username key required.
@@ -135,21 +121,6 @@ token = "your-discogs-personal-access-token"
 # hold = 600
 # timeout = 3600
 # priority = 5
-
-[trakt]
-# OAuth credentials — create an application at https://trakt.tv/oauth/applications/new
-# Set Redirect URI to: urn:ietf:wg:oauth:2.0:oob
-client_id = "your-trakt-client-id"
-client_secret = "your-trakt-client-secret"
-
-# Written by the auth flow — do not edit manually.
-# Start the container, check logs for auth instructions, then approve in a browser.
-# access_token = "..."
-# refresh_token = "..."
-# expires_at = 1234567890
-
-# Optional: number of days ahead to show in the calendar (default 7, max 33)
-# calendar_days = 7
 
 [diving]
 # Scuba diving conditions — wave height, swell period, wind, and water temperature.
@@ -181,23 +152,6 @@ client_secret = "your-trakt-client-secret"
 # priority = 5
 # refresh_interval = 1800
 
-[tmdb]
-# Optional: canonical media metadata authority for the Plex and Trakt integrations.
-# When set, show/movie titles are resolved to their TMDb canonical form and Trakt
-# episode numbers are corrected via TMDb (important for anime, which Trakt numbers
-# using TVDb's single-season convention). When absent, integrations use their native
-# titles and episode numbers unchanged.
-#
-# Free read access token — sign up at https://www.themoviedb.org and generate one at
-# https://www.themoviedb.org/settings/api (under "API Read Access Token").
-# api_read_access_token = "your-tmdb-api-read-access-token"
-
-[plex]
-# Optional: seconds to wait after a media.stop event before showing the stopped
-# card. If a media.play or media.resume arrives in this window (e.g. between
-# back-to-back episodes), the stopped card is suppressed entirely. Default: 3.
-# stop_debounce = 3
-
 [message]
 # Friend message integration — ad-hoc messages from registered friends via webhook.
 # Friends are registered using the admin iOS Shortcut (see content/contrib/message.md).
@@ -209,13 +163,59 @@ client_secret = "your-trakt-client-secret"
 # [message.friends.alice]
 # color = "R"          # R O Y G B V W K H (H = heart ❤️)
 #
-# (The corresponding [webhook.credentials.alice] entry is written to [webhook] above.)
+# (The corresponding [webhook.credentials.alice] entry is written to [webhook] below.)
 #
 # To override hold/timeout/priority for the notification template:
 # [message.schedules.notification]
 # hold = 60
 # timeout = 60
 # priority = 8
+
+[plex]
+# Optional: seconds to wait after a media.stop event before showing the stopped
+# card. If a media.play or media.resume arrives in this window (e.g. between
+# back-to-back episodes), the stopped card is suppressed entirely. Default: 3.
+# stop_debounce = 3
+
+[tmdb]
+# Optional: canonical media metadata authority for the Plex and Trakt integrations.
+# When set, show/movie titles are resolved to their TMDb canonical form and Trakt
+# episode numbers are corrected via TMDb (important for anime, which Trakt numbers
+# using TVDb's single-season convention). When absent, integrations use their native
+# titles and episode numbers unchanged.
+#
+# Free read access token — sign up at https://www.themoviedb.org and generate one at
+# https://www.themoviedb.org/settings/api (under "API Read Access Token").
+# api_read_access_token = "your-tmdb-api-read-access-token"
+
+[trakt]
+# OAuth credentials — create an application at https://trakt.tv/oauth/applications/new
+# Set Redirect URI to: urn:ietf:wg:oauth:2.0:oob
+client_id = "your-trakt-client-id"
+client_secret = "your-trakt-client-secret"
+
+# Written by the auth flow — do not edit manually.
+# Start the container, check logs for auth instructions, then approve in a browser.
+# access_token = "..."
+# refresh_token = "..."
+# expires_at = 1234567890
+
+# Optional: number of days ahead to show in the calendar (default 7, max 33)
+# calendar_days = 7
+
+[weather]
+# City to display weather for. Geocoded via Open-Meteo on first call; no API
+# key required.
+city = "San Francisco"
+
+# Unit system: "imperial" (°F, mph, default) or "metric" (°C, km/h).
+# units = "imperial"
+
+# [weather.schedules.conditions]
+# cron = "0 * * * *"
+# hold = 600
+# timeout = 1800
+# priority = 5
 
 [webhook]
 # Optional: enable the HTTP webhook listener so external systems (Plex,

--- a/content/README.md
+++ b/content/README.md
@@ -145,18 +145,18 @@ appropriate priority range and informs scheduling decisions:
 |---|---|---|
 | `birthdays.self` | Personal | 9 |
 | `message.notification` | Social | 8 |
+| `notion.notification` | Social | 7 |
 | `birthdays.today` | Social | 6 |
 | `bart.departures` | Logistics | 8 |
 | `weather.conditions` | Logistics | 5 |
 | `calendar.today` | Logistics | 5 |
-| `notion.notification` | Social | 7 |
-| `trakt.watching` | Entertainment | 7 |
 | `diving.conditions` | Hobbies | 5 |
 | `discogs.morning_spin` | Hobbies | 5 |
 | `diving.last_dive` | Hobbies | 3 |
+| `plex.now_playing`, `plex.paused`, `plex.stopped` | Entertainment | 8 |
+| `trakt.watching` | Entertainment | 7 |
 | `trakt.calendar`, `trakt.next_up` | Entertainment | 4 |
 | `morning_night.good_morning`, `morning_night.good_night` | Ambient | 4 |
-| `plex.now_playing`, `plex.paused`, `plex.stopped` | Entertainment | 8 |
 
 When adding a new template, identify its category first — that gives you the
 priority range to start from before tuning for contention.
@@ -374,14 +374,14 @@ guidelines above.
 
 | File | Description |
 |---|---|
-| [`weather.json`](contrib/weather.md) | Current weather conditions via Open-Meteo |
-| [`calendar.json`](contrib/calendar.md) | Today's calendar events (ICS and iCloud CalDAV) |
-| [`birthdays.json`](contrib/birthdays.md) | Upcoming birthdays from iCloud Contacts; prominent self-birthday display |
 | [`bart.json`](contrib/bart.md) | BART real-time departure board |
+| [`birthdays.json`](contrib/birthdays.md) | Upcoming birthdays from iCloud Contacts; prominent self-birthday display |
+| [`calendar.json`](contrib/calendar.md) | Today's calendar events (ICS and iCloud CalDAV) |
 | [`discogs.json`](contrib/discogs.md) | Daily vinyl suggestion from your Discogs collection |
-| [`trakt.json`](contrib/trakt.md) | Trakt.tv upcoming calendar and now-playing |
-| [`morning_night.json`](contrib/morning_night.md) | Good morning and good night messages with moon phase visual |
-| [`plex.json`](contrib/plex.md) | Plex Media Server now-playing via webhook |
-| [`message.json`](contrib/message.md) | Friend messages via iOS Shortcuts → webhook |
-| [`notion.json`](contrib/notion.md) | Notion automation notifications via webhook |
 | [`diving.json`](contrib/diving.md) | Scuba diving conditions via NOAA NDBC buoy data or Open-Meteo |
+| [`message.json`](contrib/message.md) | Friend messages via iOS Shortcuts → webhook |
+| [`morning_night.json`](contrib/morning_night.md) | Good morning and good night messages with moon phase visual |
+| [`notion.json`](contrib/notion.md) | Notion automation notifications via webhook |
+| [`plex.json`](contrib/plex.md) | Plex Media Server now-playing via webhook |
+| [`trakt.json`](contrib/trakt.md) | Trakt.tv upcoming calendar and now-playing |
+| [`weather.json`](contrib/weather.md) | Current weather conditions via Open-Meteo |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,23 +35,23 @@ dependencies = [
 [project.scripts]
 e-note-ion = "scheduler:main"
 
-[tool.uv]
-package = true
+[project.urls]
+Homepage = "https://github.com/JasonPuglisi/e-note-ion"
+Repository = "https://github.com/JasonPuglisi/e-note-ion"
+Issues = "https://github.com/JasonPuglisi/e-note-ion/issues"
 
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.uv]
+package = true
 
 [tool.setuptools]
 py-modules = ["scheduler", "config", "exceptions"]
 
 [tool.setuptools.packages.find]
 include = ["integrations*"]
-
-[project.urls]
-Homepage = "https://github.com/JasonPuglisi/e-note-ion"
-Repository = "https://github.com/JasonPuglisi/e-note-ion"
-Issues = "https://github.com/JasonPuglisi/e-note-ion/issues"
 
 [dependency-groups]
 dev = [
@@ -61,6 +61,24 @@ dev = [
     "pyright>=1.1.408",
     "pytest>=8.3.5",
     "ruff>=0.15.2",
+]
+
+[tool.bandit]
+exclude_dirs = [".venv", "tests"]
+# Add skips = ["BXXX"] here for any false positives that arise
+
+[tool.pyright]
+pythonVersion = "3.14"
+typeCheckingMode = "standard"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+addopts = "-m 'not integration'"
+log_level = "DEBUG"
+markers = [
+  "integration: marks tests that call real external APIs (deselected by default)",
+  "require_env: list env var names required for the test to run",
 ]
 
 [tool.ruff]
@@ -73,21 +91,3 @@ indent-style = "space"
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]  # pycodestyle errors, pyflakes, isort
-
-[tool.pytest.ini_options]
-testpaths = ["tests"]
-pythonpath = ["."]
-addopts = "-m 'not integration'"
-log_level = "DEBUG"
-markers = [
-  "integration: marks tests that call real external APIs (deselected by default)",
-  "require_env: list env var names required for the test to run",
-]
-
-[tool.bandit]
-exclude_dirs = [".venv", "tests"]
-# Add skips = ["BXXX"] here for any false positives that arise
-
-[tool.pyright]
-pythonVersion = "3.14"
-typeCheckingMode = "standard"


### PR DESCRIPTION
— *Claude Code*

Sort and tidy config, content docs, and pyproject sections now that the project has grown to 11 integrations.

## Changes

**`config.example.toml`** — integrations alphabetised after `[vestaboard]`: `bart → calendar → discogs → diving → message → plex → tmdb → trakt → weather → webhook`. Fixes a stale comment in `[message]` that said "written to [webhook] above" when `[webhook]` actually follows `[message]`.

**`content/README.md`** — template mapping table sorted by category (Personal → Social → Logistics → Hobbies → Entertainment → Ambient) then priority descending; `notion.notification` moved to Social, plex moved above Ambient. Contrib integrations table sorted alphabetically to match files on disk.

**`pyproject.toml`** — `[project.scripts]` and `[project.urls]` moved immediately after `[project]`; tool sections alphabetised (`bandit → pyright → pytest → ruff`).

## Test plan

- [ ] `uv run ruff check .` passes
- [ ] `uv run ruff format --check .` passes
- [ ] `uv run pyright` passes
- [ ] `uv run pytest` passes (no logic changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
