### PR TITLE
fix(docker): add missing quiet.py to Dockerfile COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev
 
 # Copy source, config example, and bundled contrib content.
-COPY scheduler.py config.py exceptions.py config.example.toml ./
+COPY scheduler.py config.py exceptions.py quiet.py config.example.toml ./
 COPY integrations/ ./integrations/
 COPY content/contrib/ ./content/contrib/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.4.0"
+version = "1.4.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Add missing `quiet.py` to the Dockerfile `COPY` directive — omitted in #442, causing `ModuleNotFoundError` at container startup

## Test plan

- [x] All 1038 tests pass
- [ ] Docker container starts without import error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
