### PR TITLE
fix(docs): remove Bot Fight Mode recommendation

### DIFF
--- a/docs/webhook-reverse-proxy.md
+++ b/docs/webhook-reverse-proxy.md
@@ -137,11 +137,6 @@ The free plan includes **one rate limiting rule**; spending it here is the
 highest-value use. It fires at Cloudflare's edge before the request reaches
 `cloudflared`, so the origin never sees the blocked traffic.
 
-Also enable **Bot Fight Mode** (**Security → Bots → Bot Fight Mode**) if not
-already on. It challenges requests from known bot infrastructure and automated
-scanners globally — free, no configuration required, and safe for
-machine-to-machine webhook senders like Plex, Notion, and iOS Shortcuts.
-
 ### Nginx
 
 ```nginx


### PR DESCRIPTION
— *Claude Code*

## Summary
- Remove the Bot Fight Mode recommendation from the webhook reverse proxy docs
- Bot Fight Mode blocks legitimate machine-to-machine webhook senders (confirmed with Notion, likely affects others hosted on cloud infrastructure Cloudflare classifies as bot traffic)

## Test plan
- [ ] Verify Notion webhooks work after disabling Bot Fight Mode in Cloudflare

🤖 Generated with [Claude Code](https://claude.com/claude-code)
