### PR TITLE
feat(calendar): improve birthday name display — nickname preference, day-before-name

### DIFF
--- a/integrations/calendar.py
+++ b/integrations/calendar.py
@@ -84,11 +84,11 @@ _carddav_addressbook_url: str | None = None
 _carddav_home_url: str | None = None
 
 # Birthday contacts cache: (contacts, monotonic_fetch_time) or None.
-# contacts is a list of (first_name, month, day).
+# contacts is a list of (display_name, month, day).
 _birthday_cache: tuple[list[tuple[str, int, int]], float] | None = None
 _BIRTHDAY_CACHE_TTL = 24 * 60 * 60  # 24 hours
 
-# Self contact cache: (first_name, month, day) or None (process lifetime).
+# Self contact cache: (display_name, month, day) or None (process lifetime).
 # Populated by _resolve_self_contact(); BDAY never changes in practice.
 _self_contact_cache: tuple[str, int, int] | None = None
 
@@ -453,6 +453,18 @@ def _collect_candidates_caldav(
 # ── CardDAV / birthdays ────────────────────────────────────────────────────────
 
 
+def _resolve_display_name(nickname: str | None, fn_parts: list[str]) -> str:
+  """Return the preferred display name for a contact, uppercased.
+
+  Priority: nickname → first + last initial → first name only.
+  """
+  if nickname and nickname.strip():
+    return nickname.strip().upper()
+  if len(fn_parts) >= 2:
+    return f'{fn_parts[0].upper()} {fn_parts[-1][0].upper()}'
+  return fn_parts[0].upper() if fn_parts else ''
+
+
 def _parse_bday(bday_str: str) -> tuple[int, int] | None:
   """Parse a BDAY vCard value into (month, day), or None if unparseable.
 
@@ -612,11 +624,14 @@ def _fetch_birthday_contacts(
     if not data:
       continue
     fn: str | None = None
+    nickname: str | None = None
     bday_raw: str | None = None
     for line in data.splitlines():
       upper = line.upper()
       if upper.startswith('FN:'):
         fn = line[3:].strip()
+      elif upper.startswith('NICKNAME:'):
+        nickname = line[9:].strip()
       elif upper.startswith('BDAY') and ':' in line:
         bday_raw = line.split(':', 1)[1].strip()
     if not fn or not bday_raw:
@@ -627,7 +642,8 @@ def _fetch_birthday_contacts(
     parts = fn.split()
     if not parts:
       continue
-    contacts.append((parts[0].upper(), parsed[0], parsed[1]))
+    display_name = _resolve_display_name(nickname, parts)
+    contacts.append((display_name, parsed[0], parsed[1]))
 
   logger.debug('calendar: fetched %d birthday contact(s)', len(contacts))
   _birthday_cache = (contacts, time.monotonic())
@@ -693,11 +709,14 @@ def _resolve_self_contact(
     r.raise_for_status()
 
     fn: str | None = None
+    nickname: str | None = None
     bday_raw: str | None = None
     for line in r.text.splitlines():
       upper = line.upper()
       if upper.startswith('FN:'):
         fn = line[3:].strip()
+      elif upper.startswith('NICKNAME:'):
+        nickname = line[9:].strip()
       elif upper.startswith('BDAY') and ':' in line:
         bday_raw = line.split(':', 1)[1].strip()
 
@@ -710,8 +729,8 @@ def _resolve_self_contact(
       logger.debug('calendar: me-card BDAY unparseable — self-birthday unavailable')
       return None
 
-    first_name = fn.split()[0].upper()
-    _self_contact_cache = (first_name, parsed[0], parsed[1])
+    display_name = _resolve_display_name(nickname, fn.split())
+    _self_contact_cache = (display_name, parsed[0], parsed[1])
     logger.debug('calendar: self contact resolved')
     return _self_contact_cache
 
@@ -845,9 +864,9 @@ def get_variables_birthdays() -> dict[str, list[list[str]]]:
 
   self_contact = _resolve_self_contact(carddav_url, username, password)
 
-  entries: list[tuple[int, str, str]] = []  # (days_ahead, first_name, line)
-  for first_name, month, day in contacts:
-    if self_contact and (first_name, month, day) == self_contact:
+  entries: list[tuple[int, str, str]] = []  # (days_ahead, display_name, line)
+  for display_name, month, day in contacts:
+    if self_contact and (display_name, month, day) == self_contact:
       continue  # shown exclusively via birthday_self.json
     try:
       candidate = today.replace(month=month, day=day)
@@ -862,7 +881,7 @@ def get_variables_birthdays() -> dict[str, list[list[str]]]:
     if days_ahead > lookahead:
       continue
     day_label = 'TODAY' if days_ahead == 0 else candidate.strftime('%a').upper()
-    entries.append((days_ahead, first_name, f'{first_name} {day_label}'))
+    entries.append((days_ahead, display_name, f'{day_label} {display_name}'))
 
   if not entries:
     raise IntegrationDataUnavailableError(f'calendar: no birthdays in the next {lookahead} days')
@@ -895,7 +914,7 @@ def get_variables_self_birthday() -> dict[str, list[list[str]]]:
   if self_contact is None:
     raise IntegrationDataUnavailableError('calendar: self contact could not be resolved (iCloud me-card required)')
 
-  first_name, month, day = self_contact
+  display_name, month, day = self_contact
 
   tz = _display_tz()
   now = _get_now(tz)
@@ -909,4 +928,4 @@ def get_variables_self_birthday() -> dict[str, list[list[str]]]:
   if today != birthday_this_year:
     raise IntegrationDataUnavailableError("calendar: today is not the owner's birthday")
 
-  return {'name': [[first_name]]}
+  return {'name': [[display_name]]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.1.0"
+version = "1.2.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_calendar.py
+++ b/tests/core/test_calendar.py
@@ -552,26 +552,26 @@ def _patch_birthdays(
 
 
 def test_birthday_formats_today(monkeypatch: pytest.MonkeyPatch) -> None:
-  """Birthday today → 'FIRSTNAME TODAY'."""
+  """Birthday today → 'TODAY FIRSTNAME'."""
   _patch_birthdays(monkeypatch, [('ADAM', _BDAY_TODAY.month, _BDAY_TODAY.day)])
   result = calendar.get_variables_birthdays()
-  assert result['birthdays'][0] == ['ADAM TODAY']
+  assert result['birthdays'][0] == ['TODAY ADAM']
 
 
 def test_birthday_formats_day_name(monkeypatch: pytest.MonkeyPatch) -> None:
-  """Birthday in 3 days → 'FIRSTNAME <DAY>'."""
+  """Birthday in 3 days → '<DAY> FIRSTNAME'."""
   target = _BDAY_TODAY + timedelta(days=3)
   expected_day = target.strftime('%a').upper()
   _patch_birthdays(monkeypatch, [('BRIANNA', target.month, target.day)])
   result = calendar.get_variables_birthdays()
-  assert result['birthdays'][0] == [f'BRIANNA {expected_day}']
+  assert result['birthdays'][0] == [f'{expected_day} BRIANNA']
 
 
-def test_birthday_uses_first_name_only(monkeypatch: pytest.MonkeyPatch) -> None:
-  """Contacts are already stored as first names — pass-through check."""
+def test_birthday_uses_display_name(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Display name from cache appears after the day label."""
   _patch_birthdays(monkeypatch, [('ADAM', _BDAY_TODAY.month, _BDAY_TODAY.day)])
   result = calendar.get_variables_birthdays()
-  assert result['birthdays'][0][0].startswith('ADAM')
+  assert result['birthdays'][0][0].endswith('ADAM')
 
 
 def test_birthday_filters_outside_window(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -594,9 +594,9 @@ def test_birthday_multiple_sorted(monkeypatch: pytest.MonkeyPatch) -> None:
   _patch_birthdays(monkeypatch, contacts)
   result = calendar.get_variables_birthdays()
   lines = result['birthdays'][0]
-  assert lines[0].startswith('ADAM')
-  assert lines[1].startswith('BLAKE')
-  assert lines[2].startswith('ZARA')
+  assert lines[0].endswith('ADAM')
+  assert lines[1].endswith('BLAKE')
+  assert lines[2].endswith('ZARA')
 
 
 def test_birthday_no_results_raises(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -726,10 +726,10 @@ def _patch_self_birthday(
 
 
 def test_self_birthday_today(monkeypatch: pytest.MonkeyPatch) -> None:
-  """Birthday matches today → returns {'name': [['ALEX']]}."""
+  """Birthday matches today → returns display name (first + last initial)."""
   _patch_self_birthday(monkeypatch)
   result = calendar.get_variables_self_birthday()
-  assert result == {'name': [['ALEX']]}
+  assert result == {'name': [['ALEX S']]}
 
 
 def test_self_birthday_not_today(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -785,7 +785,7 @@ def test_self_birthday_me_card_discovery(monkeypatch: pytest.MonkeyPatch) -> Non
   _patch_self_birthday(monkeypatch)
   assert calendar._self_contact_cache is None
   calendar.get_variables_self_birthday()
-  assert calendar._self_contact_cache == ('ALEX', _SELF_BDAY_TODAY.month, _SELF_BDAY_TODAY.day)
+  assert calendar._self_contact_cache == ('ALEX S', _SELF_BDAY_TODAY.month, _SELF_BDAY_TODAY.day)
 
 
 def test_birthdays_suppresses_self(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -805,6 +805,6 @@ def test_birthdays_suppresses_self(monkeypatch: pytest.MonkeyPatch) -> None:
     ],
   )
   result = calendar.get_variables_birthdays()
-  names = [line.split()[0] for line in result['birthdays'][0]]
-  assert 'ALEX' not in names
-  assert 'BLAKE' in names
+  lines = result['birthdays'][0]
+  assert not any('ALEX' in line for line in lines)
+  assert any('BLAKE' in line for line in lines)

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,0 +1,212 @@
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import config as _cfg
+from integrations.calendar import _resolve_display_name
+
+# ── _resolve_display_name ──────────────────────────────────────────────────────
+
+
+def test_resolve_display_name_prefers_nickname() -> None:
+  assert _resolve_display_name('Jay', ['Jason', 'Puglisi']) == 'JAY'
+
+
+def test_resolve_display_name_nickname_strips_whitespace() -> None:
+  assert _resolve_display_name('  Jay  ', ['Jason', 'Puglisi']) == 'JAY'
+
+
+def test_resolve_display_name_empty_nickname_falls_through() -> None:
+  assert _resolve_display_name('', ['Jason', 'Puglisi']) == 'JASON P'
+
+
+def test_resolve_display_name_whitespace_nickname_falls_through() -> None:
+  assert _resolve_display_name('   ', ['Jason', 'Puglisi']) == 'JASON P'
+
+
+def test_resolve_display_name_none_nickname_falls_through() -> None:
+  assert _resolve_display_name(None, ['Jason', 'Puglisi']) == 'JASON P'
+
+
+def test_resolve_display_name_first_last_initial() -> None:
+  assert _resolve_display_name(None, ['Jane', 'Smith']) == 'JANE S'
+
+
+def test_resolve_display_name_single_name_no_initial() -> None:
+  assert _resolve_display_name(None, ['Cher']) == 'CHER'
+
+
+def test_resolve_display_name_empty_parts_returns_empty() -> None:
+  assert _resolve_display_name(None, []) == ''
+
+
+def test_resolve_display_name_uppercases_nickname() -> None:
+  assert _resolve_display_name('jay', ['Jason', 'Puglisi']) == 'JAY'
+
+
+def test_resolve_display_name_uppercases_fn() -> None:
+  assert _resolve_display_name(None, ['jason', 'puglisi']) == 'JASON P'
+
+
+# ── _fetch_birthday_contacts vCard parsing ─────────────────────────────────────
+
+# Minimal CardDAV REPORT response with one contact.
+_CARDDAV_RESPONSE_TEMPLATE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<multistatus xmlns="DAV:" xmlns:card="urn:ietf:params:xml:ns:carddav">
+  <response>
+    <propstat>
+      <prop>
+        <card:address-data>{vcard}</card:address-data>
+      </prop>
+    </propstat>
+  </response>
+</multistatus>"""
+
+_VCARD_NICKNAME = 'BEGIN:VCARD\r\nFN:Jason Puglisi\r\nNICKNAME:Jay\r\nBDAY:1990-06-15\r\nEND:VCARD\r\n'
+
+_VCARD_NO_NICKNAME = 'BEGIN:VCARD\r\nFN:Jason Puglisi\r\nBDAY:1990-06-15\r\nEND:VCARD\r\n'
+
+_VCARD_SINGLE_NAME = 'BEGIN:VCARD\r\nFN:Cher\r\nBDAY:1946-05-20\r\nEND:VCARD\r\n'
+
+
+def _make_mock_response(vcard: str) -> MagicMock:
+  xml = _CARDDAV_RESPONSE_TEMPLATE.format(vcard=vcard).encode()
+  mock = MagicMock()
+  mock.content = xml
+  return mock
+
+
+@patch('integrations.calendar._birthday_cache', None)
+@patch('integrations.calendar.requests.request')
+def test_fetch_birthday_contacts_uses_nickname(mock_req: MagicMock) -> None:
+  from integrations.calendar import _fetch_birthday_contacts
+
+  mock_req.return_value = _make_mock_response(_VCARD_NICKNAME)
+  contacts = _fetch_birthday_contacts('http://example.com/ab/', 'user', 'pass')
+
+  assert len(contacts) == 1
+  display_name, month, day = contacts[0]
+  assert display_name == 'JAY'
+  assert month == 6
+  assert day == 15
+
+
+@patch('integrations.calendar._birthday_cache', None)
+@patch('integrations.calendar.requests.request')
+def test_fetch_birthday_contacts_first_last_initial(mock_req: MagicMock) -> None:
+  from integrations.calendar import _fetch_birthday_contacts
+
+  mock_req.return_value = _make_mock_response(_VCARD_NO_NICKNAME)
+  contacts = _fetch_birthday_contacts('http://example.com/ab/', 'user', 'pass')
+
+  assert len(contacts) == 1
+  display_name, _, _ = contacts[0]
+  assert display_name == 'JASON P'
+
+
+@patch('integrations.calendar._birthday_cache', None)
+@patch('integrations.calendar.requests.request')
+def test_fetch_birthday_contacts_single_name(mock_req: MagicMock) -> None:
+  from integrations.calendar import _fetch_birthday_contacts
+
+  mock_req.return_value = _make_mock_response(_VCARD_SINGLE_NAME)
+  contacts = _fetch_birthday_contacts('http://example.com/ab/', 'user', 'pass')
+
+  assert len(contacts) == 1
+  display_name, _, _ = contacts[0]
+  assert display_name == 'CHER'
+
+
+# ── get_variables_birthdays display format ─────────────────────────────────────
+
+
+@patch('integrations.calendar._resolve_self_contact', return_value=None)
+@patch('integrations.calendar._get_addressbook_url', return_value='http://x/')
+@patch('integrations.calendar._fetch_birthday_contacts')
+def test_get_variables_birthdays_today_format(
+  mock_fetch: MagicMock,
+  _mock_ab: MagicMock,
+  _mock_self: MagicMock,
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  import integrations.calendar as cal
+
+  monkeypatch.setattr(_cfg, '_config', {'calendar': {'carddav_url': 'x', 'username': 'u', 'password': 'p'}})
+  today = date.today()
+  mock_fetch.return_value = [('JAY', today.month, today.day)]
+
+  with patch.object(cal, '_get_now', return_value=MagicMock(date=lambda: today)):
+    result = cal.get_variables_birthdays()
+
+  lines = result['birthdays'][0]
+  assert lines == ['TODAY JAY']
+
+
+@patch('integrations.calendar._resolve_self_contact', return_value=None)
+@patch('integrations.calendar._get_addressbook_url', return_value='http://x/')
+@patch('integrations.calendar._fetch_birthday_contacts')
+def test_get_variables_birthdays_future_format(
+  mock_fetch: MagicMock,
+  _mock_ab: MagicMock,
+  _mock_self: MagicMock,
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  import integrations.calendar as cal
+
+  monkeypatch.setattr(_cfg, '_config', {'calendar': {'carddav_url': 'x', 'username': 'u', 'password': 'p'}})
+  # Use a fixed "today" of 2026-03-14 (Saturday) and a birthday 2 days later (Monday).
+  fixed_today = date(2026, 3, 14)
+  mock_fetch.return_value = [('JANE S', 3, 16)]  # March 16 = Monday
+
+  with patch.object(cal, '_get_now', return_value=MagicMock(date=lambda: fixed_today)):
+    result = cal.get_variables_birthdays()
+
+  lines = result['birthdays'][0]
+  assert lines == ['MON JANE S']
+
+
+@patch('integrations.calendar._resolve_self_contact', return_value=None)
+@patch('integrations.calendar._get_addressbook_url', return_value='http://x/')
+@patch('integrations.calendar._fetch_birthday_contacts')
+def test_get_variables_birthdays_sorted_by_days_ahead(
+  mock_fetch: MagicMock,
+  _mock_ab: MagicMock,
+  _mock_self: MagicMock,
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  import integrations.calendar as cal
+
+  monkeypatch.setattr(_cfg, '_config', {'calendar': {'carddav_url': 'x', 'username': 'u', 'password': 'p'}})
+  fixed_today = date(2026, 3, 14)
+  # Two contacts: one in 3 days, one in 1 day.
+  mock_fetch.return_value = [('FAR A', 3, 17), ('NEAR B', 3, 15)]
+
+  with patch.object(cal, '_get_now', return_value=MagicMock(date=lambda: fixed_today)):
+    result = cal.get_variables_birthdays()
+
+  lines = result['birthdays'][0]
+  # NEAR B (1 day) should come before FAR A (3 days).
+  assert lines[0].endswith('NEAR B')
+  assert lines[1].endswith('FAR A')
+
+
+# ── get_variables_self_birthday display name ───────────────────────────────────
+
+
+@patch('integrations.calendar._resolve_self_contact')
+def test_get_variables_self_birthday_uses_display_name(
+  mock_self: MagicMock,
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  import integrations.calendar as cal
+
+  today = date.today()
+  monkeypatch.setattr(_cfg, '_config', {'calendar': {'carddav_url': 'x', 'username': 'u', 'password': 'p'}})
+  mock_self.return_value = ('JAY', today.month, today.day)
+
+  with patch.object(cal, '_get_now', return_value=MagicMock(date=lambda: today)):
+    result = cal.get_variables_self_birthday()
+
+  assert result == {'name': [['JAY']]}

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Improves how birthday contact names are resolved and displayed on the board.

## Changes

- **Name priority**: `NICKNAME` vCard field → first name + last initial (e.g. `JASON P`) → first name only
- **Display order**: day label now precedes name — `TODAY JASON P`, `MON JANE S` — instead of name-first
- Applies to both other-birthday contacts (`_fetch_birthday_contacts`) and the self-birthday me-card (`_resolve_self_contact`)
- New `_resolve_display_name()` helper consolidates the resolution logic
- New `tests/test_calendar.py` covers helper edge cases, vCard parsing, and format assertions
- Updated `tests/core/test_calendar.py` to reflect the new format and name resolution

Closes #433

## Test plan

- [ ] `uv run pytest` — all 984 tests pass
- [ ] Full check suite clean (ruff, pyright, bandit, pip-audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
