### PR TITLE
chore(ci): add Docker smoke test to catch missing modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,11 @@ jobs:
         with:
           context: .
           push: false
+          load: true
+          tags: e-note-ion:ci
+
+      - name: Smoke test
+        run: docker run --rm e-note-ion:ci python -c "import scheduler"
 
   # Advisory only — not required by the branch ruleset. Failures surface in
   # the PR checks list but do not block merge.


### PR DESCRIPTION
— *Claude Code*

Closes #444.

## Summary

- Add a smoke test step to the Docker CI job that loads the built image and runs `import scheduler`, catching missing modules at PR time instead of deployment

## Test plan

- [ ] CI `Docker build` job passes with the new smoke test step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
