### PR TITLE
feat(content): mark personal content templates as private

### DIFF
--- a/content/contrib/birthdays.json
+++ b/content/contrib/birthdays.json
@@ -7,6 +7,7 @@
         "timeout": 3600
       },
       "priority": 6,
+      "private": true,
       "truncation": "ellipsis",
       "integration": "calendar",
       "integration_fn": "get_variables_birthdays",
@@ -26,6 +27,7 @@
         "timeout": 7200
       },
       "priority": 9,
+      "private": true,
       "truncation": "word",
       "integration": "calendar",
       "integration_fn": "get_variables_self_birthday",

--- a/content/contrib/calendar.json
+++ b/content/contrib/calendar.json
@@ -7,6 +7,7 @@
         "timeout": 1800
       },
       "priority": 5,
+      "private": true,
       "truncation": "ellipsis",
       "integration": "calendar",
       "templates": [

--- a/content/contrib/diving.json
+++ b/content/contrib/diving.json
@@ -26,6 +26,7 @@
         "timeout": 3600
       },
       "priority": 3,
+      "private": true,
       "integration": "diving",
       "integration_fn": "get_variables_last_dive",
       "templates": [

--- a/content/contrib/message.json
+++ b/content/contrib/message.json
@@ -7,6 +7,7 @@
         "timeout": 600
       },
       "priority": 8,
+      "private": true,
       "truncation": "wrap_ellipsis",
       "integration": "message"
     }

--- a/content/contrib/notion.json
+++ b/content/contrib/notion.json
@@ -7,6 +7,7 @@
         "timeout": 120
       },
       "priority": 7,
+      "private": true,
       "truncation": "ellipsis",
       "integration": "notion",
       "templates": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.2.1"
+version = "1.3.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.2.1"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary
- Mark `calendar.today`, `birthdays.today`, `birthdays.self`, `diving.last_dive`, `message.notification`, and `notion.notification` as `"private": true` so they are hidden when public mode is enabled
- Bump version to 1.3.0

## Test plan
- [x] All 1008 unit tests pass
- [x] Full check suite passes (ruff, pyright, bandit, pip-audit, pre-commit, pytest)
- [ ] Verify private templates are suppressed when `public_mode = true` in config.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)
