### PR TITLE
fix(plex): unify event debouncing — debounce play and pause to eliminate display flashes

### DIFF
--- a/content/contrib/plex.md
+++ b/content/contrib/plex.md
@@ -88,26 +88,19 @@ hold = 3600
 | `timeout` | `30` | Seconds the message can wait in the queue before being discarded |
 | `priority` | `8` | Display priority (0–10) |
 
-To tune the stop debounce window, add a top-level `[plex]` key:
-
-```toml
-[plex]
-stop_debounce = 3  # seconds; default 3
-```
-
-When Plex stops playback and immediately starts the next episode, a `media.stop`
-followed by `media.play` arrive in rapid succession. The debounce window
-suppresses the "stopped" card if a play or resume arrives within that many
-seconds — avoiding a brief flash of the stopped state between episodes. Set to
-`0` to disable debouncing and always show the stopped card immediately.
+All three event types (play, pause, stop) are debounced with a hardcoded 3-second
+window. Rapid self-cancelling sequences — play→pause, pause→resume, or stop→play
+between back-to-back episodes — produce no intermediate display flashes. Only the
+settled final state reaches the board.
 
 **Testing during quiet hours:** Plex state transitions (play → pause → stop)
 will not work correctly during the board's quiet hours. Pause and stop events
-include a board-displacement check — they are silently discarded if no Plex
-content is currently showing. During quiet hours, writes fail and the scheduler
-sees the board as idle, so pause/stop events are discarded as if playback
-weren't active. If you observe play/pause/stop not interrupting each other,
-check whether you were testing during quiet hours before investigating further.
+include a board-displacement check that fires when their debounce timers elapse —
+if no Plex content is currently showing at that point, the event is suppressed.
+During quiet hours, writes fail and the scheduler sees the board as idle, so
+pause/stop debounce timers will suppress their messages. If you observe
+play/pause/stop not interrupting each other, check whether you were testing
+during quiet hours before investigating further.
 
 ## Webhook setup
 

--- a/integrations/plex.py
+++ b/integrations/plex.py
@@ -7,9 +7,11 @@
 #   - media.play / media.resume → "NOW PLAYING" with show/movie title
 #   - media.pause               → "PAUSED" with show/movie title
 #   - media.stop                → short "stopped" card ([R] NOW PLAYING, hold=60s)
-#                                 debounced: if a play/resume arrives within the
-#                                 stop_debounce window, the stopped card is suppressed
-#                                 to avoid a flash between back-to-back episodes.
+#
+# All three events are debounced with a 3-second window to suppress display
+# flashes for rapid event sequences (e.g. play→pause, pause→resume, or
+# stop→play between back-to-back episodes). Only the settled final state
+# reaches the board.
 #
 # Requires Plex Pass and a webhook configured in Plex Media Server settings
 # to POST to the scheduler's webhook endpoint. See content/contrib/plex.md
@@ -19,7 +21,6 @@
 # hold/timeout/priority for the now_playing or paused templates, add a
 # [plex.schedules.now_playing] or [plex.schedules.paused] section to
 # config.toml — the same override syntax used for scheduled templates.
-# To tune the stop debounce window, add [plex] stop_debounce = <seconds>.
 
 import enum
 import json
@@ -44,6 +45,9 @@ _STOP_EVENTS = frozenset({'media.stop'})
 # All events this integration handles; others are silently discarded.
 _HANDLED_EVENTS = _PLAY_EVENTS | {_PAUSE_EVENT} | _STOP_EVENTS
 
+# Debounce window applied to play, pause, and stop events.
+_DEBOUNCE_SECS = 3
+
 
 class _State(enum.Enum):
   IDLE = 'idle'
@@ -56,22 +60,22 @@ class _State(enum.Enum):
 # PAUSED. Invalid transitions return None without firing any display update.
 _state: _State = _State.IDLE
 
-# Pending debounce timer for media.stop. When a stop event arrives we delay
-# enqueueing the stopped card by _stop_debounce() seconds. If a play/resume
-# arrives in that window we cancel the timer — suppressing the stopped card
-# entirely to avoid a flash between back-to-back episodes.
+# Pending debounce timers for play, pause, and stop events. All three share
+# the same _DEBOUNCE_SECS window. Incoming events cancel sibling timers so
+# that only the settled final state reaches the board.
+_pending_play_timer: threading.Timer | None = None
+_pending_pause_timer: threading.Timer | None = None
 _pending_stop_timer: threading.Timer | None = None
 
+# Data captured for the currently-pending stop timer, stored at module level
+# so that an incoming play event can rescue it into _saved_stop_data on cancel.
+_pending_stop_data: dict[str, Any] | None = None
 
-def _stop_debounce() -> int:
-  """Return the stop debounce window in seconds from config (default 3)."""
-  import config as _config_mod
-
-  raw = _config_mod.get_optional('plex', 'stop_debounce')
-  try:
-    return max(0, int(raw)) if raw is not None else 3
-  except ValueError:
-    return 3
+# Stop data saved when a stop debounce is cancelled by an incoming play event.
+# If the play debounce is subsequently cancelled by another stop, this data
+# (the original stopped episode) is used instead of the new stop's metadata.
+# Cleared only when the play debounce fires (NOW PLAYING confirmed shown).
+_saved_stop_data: dict[str, Any] | None = None
 
 
 def _parse_guid_id(guids: list[dict[str, Any]], scheme: str) -> int | None:
@@ -247,26 +251,23 @@ def _load_template_config(template_name: str) -> dict[str, Any]:
 
 
 def handle_webhook(payload: dict[str, Any], credential_name: str | None = None) -> WebhookMessage | None:
-  """Process a Plex webhook event and return a WebhookMessage or None.
+  """Process a Plex webhook event and schedule a debounced display update.
 
   Enforces a state machine (IDLE → PLAYING ↔ PAUSED → IDLE):
   - play/resume: always valid; transition to PLAYING.
   - pause: only valid from PLAYING; ignored in IDLE or PAUSED.
   - stop: only valid from PLAYING or PAUSED; ignored in IDLE.
 
-  For pause and stop, also checks whether Plex content is still on the board
-  (via scheduler.current_hold_tag). If the board has moved on to other content,
-  the state still transitions (reflecting reality) but no message is returned —
-  avoiding stale events interrupting unrelated content.
+  All three event types are debounced: the display update is enqueued
+  asynchronously after _DEBOUNCE_SECS seconds. Incoming events cancel
+  sibling timers so that rapid self-cancelling sequences (play→pause,
+  pause→resume, stop→play between episodes) produce no display flashes.
 
-  stop events are debounced: the stopped card is enqueued asynchronously after
-  _stop_debounce() seconds. If a play/resume arrives in that window the timer
-  is cancelled and the stopped card is suppressed entirely.
-
-  Returns None for unrecognised events, invalid state transitions, non-video
-  media, board displacement, or missing metadata.
+  Always returns None — the scheduler receives "Discarded" for every Plex
+  webhook and the actual enqueueing is handled by the timer callbacks.
   """
-  global _state, _pending_stop_timer
+  global _state, _pending_play_timer, _pending_pause_timer, _pending_stop_timer
+  global _pending_stop_data, _saved_stop_data
 
   try:
     event = payload.get('event', '')
@@ -282,96 +283,189 @@ def handle_webhook(payload: dict[str, Any], credential_name: str | None = None) 
     except ImportError:
       pass
 
-    # --- State machine transition and validity check ---
+    # --- State machine transition and timer management ---
 
     if event in _PLAY_EVENTS:
-      # Cancel any pending stop debounce — a follow-up play supersedes the stop.
+      # Cancel all sibling timers. When cancelling a pending stop, rescue its
+      # data into _saved_stop_data so a subsequent quick stop can reuse it.
+      if _pending_play_timer is not None:
+        _pending_play_timer.cancel()
+        _pending_play_timer = None
+      if _pending_pause_timer is not None:
+        _pending_pause_timer.cancel()
+        _pending_pause_timer = None
       if _pending_stop_timer is not None:
         _pending_stop_timer.cancel()
         _pending_stop_timer = None
+        _saved_stop_data = _pending_stop_data
+        _pending_stop_data = None
         logger.debug('plex: cancelled pending stop timer (play/resume arrived)')
       _state = _State.PLAYING
-    elif event == _PAUSE_EVENT:
-      if _state != _State.PLAYING:
-        logger.debug('plex: discarding %s: state=%s, expected playing', event, _state.value)
-        return None
-      _state = _State.PAUSED
-    elif event in _STOP_EVENTS:
-      # Cancel any stale pending stop timer (defensive — shouldn't normally exist).
-      if _pending_stop_timer is not None:
-        _pending_stop_timer.cancel()
-        _pending_stop_timer = None
-      if _state == _State.IDLE:
-        logger.debug('plex: discarding %s: state=idle', event)
-        return None
-      _state = _State.IDLE
 
-    # --- Board displacement check (pause and stop only) ---
-    # play/resume always fires — it initiates a new session regardless of what
-    # is currently on the board. pause and stop are only meaningful if Plex
-    # content is still showing; if the board has moved on, suppress the message
-    # (state has already transitioned above to reflect reality).
+      # Build metadata.
+      metadata = payload.get('Metadata')
+      media_type = metadata.get('type') if metadata else None
+      show_name, episode_line = _build_metadata(metadata, media_type, event)
 
-    if event not in _PLAY_EVENTS:
-      import scheduler as _sched
-
-      hold_tag = _sched.current_hold_tag()
-      if hold_tag != 'plex':
-        logger.debug('plex: discarding %s: board tag=%r, expected "plex"', event, hold_tag)
+      if not show_name:
+        logger.debug('plex: discarding %s: no show_name (media_type=%r)', event, media_type)
         return None
 
-    # --- Build metadata ---
-
-    metadata = payload.get('Metadata')
-    media_type = metadata.get('type') if metadata else None
-
-    if media_type == 'episode' and metadata:
-      guids: list[dict[str, Any]] = metadata.get('Guid') or []
-      logger.debug(
-        'plex: episode guids=%r guid=%r grandparentGuid=%r',
-        guids,
-        metadata.get('guid'),
-        metadata.get('grandparentGuid'),
-      )
-      raw_show, tmdb_ep_title = _canonicalize_plex_title(
-        metadata['grandparentTitle'],
-        guids,
-        'episode',
-        season=metadata.get('parentIndex'),
-        episode=metadata.get('index'),
-      )
-      show_name = _vb.truncate_line(raw_show.upper(), _vb.model.cols, 'ellipsis')
-      episode_ref = _media.format_episode_ref(metadata['parentIndex'], metadata['index'])
-      plex_ep_title = (metadata.get('title') or '').strip()
-      episode_title = tmdb_ep_title or plex_ep_title
-      episode_detail = _media.strip_leading_article_if_needed(episode_title.upper(), _vb.model.cols, f'{episode_ref} ')
-      episode_line = f'{episode_ref} {episode_detail}'.strip()
-    elif media_type == 'movie' and metadata:
-      guids = metadata.get('Guid') or []
-      raw_movie, _ = _canonicalize_plex_title(metadata['title'], guids, 'movie')
-      show_name = _vb.truncate_line(raw_movie.upper(), _vb.model.cols, 'ellipsis')
-      episode_line = ''
-    else:
-      logger.debug('plex: no displayable metadata (type=%r)', media_type)
-      show_name = ''
-      episode_line = ''
-
-    if event in _STOP_EVENTS:
-      cfg = _load_template_config('stopped')
-      has_media = bool(show_name)
-      stop_data = {
+      cfg = _load_template_config('now_playing')
+      play_data = {
         'templates': cfg['templates'],
-        'variables': {'show_name': [[show_name]], 'episode_line': [[episode_line]]} if has_media else {},
+        'variables': {
+          'show_name': [[show_name]],
+          'episode_line': [[episode_line]],
+        },
         'truncation': cfg['truncation'],
       }
       priority = cfg['priority']
       hold = cfg['hold']
       timeout = cfg['timeout']
-      debounce = _stop_debounce()
+      captured_show_name = show_name  # closure needs the local value
+
+      def _enqueue_now_playing() -> None:
+        global _pending_play_timer, _saved_stop_data
+        _pending_play_timer = None
+        _saved_stop_data = None  # NOW PLAYING confirmed shown; discard rescued stop data
+        if _state != _State.PLAYING:
+          logger.debug('plex: play timer fired but state=%s, skipping', _state.value)
+          return
+        if not captured_show_name:  # defensive re-check
+          logger.debug('plex: play timer fired but show_name empty, skipping')
+          return
+        import scheduler as _sched
+
+        logger.debug('plex: play debounce elapsed, enqueueing now_playing (credential=%r)', credential_name)
+        _sched.enqueue(
+          priority=priority,
+          data=play_data,
+          hold=hold,
+          timeout=timeout,
+          name='webhook.plex',
+          indefinite=True,
+          supersede_tag='plex',
+        )
+        _sched.fire_hold_interrupt(supersede_tag='plex')
+
+      logger.debug('plex: play debounce started (%ds)', _DEBOUNCE_SECS)
+      _pending_play_timer = threading.Timer(_DEBOUNCE_SECS, _enqueue_now_playing)
+      _pending_play_timer.daemon = True
+      _pending_play_timer.start()
+      return None
+
+    elif event == _PAUSE_EVENT:
+      if _state != _State.PLAYING:
+        logger.debug('plex: discarding %s: state=%s, expected playing', event, _state.value)
+        return None
+      # Cancel pending play timer. Do NOT touch _saved_stop_data — it is only
+      # cleared when the play debounce fires (NOW PLAYING confirmed shown).
+      if _pending_play_timer is not None:
+        _pending_play_timer.cancel()
+        _pending_play_timer = None
+        logger.debug('plex: cancelled pending play timer (pause arrived)')
+      _state = _State.PAUSED
+
+      # Build metadata.
+      metadata = payload.get('Metadata')
+      media_type = metadata.get('type') if metadata else None
+      show_name, episode_line = _build_metadata(metadata, media_type, event)
+
+      if not show_name:
+        logger.debug('plex: discarding %s: no show_name (media_type=%r)', event, media_type)
+        return None
+
+      cfg = _load_template_config('paused')
+      pause_data = {
+        'templates': cfg['templates'],
+        'variables': {
+          'show_name': [[show_name]],
+          'episode_line': [[episode_line]],
+        },
+        'truncation': cfg['truncation'],
+      }
+      priority = cfg['priority']
+      hold = cfg['hold']
+      timeout = cfg['timeout']
+
+      def _enqueue_paused() -> None:
+        global _pending_pause_timer
+        _pending_pause_timer = None
+        if _state != _State.PAUSED:
+          logger.debug('plex: pause timer fired but state=%s, skipping', _state.value)
+          return
+        import scheduler as _sched
+
+        hold_tag = _sched.current_hold_tag()
+        if hold_tag != 'plex':
+          logger.debug('plex: pause timer fired but board tag=%r, skipping', hold_tag)
+          return
+        logger.debug('plex: pause debounce elapsed, enqueueing paused (credential=%r)', credential_name)
+        _sched.enqueue(
+          priority=priority,
+          data=pause_data,
+          hold=hold,
+          timeout=timeout,
+          name='webhook.plex',
+          indefinite=True,
+          supersede_tag='plex',
+        )
+        _sched.fire_hold_interrupt(supersede_tag='plex')
+
+      logger.debug('plex: pause debounce started (%ds)', _DEBOUNCE_SECS)
+      _pending_pause_timer = threading.Timer(_DEBOUNCE_SECS, _enqueue_paused)
+      _pending_pause_timer.daemon = True
+      _pending_pause_timer.start()
+      return None
+
+    elif event in _STOP_EVENTS:
+      # Cancel any stale pending stop timer (defensive — e.g. duplicate stop).
+      if _pending_stop_timer is not None:
+        _pending_stop_timer.cancel()
+        _pending_stop_timer = None
+        _pending_stop_data = None
+      # Cancel play and pause timers.
+      if _pending_play_timer is not None:
+        _pending_play_timer.cancel()
+        _pending_play_timer = None
+        logger.debug('plex: cancelled pending play timer (stop arrived)')
+      if _pending_pause_timer is not None:
+        _pending_pause_timer.cancel()
+        _pending_pause_timer = None
+        logger.debug('plex: cancelled pending pause timer (stop arrived)')
+      if _state == _State.IDLE:
+        logger.debug('plex: discarding %s: state=idle', event)
+        return None
+      _state = _State.IDLE
+
+      # Build metadata from the current stop event.
+      metadata = payload.get('Metadata')
+      media_type = metadata.get('type') if metadata else None
+      show_name, episode_line = _build_metadata(metadata, media_type, event)
+
+      cfg = _load_template_config('stopped')
+      has_media = bool(show_name)
+      new_stop_data = {
+        'templates': cfg['templates'],
+        'variables': {'show_name': [[show_name]], 'episode_line': [[episode_line]]} if has_media else {},
+        'truncation': cfg['truncation'],
+      }
+
+      # Prefer rescued stop data from an earlier cancelled stop debounce
+      # (e.g. ep1-stop → ep2-play → ep2-stop: show ep1's stopped card).
+      effective_stop_data = _saved_stop_data if _saved_stop_data is not None else new_stop_data
+      _saved_stop_data = None  # consumed regardless
+      _pending_stop_data = effective_stop_data
+
+      priority = cfg['priority']
+      hold = cfg['hold']
+      timeout = cfg['timeout']
 
       def _enqueue_stopped() -> None:
-        global _pending_stop_timer
+        global _pending_stop_timer, _pending_stop_data
         _pending_stop_timer = None
+        _pending_stop_data = None
         if _state != _State.IDLE:
           logger.debug('plex: stop timer fired but state=%s, skipping', _state.value)
           return
@@ -384,7 +478,7 @@ def handle_webhook(payload: dict[str, Any], credential_name: str | None = None) 
         logger.debug('plex: stop debounce elapsed, enqueueing stopped (has_media=%s)', has_media)
         _sched.enqueue(
           priority=priority,
-          data=stop_data,
+          data=effective_stop_data,
           hold=hold,
           timeout=timeout,
           name='webhook.plex',
@@ -392,36 +486,57 @@ def handle_webhook(payload: dict[str, Any], credential_name: str | None = None) 
         )
         _sched.fire_hold_interrupt(supersede_tag='plex')
 
-      logger.debug('plex: stop debounce started (%ds)', debounce)
-      _pending_stop_timer = threading.Timer(debounce, _enqueue_stopped)
+      logger.debug('plex: stop debounce started (%ds)', _DEBOUNCE_SECS)
+      _pending_stop_timer = threading.Timer(_DEBOUNCE_SECS, _enqueue_stopped)
       _pending_stop_timer.daemon = True
       _pending_stop_timer.start()
       return None
 
-    if not show_name:
-      logger.debug('plex: discarding %s: no show_name (media_type=%r)', event, media_type)
-      return None
-
-    template_name = 'paused' if event == _PAUSE_EVENT else 'now_playing'
-    logger.debug('plex: enqueueing %s: %r (credential=%r)', template_name, show_name, credential_name)
-    cfg = _load_template_config(template_name)
-
-    return WebhookMessage(
-      data={
-        'templates': cfg['templates'],
-        'variables': {
-          'show_name': [[show_name]],
-          'episode_line': [[episode_line]],
-        },
-        'truncation': cfg['truncation'],
-      },
-      priority=cfg['priority'],
-      hold=cfg['hold'],
-      timeout=cfg['timeout'],
-      indefinite=True,
-      interrupt=True,
-      supersede_tag='plex',
-    )
   except Exception as e:  # noqa: BLE001
     logger.error('Plex webhook error: %s', e)
     return None
+
+  return None  # unreachable but satisfies type checker
+
+
+def _build_metadata(
+  metadata: dict[str, Any] | None,
+  media_type: str | None,
+  event: str,
+) -> tuple[str, str]:
+  """Parse metadata from a Plex payload and return (show_name, episode_line).
+
+  Returns ('', '') for non-video media or missing/malformed metadata.
+  """
+  if media_type == 'episode' and metadata:
+    guids: list[dict[str, Any]] = metadata.get('Guid') or []
+    logger.debug(
+      'plex: episode guids=%r guid=%r grandparentGuid=%r',
+      guids,
+      metadata.get('guid'),
+      metadata.get('grandparentGuid'),
+    )
+    raw_show, tmdb_ep_title = _canonicalize_plex_title(
+      metadata['grandparentTitle'],
+      guids,
+      'episode',
+      season=metadata.get('parentIndex'),
+      episode=metadata.get('index'),
+    )
+    show_name = _vb.truncate_line(raw_show.upper(), _vb.model.cols, 'ellipsis')
+    episode_ref = _media.format_episode_ref(metadata['parentIndex'], metadata['index'])
+    plex_ep_title = (metadata.get('title') or '').strip()
+    episode_title = tmdb_ep_title or plex_ep_title
+    episode_detail = _media.strip_leading_article_if_needed(episode_title.upper(), _vb.model.cols, f'{episode_ref} ')
+    episode_line = f'{episode_ref} {episode_detail}'.strip()
+  elif media_type == 'movie' and metadata:
+    guids = metadata.get('Guid') or []
+    raw_movie, _ = _canonicalize_plex_title(metadata['title'], guids, 'movie')
+    show_name = _vb.truncate_line(raw_movie.upper(), _vb.model.cols, 'ellipsis')
+    episode_line = ''
+  else:
+    logger.debug('plex: no displayable metadata (type=%r)', media_type)
+    show_name = ''
+    episode_line = ''
+
+  return show_name, episode_line

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.2.0"
+version = "1.2.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_plex.py
+++ b/tests/core/test_plex.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Any
 from unittest.mock import patch
 
@@ -8,7 +7,6 @@ import config as _cfg
 import integrations.plex as _plex
 import integrations.tmdb as _tmdb
 import integrations.vestaboard as _vb
-import scheduler as _mod
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -63,22 +61,28 @@ def _clear_tmdb_caches() -> None:
 
 @pytest.fixture(autouse=True)
 def _reset_plex_state(monkeypatch: pytest.MonkeyPatch) -> None:
-  """Reset _state and cancel any pending stop timer before each test."""
-  if _plex._pending_stop_timer is not None:
-    _plex._pending_stop_timer.cancel()
+  """Reset all state and cancel any pending timers before each test."""
+  for attr in ('_pending_play_timer', '_pending_pause_timer', '_pending_stop_timer'):
+    timer = getattr(_plex, attr)
+    if timer is not None:
+      timer.cancel()
   monkeypatch.setattr(_plex, '_state', _plex._State.IDLE)
+  monkeypatch.setattr(_plex, '_pending_play_timer', None)
+  monkeypatch.setattr(_plex, '_pending_pause_timer', None)
   monkeypatch.setattr(_plex, '_pending_stop_timer', None)
+  monkeypatch.setattr(_plex, '_pending_stop_data', None)
+  monkeypatch.setattr(_plex, '_saved_stop_data', None)
 
 
 @pytest.fixture()
 def _plex_playing(monkeypatch: pytest.MonkeyPatch) -> None:
-  """Set state to PLAYING and board tag to 'plex' — simulates active session."""
+  """Set state to PLAYING — simulates active session."""
   monkeypatch.setattr(_plex, '_state', _plex._State.PLAYING)
 
 
 @pytest.fixture()
 def _plex_paused(monkeypatch: pytest.MonkeyPatch) -> None:
-  """Set state to PAUSED and board tag to 'plex' — simulates paused session."""
+  """Set state to PAUSED — simulates paused session."""
   monkeypatch.setattr(_plex, '_state', _plex._State.PAUSED)
 
 
@@ -90,8 +94,24 @@ def _board_shows_plex() -> Any:
 
 
 # ---------------------------------------------------------------------------
-# Helper: invoke stop timer callback synchronously without waiting
+# Helpers: fire timer callbacks synchronously without waiting
 # ---------------------------------------------------------------------------
+
+
+def _fire_play_timer() -> None:
+  """Cancel the pending play timer and invoke its callback synchronously."""
+  timer = _plex._pending_play_timer
+  assert timer is not None, '_pending_play_timer was not set'
+  timer.cancel()
+  timer.function(*timer.args, **timer.kwargs)
+
+
+def _fire_pause_timer() -> None:
+  """Cancel the pending pause timer and invoke its callback synchronously."""
+  timer = _plex._pending_pause_timer
+  assert timer is not None, '_pending_pause_timer was not set'
+  timer.cancel()
+  timer.function(*timer.args, **timer.kwargs)
 
 
 def _fire_stop_timer() -> None:
@@ -103,24 +123,31 @@ def _fire_stop_timer() -> None:
 
 
 # ---------------------------------------------------------------------------
-# play / resume → now_playing
+# play / resume — timer started, state transitions
 # ---------------------------------------------------------------------------
 
 
-def test_handle_webhook_play_returns_indefinite_now_playing() -> None:
+def test_handle_webhook_play_returns_none() -> None:
+  """play returns None immediately; enqueueing is async via timer."""
   result = _plex.handle_webhook(_episode_payload('media.play'))
-  assert isinstance(result, _mod.WebhookMessage)
-  assert result.indefinite is True
-  assert result.interrupt is True
-  assert result.interrupt_only is False
-  assert 'NOW PLAYING' in str(result.data['templates'])
+  assert result is None
 
 
-def test_handle_webhook_resume_returns_indefinite_now_playing() -> None:
+def test_handle_webhook_resume_returns_none() -> None:
   result = _plex.handle_webhook(_episode_payload('media.resume'))
-  assert isinstance(result, _mod.WebhookMessage)
-  assert result.indefinite is True
-  assert 'NOW PLAYING' in str(result.data['templates'])
+  assert result is None
+
+
+def test_handle_webhook_play_starts_play_timer() -> None:
+  _plex.handle_webhook(_episode_payload('media.play'))
+  assert _plex._pending_play_timer is not None
+  _plex._pending_play_timer.cancel()
+
+
+def test_handle_webhook_resume_starts_play_timer() -> None:
+  _plex.handle_webhook(_episode_payload('media.resume'))
+  assert _plex._pending_play_timer is not None
+  _plex._pending_play_timer.cancel()
 
 
 def test_handle_webhook_play_transitions_state_to_playing() -> None:
@@ -133,31 +160,105 @@ def test_handle_webhook_resume_transitions_state_to_playing() -> None:
   assert _plex._state == _plex._State.PLAYING
 
 
-def test_handle_webhook_play_always_fires_regardless_of_board(monkeypatch: pytest.MonkeyPatch) -> None:
-  """play fires even when the board is showing non-Plex content."""
+def test_handle_webhook_play_always_starts_timer_regardless_of_board() -> None:
+  """play starts its timer even when the board is showing non-Plex content."""
   with patch('scheduler.current_hold_tag', return_value=''):
-    result = _plex.handle_webhook(_episode_payload('media.play'))
-  assert isinstance(result, _mod.WebhookMessage)
+    _plex.handle_webhook(_episode_payload('media.play'))
+  assert _plex._pending_play_timer is not None
+  _plex._pending_play_timer.cancel()
 
 
-def test_handle_webhook_resume_always_fires_regardless_of_board() -> None:
-  """resume fires even when the board is showing non-Plex content."""
+def test_handle_webhook_resume_always_starts_timer_regardless_of_board() -> None:
   with patch('scheduler.current_hold_tag', return_value=''):
-    result = _plex.handle_webhook(_episode_payload('media.resume'))
-  assert isinstance(result, _mod.WebhookMessage)
+    _plex.handle_webhook(_episode_payload('media.resume'))
+  assert _plex._pending_play_timer is not None
+  _plex._pending_play_timer.cancel()
 
 
 # ---------------------------------------------------------------------------
-# pause → paused
+# play timer fires → NOW PLAYING enqueued
 # ---------------------------------------------------------------------------
 
 
-def test_handle_webhook_pause_returns_indefinite_paused_yellow(_plex_playing: None) -> None:
+def test_play_timer_fires_enqueues_now_playing() -> None:
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload('media.play'))
+    _fire_play_timer()
+  mock_enqueue.assert_called_once()
+  kwargs = mock_enqueue.call_args.kwargs
+  assert 'NOW PLAYING' in str(kwargs['data']['templates'])
+  assert kwargs['indefinite'] is True
+  assert kwargs['supersede_tag'] == 'plex'
+
+
+def test_play_timer_fires_calls_hold_interrupt() -> None:
+  with patch('scheduler.enqueue'), patch('scheduler.fire_hold_interrupt') as mock_interrupt:
+    _plex.handle_webhook(_episode_payload('media.play'))
+    _fire_play_timer()
+  mock_interrupt.assert_called_once_with(supersede_tag='plex')
+
+
+def test_play_timer_fires_enqueues_episode_metadata() -> None:
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload('media.play'))
+    _fire_play_timer()
+  data = mock_enqueue.call_args.kwargs['data']
+  assert data['variables']['show_name'] == [['THE BEAR']]
+  assert data['variables']['episode_line'] == [['S2E1 THE BEEF']]
+
+
+def test_play_timer_fires_enqueues_movie_metadata() -> None:
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_movie_payload('media.play', 'Inception'))
+    _fire_play_timer()
+  data = mock_enqueue.call_args.kwargs['data']
+  assert data['variables']['show_name'] == [['INCEPTION']]
+  assert data['variables']['episode_line'] == [['']]
+
+
+def test_play_timer_skips_if_state_not_playing() -> None:
+  """If another event changed state before timer fires, skip enqueue."""
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload('media.play'))
+    _plex._state = _plex._State.IDLE
+    _fire_play_timer()
+  mock_enqueue.assert_not_called()
+
+
+def test_play_timer_clears_saved_stop_data() -> None:
+  """When play timer fires, _saved_stop_data is cleared (NOW PLAYING confirmed)."""
+  _plex._saved_stop_data = {'templates': [], 'variables': {}, 'truncation': 'hard'}
+  with patch('scheduler.enqueue'), patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload('media.play'))
+    _fire_play_timer()
+  assert _plex._saved_stop_data is None
+
+
+def test_play_timer_skips_empty_show_name() -> None:
+  """Closure re-checks show_name and skips enqueueing if it is empty."""
+  payload = {'event': 'media.play', 'Metadata': {'type': 'track', 'title': 'Song'}}
+  # Non-video type produces empty show_name — no timer should be started at all
+  result = _plex.handle_webhook(payload)
+  assert result is None
+  assert _plex._pending_play_timer is None
+
+
+# ---------------------------------------------------------------------------
+# pause → paused (timer-based)
+# ---------------------------------------------------------------------------
+
+
+def test_handle_webhook_pause_returns_none(_plex_playing: None) -> None:
   result = _plex.handle_webhook(_episode_payload('media.pause'))
-  assert isinstance(result, _mod.WebhookMessage)
-  assert result.indefinite is True
-  assert result.interrupt is True
-  assert '[Y] NOW PLAYING' in str(result.data['templates'])
+  assert result is None
+  if _plex._pending_pause_timer:
+    _plex._pending_pause_timer.cancel()
+
+
+def test_handle_webhook_pause_starts_pause_timer(_plex_playing: None) -> None:
+  _plex.handle_webhook(_episode_payload('media.pause'))
+  assert _plex._pending_pause_timer is not None
+  _plex._pending_pause_timer.cancel()
 
 
 def test_handle_webhook_pause_transitions_state_to_paused(_plex_playing: None) -> None:
@@ -176,21 +277,73 @@ def test_handle_webhook_pause_in_idle_does_not_change_state() -> None:
   assert _plex._state == _plex._State.IDLE
 
 
+def test_handle_webhook_pause_in_idle_does_not_start_timer() -> None:
+  _plex.handle_webhook(_episode_payload('media.pause'))
+  assert _plex._pending_pause_timer is None
+
+
 def test_handle_webhook_pause_in_paused_returns_none(_plex_paused: None) -> None:
   """pause is a no-op when already paused."""
   result = _plex.handle_webhook(_episode_payload('media.pause'))
   assert result is None
 
 
-def test_handle_webhook_pause_when_board_displaced_returns_none(_plex_playing: None) -> None:
-  """pause suppressed when Plex hold has been displaced by other content."""
+def test_handle_webhook_pause_in_paused_does_not_start_timer(_plex_paused: None) -> None:
+  _plex.handle_webhook(_episode_payload('media.pause'))
+  assert _plex._pending_pause_timer is None
+
+
+# ---------------------------------------------------------------------------
+# pause timer fires → PAUSED enqueued (with board check in closure)
+# ---------------------------------------------------------------------------
+
+
+def test_pause_timer_fires_enqueues_paused(_plex_playing: None) -> None:
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload('media.pause'))
+    _fire_pause_timer()
+  mock_enqueue.assert_called_once()
+  kwargs = mock_enqueue.call_args.kwargs
+  assert '[Y] NOW PLAYING' in str(kwargs['data']['templates'])
+  assert kwargs['indefinite'] is True
+  assert kwargs['supersede_tag'] == 'plex'
+
+
+def test_pause_timer_fires_calls_hold_interrupt(_plex_playing: None) -> None:
+  with patch('scheduler.enqueue'), patch('scheduler.fire_hold_interrupt') as mock_interrupt:
+    _plex.handle_webhook(_episode_payload('media.pause'))
+    _fire_pause_timer()
+  mock_interrupt.assert_called_once_with(supersede_tag='plex')
+
+
+def test_pause_timer_skips_if_state_not_paused(_plex_playing: None) -> None:
+  """If state changed before pause timer fires, skip enqueue."""
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload('media.pause'))
+    _plex._state = _plex._State.IDLE
+    _fire_pause_timer()
+  mock_enqueue.assert_not_called()
+
+
+def test_pause_timer_skips_if_board_displaced(_plex_playing: None) -> None:
+  """Board-displacement check is in the pause timer closure, not at event-arrival."""
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload('media.pause'))
+    with patch('scheduler.current_hold_tag', return_value=''):
+      _fire_pause_timer()
+  mock_enqueue.assert_not_called()
+
+
+def test_handle_webhook_pause_still_starts_timer_when_board_displaced(_plex_playing: None) -> None:
+  """Board displacement does NOT suppress the pause timer at event-arrival time."""
   with patch('scheduler.current_hold_tag', return_value=''):
-    result = _plex.handle_webhook(_episode_payload('media.pause'))
-  assert result is None
+    _plex.handle_webhook(_episode_payload('media.pause'))
+  assert _plex._pending_pause_timer is not None
+  _plex._pending_pause_timer.cancel()
 
 
 def test_handle_webhook_pause_when_board_displaced_still_transitions_state(_plex_playing: None) -> None:
-  """State transitions to PAUSED even when board check suppresses the message."""
+  """State transitions to PAUSED regardless of board content."""
   with patch('scheduler.current_hold_tag', return_value=''):
     _plex.handle_webhook(_episode_payload('media.pause'))
   assert _plex._state == _plex._State.PAUSED
@@ -314,44 +467,51 @@ def test_handle_webhook_stop_timer_skips_if_board_displaced(_plex_playing: None)
   mock_enqueue.assert_not_called()
 
 
-def test_handle_webhook_stop_when_board_displaced_returns_none(_plex_playing: None) -> None:
-  """stop suppressed when Plex hold has been displaced by other content."""
+def test_handle_webhook_stop_still_starts_timer_when_board_displaced(_plex_playing: None) -> None:
+  """Board displacement does NOT prevent the stop timer from starting."""
   with patch('scheduler.current_hold_tag', return_value=''):
-    result = _plex.handle_webhook({'event': 'media.stop'})
-  assert result is None
-  assert _plex._pending_stop_timer is None
+    _plex.handle_webhook({'event': 'media.stop'})
+  assert _plex._pending_stop_timer is not None
 
 
 def test_handle_webhook_stop_when_board_displaced_still_transitions_to_idle(_plex_playing: None) -> None:
-  """State transitions to IDLE even when board check suppresses the message."""
+  """State transitions to IDLE even when the board tag is not 'plex'."""
   with patch('scheduler.current_hold_tag', return_value=''):
     _plex.handle_webhook({'event': 'media.stop'})
   assert _plex._state == _plex._State.IDLE
 
 
 def test_handle_webhook_play_after_displaced_stop_fires(_plex_playing: None) -> None:
-  """play always fires — even after a stop was suppressed due to displacement."""
+  """play always fires — even after a stop was followed by a displacement."""
   with patch('scheduler.current_hold_tag', return_value=''):
     _plex.handle_webhook({'event': 'media.stop'})
   with patch('scheduler.current_hold_tag', return_value=''):
-    result = _plex.handle_webhook(_episode_payload('media.play'))
-  assert isinstance(result, _mod.WebhookMessage)
+    _plex.handle_webhook(_episode_payload('media.play'))
+  assert _plex._pending_play_timer is not None
+  _plex._pending_play_timer.cancel()
 
 
 # ---------------------------------------------------------------------------
-# Debounce: stop followed by play/resume cancels the timer
+# Debounce: rapid sequences — timer cancellation
 # ---------------------------------------------------------------------------
 
 
-def test_stop_followed_by_play_within_window_cancels_timer(_plex_playing: None) -> None:
+def test_stop_followed_by_play_within_window_cancels_stop_timer(_plex_playing: None) -> None:
   """play arriving before the stop timer fires cancels the stopped card."""
   _plex.handle_webhook({'event': 'media.stop'})
   assert _plex._pending_stop_timer is not None
   with patch('scheduler.enqueue') as mock_enqueue:
     _plex.handle_webhook(_episode_payload('media.play'))
-  # Timer is cleared from module state and its function will not be called.
   assert _plex._pending_stop_timer is None
   mock_enqueue.assert_not_called()
+
+
+def test_stop_followed_by_play_starts_play_timer(_plex_playing: None) -> None:
+  """play after stop (within window) starts the play debounce timer."""
+  _plex.handle_webhook({'event': 'media.stop'})
+  _plex.handle_webhook(_episode_payload('media.play'))
+  assert _plex._pending_play_timer is not None
+  _plex._pending_play_timer.cancel()
 
 
 def test_stop_followed_by_resume_within_window_cancels_timer(_plex_playing: None) -> None:
@@ -362,28 +522,116 @@ def test_stop_followed_by_resume_within_window_cancels_timer(_plex_playing: None
   assert _plex._pending_stop_timer is None
 
 
-# ---------------------------------------------------------------------------
-# Debounce: configurable window
-# ---------------------------------------------------------------------------
+def test_play_pause_within_debounce_cancels_play_timer_starts_pause_timer() -> None:
+  """play → pause: play timer cancelled, pause timer started; no NOW PLAYING flash."""
+  _plex.handle_webhook(_episode_payload('media.play'))
+  assert _plex._pending_play_timer is not None
+  with patch('scheduler.enqueue') as mock_enqueue:
+    _plex.handle_webhook(_episode_payload('media.pause'))
+  # Play timer must be gone; no enqueue from it
+  assert _plex._pending_play_timer is None
+  assert _plex._pending_pause_timer is not None
+  mock_enqueue.assert_not_called()
+  _plex._pending_pause_timer.cancel()
 
 
-def test_stop_debounce_configurable(monkeypatch: pytest.MonkeyPatch, _plex_playing: None) -> None:
-  """[plex] stop_debounce = 5 is respected as the timer interval."""
-  monkeypatch.setattr(_cfg, '_config', {'plex': {'stop_debounce': 5}})
-  captured_interval: list[float] = []
-  orig_timer = threading.Timer
+def test_pause_resume_within_debounce_cancels_pause_timer_starts_play_timer(_plex_playing: None) -> None:
+  """pause → resume: pause timer cancelled, play timer started; no PAUSED flash."""
+  _plex.handle_webhook(_episode_payload('media.pause'))
+  assert _plex._pending_pause_timer is not None
+  with patch('scheduler.enqueue') as mock_enqueue:
+    _plex.handle_webhook(_episode_payload('media.resume'))
+  assert _plex._pending_pause_timer is None
+  assert _plex._pending_play_timer is not None
+  mock_enqueue.assert_not_called()
+  _plex._pending_play_timer.cancel()
 
-  def _spy_timer(interval: float, fn: Any, *args: Any, **kwargs: Any) -> threading.Timer:
-    captured_interval.append(interval)
-    t = orig_timer(interval, fn, *args, **kwargs)
-    return t
 
-  with patch('integrations.plex.threading.Timer', side_effect=_spy_timer):
+def test_play_stop_within_debounce_cancels_play_timer_starts_stop_timer() -> None:
+  """play → stop: play timer cancelled, stop timer started."""
+  _plex.handle_webhook(_episode_payload('media.play'))
+  assert _plex._pending_play_timer is not None
+  with patch('scheduler.enqueue') as mock_enqueue:
     _plex.handle_webhook({'event': 'media.stop'})
+  assert _plex._pending_play_timer is None
+  assert _plex._pending_stop_timer is not None
+  mock_enqueue.assert_not_called()
 
-  assert captured_interval == [5]
-  if _plex._pending_stop_timer is not None:
-    _plex._pending_stop_timer.cancel()
+
+def test_play_pause_resume_nets_to_now_playing() -> None:
+  """play → pause → resume all within debounce windows: settles to NOW PLAYING."""
+  _plex.handle_webhook(_episode_payload('media.play'))
+  _plex.handle_webhook(_episode_payload('media.pause'))
+  _plex.handle_webhook(_episode_payload('media.resume'))
+  assert _plex._pending_pause_timer is None
+  assert _plex._pending_play_timer is not None
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _fire_play_timer()
+  mock_enqueue.assert_called_once()
+  assert 'NOW PLAYING' in str(mock_enqueue.call_args.kwargs['data']['templates'])
+  assert '[Y]' not in str(mock_enqueue.call_args.kwargs['data']['templates'])
+
+
+# ---------------------------------------------------------------------------
+# _saved_stop_data — multi-hop stop recovery
+# ---------------------------------------------------------------------------
+
+
+def test_stop_cancelled_by_play_saves_stop_data(_plex_playing: None) -> None:
+  """When stop debounce is cancelled by play, stop data is saved."""
+  _plex.handle_webhook(_episode_payload('media.stop'))
+  # Stop timer is pending with ep data in _pending_stop_data
+  assert _plex._pending_stop_data is not None
+  # Play arrives and cancels the stop timer
+  _plex.handle_webhook(_episode_payload('media.play'))
+  assert _plex._pending_stop_timer is None
+  assert _plex._saved_stop_data is not None
+  if _plex._pending_play_timer:
+    _plex._pending_play_timer.cancel()
+
+
+def test_stop_play_stop_within_debounce_uses_saved_stop_data(_plex_playing: None) -> None:
+  """ep1-stop → ep2-play → ep2-stop: stop timer uses ep1's metadata."""
+  # ep1 stops with known metadata
+  _plex.handle_webhook(_episode_payload('media.stop', show='Ep1 Show', title='Ep1 Title'))
+  ep1_stop_data = _plex._pending_stop_data
+  assert ep1_stop_data is not None
+
+  # ep2 play arrives — cancels ep1's stop, saves ep1 data
+  _plex.handle_webhook(_episode_payload('media.play', show='Ep2 Show', title='Ep2 Title'))
+  assert _plex._saved_stop_data is ep1_stop_data
+
+  # ep2 stops quickly — play debounce cancelled; stop should use ep1's data
+  _plex.handle_webhook(_episode_payload('media.stop', show='Ep2 Show', title='Ep2 Title'))
+  assert _plex._saved_stop_data is None  # consumed
+
+  # Stop timer fires — should use ep1's data
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _fire_stop_timer()
+  data = mock_enqueue.call_args.kwargs['data']
+  assert data['variables']['show_name'] == [['EP1 SHOW']]
+
+
+def test_saved_stop_data_cleared_when_play_timer_fires(_plex_playing: None) -> None:
+  """_saved_stop_data is cleared when the play timer fires (NOW PLAYING shown)."""
+  _plex.handle_webhook(_episode_payload('media.stop'))
+  _plex.handle_webhook(_episode_payload('media.play'))
+  assert _plex._saved_stop_data is not None
+  with patch('scheduler.enqueue'), patch('scheduler.fire_hold_interrupt'):
+    _fire_play_timer()
+  assert _plex._saved_stop_data is None
+
+
+def test_saved_stop_data_not_cleared_when_play_cancelled_by_pause(_plex_playing: None) -> None:
+  """Cancelling the play timer via pause does NOT clear _saved_stop_data."""
+  _plex.handle_webhook(_episode_payload('media.stop'))
+  _plex.handle_webhook(_episode_payload('media.play'))
+  assert _plex._saved_stop_data is not None
+  # pause cancels play timer but must not touch _saved_stop_data
+  _plex.handle_webhook(_episode_payload('media.pause'))
+  assert _plex._saved_stop_data is not None
+  if _plex._pending_pause_timer:
+    _plex._pending_pause_timer.cancel()
 
 
 # ---------------------------------------------------------------------------
@@ -410,6 +658,9 @@ def test_handle_webhook_duplicate_stop_returns_none(_plex_playing: None) -> None
 def test_handle_webhook_stop_after_play_resets_and_starts_timer() -> None:
   """media.play resets to PLAYING so the next stop starts a timer."""
   _plex.handle_webhook(_episode_payload('media.play'))
+  if _plex._pending_play_timer:
+    _plex._pending_play_timer.cancel()
+    _plex._pending_play_timer = None
   _plex.handle_webhook({'event': 'media.stop'})
   assert _plex._pending_stop_timer is not None
 
@@ -417,6 +668,9 @@ def test_handle_webhook_stop_after_play_resets_and_starts_timer() -> None:
 def test_handle_webhook_stop_after_resume_resets_and_starts_timer() -> None:
   """media.resume resets to PLAYING so the next stop starts a timer."""
   _plex.handle_webhook(_episode_payload('media.resume'))
+  if _plex._pending_play_timer:
+    _plex._pending_play_timer.cancel()
+    _plex._pending_play_timer = None
   _plex.handle_webhook({'event': 'media.stop'})
   assert _plex._pending_stop_timer is not None
 
@@ -424,6 +678,9 @@ def test_handle_webhook_stop_after_resume_resets_and_starts_timer() -> None:
 def test_handle_webhook_pause_does_not_allow_subsequent_pause(_plex_playing: None) -> None:
   """media.pause transitions to PAUSED; a second pause is a no-op."""
   _plex.handle_webhook(_episode_payload('media.pause'))
+  if _plex._pending_pause_timer:
+    _plex._pending_pause_timer.cancel()
+    _plex._pending_pause_timer = None
   result = _plex.handle_webhook(_episode_payload('media.pause'))
   assert result is None
 
@@ -465,9 +722,10 @@ def test_handle_webhook_missing_metadata_returns_none() -> None:
 
 
 def test_handle_webhook_movie_has_empty_episode_line() -> None:
-  result = _plex.handle_webhook(_movie_payload('media.play', 'Inception'))
-  assert result is not None
-  variables = result.data['variables']
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_movie_payload('media.play', 'Inception'))
+    _fire_play_timer()
+  variables = mock_enqueue.call_args.kwargs['data']['variables']
   assert variables['episode_line'] == [['']]
   assert variables['show_name'] == [['INCEPTION']]
 
@@ -479,46 +737,52 @@ def test_handle_webhook_movie_has_empty_episode_line() -> None:
 
 def test_handle_webhook_episode_line_includes_season_episode_ref() -> None:
   """episode_line must include the S/E reference so it appears on the board."""
-  result = _plex.handle_webhook(_episode_payload('media.play', title='The Beef'))
-  assert result is not None
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload('media.play', title='The Beef'))
+    _fire_play_timer()
   # parentIndex=2, index=1 → S2E1; 'S2E1 THE BEEF' = 13 chars fits in 15 → article kept
-  assert result.data['variables']['episode_line'] == [['S2E1 THE BEEF']]
+  assert mock_enqueue.call_args.kwargs['data']['variables']['episode_line'] == [['S2E1 THE BEEF']]
 
 
 def test_handle_webhook_episode_strips_article_when_too_long() -> None:
   # 'S2E1 AN EXTRAORDINARY JOURNEY' = 29 chars > 15 cols → article stripped
-  result = _plex.handle_webhook(_episode_payload('media.play', title='An Extraordinary Journey'))
-  assert result is not None
-  assert result.data['variables']['episode_line'] == [['S2E1 EXTRAORDINARY JOURNEY']]
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload('media.play', title='An Extraordinary Journey'))
+    _fire_play_timer()
+  assert mock_enqueue.call_args.kwargs['data']['variables']['episode_line'] == [['S2E1 EXTRAORDINARY JOURNEY']]
 
 
 def test_handle_webhook_episode_keeps_article_when_it_fits() -> None:
   # 'S2E1 A NEW HOPE' = 15 chars, fits exactly in 15 cols → article kept
-  result = _plex.handle_webhook(_episode_payload('media.play', title='A New Hope'))
-  assert result is not None
-  assert result.data['variables']['episode_line'] == [['S2E1 A NEW HOPE']]
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload('media.play', title='A New Hope'))
+    _fire_play_timer()
+  assert mock_enqueue.call_args.kwargs['data']['variables']['episode_line'] == [['S2E1 A NEW HOPE']]
 
 
 def test_handle_webhook_show_name_preserves_article() -> None:
   """Show names are NOT article-stripped — "THE BEAR" stays "THE BEAR"."""
-  result = _plex.handle_webhook(_episode_payload('media.play'))
-  assert result is not None
-  assert result.data['variables']['show_name'] == [['THE BEAR']]
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload('media.play'))
+    _fire_play_timer()
+  assert mock_enqueue.call_args.kwargs['data']['variables']['show_name'] == [['THE BEAR']]
 
 
 def test_handle_webhook_movie_title_preserves_article() -> None:
   """Movie titles are NOT article-stripped."""
-  result = _plex.handle_webhook(_movie_payload('media.play', 'A Quiet Place'))
-  assert result is not None
-  assert result.data['variables']['show_name'] == [['A QUIET PLACE']]
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_movie_payload('media.play', 'A Quiet Place'))
+    _fire_play_timer()
+  assert mock_enqueue.call_args.kwargs['data']['variables']['show_name'] == [['A QUIET PLACE']]
 
 
 def test_handle_webhook_long_show_name_truncated_to_one_row() -> None:
   """A show name longer than model.cols must be ellipsis-truncated, not left to wrap."""
   long_show = 'Star Trek The Next Generation'
-  result = _plex.handle_webhook(_episode_payload(show=long_show))
-  assert result is not None
-  show_name = result.data['variables']['show_name'][0][0]
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload(show=long_show))
+    _fire_play_timer()
+  show_name = mock_enqueue.call_args.kwargs['data']['variables']['show_name'][0][0]
   upper = long_show.upper()
   assert _vb.display_len(show_name) <= _vb.model.cols
   assert show_name.endswith('...')
@@ -536,10 +800,12 @@ def test_handle_webhook_applies_config_override(monkeypatch: pytest.MonkeyPatch)
     '_config',
     {'plex': {'schedules': {'now_playing': {'hold': 7200, 'priority': 9}}}},
   )
-  result = _plex.handle_webhook(_episode_payload('media.play'))
-  assert result is not None
-  assert result.hold == 7200
-  assert result.priority == 9
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload('media.play'))
+    _fire_play_timer()
+  kwargs = mock_enqueue.call_args.kwargs
+  assert kwargs['hold'] == 7200
+  assert kwargs['priority'] == 9
 
 
 # ---------------------------------------------------------------------------
@@ -554,27 +820,30 @@ def test_handle_webhook_clears_trakt_watching_state(monkeypatch: pytest.MonkeyPa
   _trakt._last_watching_vars = {'show_name': [['SOME SHOW']]}
   _plex.handle_webhook(_episode_payload('media.play'))
   assert _trakt._last_watching_vars is None
+  if _plex._pending_play_timer:
+    _plex._pending_play_timer.cancel()
 
 
 # ---------------------------------------------------------------------------
-# supersede_tag
+# supersede_tag (verified via timer callbacks)
 # ---------------------------------------------------------------------------
 
 
-def test_handle_webhook_play_has_supersede_tag() -> None:
-  result = _plex.handle_webhook(_episode_payload('media.play'))
-  assert result is not None
-  assert result.supersede_tag == 'plex'
+def test_play_timer_has_supersede_tag() -> None:
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload('media.play'))
+    _fire_play_timer()
+  assert mock_enqueue.call_args.kwargs['supersede_tag'] == 'plex'
 
 
-def test_handle_webhook_pause_has_supersede_tag(_plex_playing: None) -> None:
-  result = _plex.handle_webhook(_episode_payload('media.pause'))
-  assert result is not None
-  assert result.supersede_tag == 'plex'
+def test_pause_timer_has_supersede_tag(_plex_playing: None) -> None:
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload('media.pause'))
+    _fire_pause_timer()
+  assert mock_enqueue.call_args.kwargs['supersede_tag'] == 'plex'
 
 
-def test_handle_webhook_stop_timer_has_supersede_tag(_plex_playing: None) -> None:
-  """The stopped card enqueued by the timer carries supersede_tag='plex'."""
+def test_stop_timer_has_supersede_tag(_plex_playing: None) -> None:
   with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
     _plex.handle_webhook({'event': 'media.stop'})
     _fire_stop_timer()
@@ -588,12 +857,16 @@ def test_handle_webhook_stop_timer_has_supersede_tag(_plex_playing: None) -> Non
 
 def test_credential_name_none_accepted() -> None:
   result = _plex.handle_webhook(_episode_payload('media.play'), credential_name=None)
-  assert isinstance(result, _mod.WebhookMessage)
+  assert result is None
+  if _plex._pending_play_timer:
+    _plex._pending_play_timer.cancel()
 
 
 def test_credential_name_passed() -> None:
   result = _plex.handle_webhook(_episode_payload('media.play'), credential_name='plex')
-  assert isinstance(result, _mod.WebhookMessage)
+  assert result is None
+  if _plex._pending_play_timer:
+    _plex._pending_play_timer.cancel()
 
 
 # ---------------------------------------------------------------------------
@@ -647,11 +920,12 @@ def test_handle_webhook_episode_uses_tmdb_canonical_show_name(monkeypatch: pytes
     return 'MasterChef'
 
   monkeypatch.setattr(_tmdb, 'get_show_title', _mock_get_show_title)
-  result = _plex.handle_webhook(_episode_payload_with_guid(tvdb_id=8765432, show='MasterChef (US)'))
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload_with_guid(tvdb_id=8765432, show='MasterChef (US)'))
+    _fire_play_timer()
 
-  assert result is not None
   assert show_calls == [40290]
-  assert result.data['variables']['show_name'] == [['MASTERCHEF']]
+  assert mock_enqueue.call_args.kwargs['data']['variables']['show_name'] == [['MASTERCHEF']]
 
 
 def test_handle_webhook_episode_falls_back_when_no_guid(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -661,11 +935,12 @@ def test_handle_webhook_episode_falls_back_when_no_guid(monkeypatch: pytest.Monk
   monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: find_calls.append(tvdb_id) or None)
   monkeypatch.setattr(_tmdb, 'search_show_by_title', lambda title: None)
 
-  result = _plex.handle_webhook(_episode_payload('media.play', show='Masterchef'))
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload('media.play', show='Masterchef'))
+    _fire_play_timer()
 
-  assert result is not None
   assert find_calls == []
-  assert result.data['variables']['show_name'] == [['MASTERCHEF']]
+  assert mock_enqueue.call_args.kwargs['data']['variables']['show_name'] == [['MASTERCHEF']]
 
 
 def test_handle_webhook_episode_falls_back_when_find_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -673,10 +948,11 @@ def test_handle_webhook_episode_falls_back_when_find_returns_none(monkeypatch: p
   monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: None)
 
-  result = _plex.handle_webhook(_episode_payload_with_guid(tvdb_id=12345, show='Clue'))
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload_with_guid(tvdb_id=12345, show='Clue'))
+    _fire_play_timer()
 
-  assert result is not None
-  assert result.data['variables']['show_name'] == [['CLUE']]
+  assert mock_enqueue.call_args.kwargs['data']['variables']['show_name'] == [['CLUE']]
 
 
 def test_handle_webhook_episode_falls_back_when_tmdb_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -685,11 +961,12 @@ def test_handle_webhook_episode_falls_back_when_tmdb_unconfigured(monkeypatch: p
   find_calls: list[int] = []
   monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: find_calls.append(tvdb_id) or None)
 
-  result = _plex.handle_webhook(_episode_payload_with_guid(tvdb_id=8765432, show='Masterchef'))
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload_with_guid(tvdb_id=8765432, show='Masterchef'))
+    _fire_play_timer()
 
-  assert result is not None
   assert find_calls == []
-  assert result.data['variables']['show_name'] == [['MASTERCHEF']]
+  assert mock_enqueue.call_args.kwargs['data']['variables']['show_name'] == [['MASTERCHEF']]
 
 
 def test_handle_webhook_movie_uses_tmdb_canonical_title(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -702,12 +979,12 @@ def test_handle_webhook_movie_uses_tmdb_canonical_title(monkeypatch: pytest.Monk
     return 'Inception'
 
   monkeypatch.setattr(_tmdb, 'get_movie_title', _mock_get_movie_title)
-  # Raw title has disambiguation that TMDb canonical doesn't
-  result = _plex.handle_webhook(_movie_payload_with_guid(tmdb_id=27205, title='Inception'))
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_movie_payload_with_guid(tmdb_id=27205, title='Inception'))
+    _fire_play_timer()
 
-  assert result is not None
   assert calls == [27205]
-  assert result.data['variables']['show_name'] == [['INCEPTION']]
+  assert mock_enqueue.call_args.kwargs['data']['variables']['show_name'] == [['INCEPTION']]
 
 
 def test_handle_webhook_movie_falls_back_when_tmdb_lookup_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -715,11 +992,11 @@ def test_handle_webhook_movie_falls_back_when_tmdb_lookup_returns_none(monkeypat
   monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   monkeypatch.setattr(_tmdb, 'get_movie_title', lambda tmdb_id: None)
 
-  # Use a short raw title to avoid truncation masking the fallback
-  result = _plex.handle_webhook(_movie_payload_with_guid(tmdb_id=27205, title='Clue'))
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_movie_payload_with_guid(tmdb_id=27205, title='Clue'))
+    _fire_play_timer()
 
-  assert result is not None
-  assert result.data['variables']['show_name'] == [['CLUE']]
+  assert mock_enqueue.call_args.kwargs['data']['variables']['show_name'] == [['CLUE']]
 
 
 def _episode_payload_with_imdb_guid(imdb_id: str, show: str = 'Jujutsu Kaisen') -> dict[str, Any]:
@@ -746,12 +1023,13 @@ def test_handle_webhook_episode_uses_tmdb_episode_title(monkeypatch: pytest.Monk
   monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: (1, 51, 'Perfect Preparation', 95479, 6827061))
   monkeypatch.setattr(_tmdb, 'get_show_title', lambda show_id: 'Jujutsu Kaisen')
 
-  result = _plex.handle_webhook(_episode_payload_with_guid(tvdb_id=11547510, show='JUJUTSU KAISEN'))
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload_with_guid(tvdb_id=11547510, show='JUJUTSU KAISEN'))
+    _fire_play_timer()
 
-  assert result is not None
   # S/E ref is always from Plex metadata (parentIndex=1, index=3 in the fixture);
   # only the episode title comes from TMDb.
-  assert result.data['variables']['episode_line'] == [['S1E3 PERFECT PREPARATION']]
+  assert mock_enqueue.call_args.kwargs['data']['variables']['episode_line'] == [['S1E3 PERFECT PREPARATION']]
 
 
 def test_handle_webhook_episode_falls_back_to_plex_title_when_no_tmdb_ep_title(
@@ -763,10 +1041,12 @@ def test_handle_webhook_episode_falls_back_to_plex_title_when_no_tmdb_ep_title(
   monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: (1, 3, '', 40290, 99001))
   monkeypatch.setattr(_tmdb, 'get_show_title', lambda show_id: 'MasterChef')
 
-  result = _plex.handle_webhook(_episode_payload_with_guid(tvdb_id=8765432, show='MasterChef (US)'))
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload_with_guid(tvdb_id=8765432, show='MasterChef (US)'))
+    _fire_play_timer()
 
-  assert result is not None
-  assert result.data['variables']['episode_line'] == [['S1E3 THE DISH']]  # fits in 15 cols — article kept
+  # fits in 15 cols — article kept
+  assert mock_enqueue.call_args.kwargs['data']['variables']['episode_line'] == [['S1E3 THE DISH']]
 
 
 def test_handle_webhook_episode_uses_imdb_fallback_when_no_tvdb_guid(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -782,12 +1062,13 @@ def test_handle_webhook_episode_uses_imdb_fallback_when_no_tvdb_guid(monkeypatch
   monkeypatch.setattr(_tmdb, 'find_episode_by_imdb_id', _mock_find_imdb)
   monkeypatch.setattr(_tmdb, 'get_show_title', lambda show_id: 'Jujutsu Kaisen')
 
-  result = _plex.handle_webhook(_episode_payload_with_imdb_guid('tt39370459', show='JUJUTSU KAISEN'))
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(_episode_payload_with_imdb_guid('tt39370459', show='JUJUTSU KAISEN'))
+    _fire_play_timer()
 
-  assert result is not None
   assert imdb_calls == ['tt39370459']
-  assert result.data['variables']['show_name'] == [['JUJUTSU KAISEN']]
-  assert result.data['variables']['episode_line'] == [['S3E4 PERFECT PREPARATION']]
+  assert mock_enqueue.call_args.kwargs['data']['variables']['show_name'] == [['JUJUTSU KAISEN']]
+  assert mock_enqueue.call_args.kwargs['data']['variables']['episode_line'] == [['S3E4 PERFECT PREPARATION']]
 
 
 def test_handle_webhook_episode_falls_back_when_no_tvdb_and_no_imdb_guid(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -808,12 +1089,13 @@ def test_handle_webhook_episode_falls_back_when_no_tvdb_and_no_imdb_guid(monkeyp
       'Guid': [{'id': 'tmdb://6827061'}],  # only tmdb://, no tvdb:// or imdb://
     },
   }
-  result = _plex.handle_webhook(payload)
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(payload)
+    _fire_play_timer()
 
-  assert result is not None
   assert imdb_calls == []
-  assert result.data['variables']['show_name'] == [['JUJUTSU KAISEN']]
-  assert result.data['variables']['episode_line'] == [['S3E4 EPISODE 4']]
+  assert mock_enqueue.call_args.kwargs['data']['variables']['show_name'] == [['JUJUTSU KAISEN']]
+  assert mock_enqueue.call_args.kwargs['data']['variables']['episode_line'] == [['S3E4 EPISODE 4']]
 
 
 def test_handle_webhook_episode_uses_title_search_when_no_guid(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -835,11 +1117,12 @@ def test_handle_webhook_episode_uses_title_search_when_no_guid(monkeypatch: pyte
       'Guid': [],
     },
   }
-  result = _plex.handle_webhook(payload)
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(payload)
+    _fire_play_timer()
 
-  assert result is not None
-  assert result.data['variables']['show_name'] == [['JUJUTSU KAISEN']]
-  assert result.data['variables']['episode_line'] == [['S3E4 PERFECT PREPARATION']]
+  assert mock_enqueue.call_args.kwargs['data']['variables']['show_name'] == [['JUJUTSU KAISEN']]
+  assert mock_enqueue.call_args.kwargs['data']['variables']['episode_line'] == [['S3E4 PERFECT PREPARATION']]
 
 
 def test_handle_webhook_episode_uses_episode_group_fallback_when_base_lookup_fails(
@@ -871,10 +1154,12 @@ def test_handle_webhook_episode_uses_episode_group_fallback_when_base_lookup_fai
       'Guid': [],
     },
   }
-  result = _plex.handle_webhook(payload)
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(payload)
+    _fire_play_timer()
 
-  assert result is not None
   # Show name is longer than model.cols so it's ellipsis-truncated
-  assert result.data['variables']['show_name'] == [['FRIEREN: BEY...']]
+  assert mock_enqueue.call_args.kwargs['data']['variables']['show_name'] == [['FRIEREN: BEY...']]
   # "A" leading article stripped; "an" preserved mid-title
-  assert result.data['variables']['episode_line'] == [['S2E7 GRAVESTONE AND AN AUTUMNAL JOURNEY']]
+  ep_line = mock_enqueue.call_args.kwargs['data']['variables']['episode_line']
+  assert ep_line == [['S2E7 GRAVESTONE AND AN AUTUMNAL JOURNEY']]

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- Adds `_pending_play_timer` and `_pending_pause_timer` alongside the existing `_pending_stop_timer`; all three share a hardcoded 3-second debounce window
- Incoming events cancel sibling timers, so rapid self-cancelling sequences (play→pause, pause→resume, stop→play between episodes) produce no display flashes — only the settled final state reaches the board
- Adds `_saved_stop_data` to rescue stop metadata when a stop debounce is cancelled by a play event, so a subsequent quick stop shows the original episode's stopped card rather than the new one
- Removes the configurable `stop_debounce` config key — the 3-second window is now hardcoded and applies uniformly to all three event types
- Board-displacement check moved from event-arrival time into timer closures for pause and stop, matching the behaviour implied by the debounced architecture
- 93 unit tests; 21 new tests covering all rapid-sequence scenarios; `test_stop_debounce_configurable` removed

## Test plan

- [x] `uv run pytest tests/core/test_plex.py` — 93 passed
- [x] Full suite `uv run pytest` — 1008 passed
- [x] `ruff check`, `ruff format`, `pyright`, `bandit`, `pip-audit` — all clean

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)
