### PR TITLE
fix(tests): update birthday integration test for new DAY NAME format

### DIFF
--- a/tests/integrations/test_calendar_integration.py
+++ b/tests/integrations/test_calendar_integration.py
@@ -105,5 +105,5 @@ def test_birthdays_mode_real_icloud(require_env: None, monkeypatch: pytest.Monke
   for line in lines:
     assert isinstance(line, str) and line.strip(), f'empty line in birthdays: {lines!r}'
     parts = line.split()
-    assert len(parts) == 2, f'expected "FIRSTNAME DAY", got: {line!r}'  # noqa: PLR2004
-    assert parts[1] in {'TODAY', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'}, f'unexpected day label: {line!r}'
+    assert len(parts) >= 2, f'expected "DAY NAME", got: {line!r}'  # noqa: PLR2004
+    assert parts[0] in {'TODAY', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'}, f'unexpected day label: {line!r}'


### PR DESCRIPTION
The birthday integration test was asserting the old `FIRSTNAME DAY` format (2 parts, day at index 1) and wasn't updated when #435 changed the format to `DAY NAME`.

Fixes the `test_birthdays_mode_real_icloud` failure on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
