### PR TITLE
feat(parcel): add package delivery tracking integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,3 +112,4 @@ jobs:
           DIVING_NDBC_STATION: ${{ vars.DIVING_NDBC_STATION }}
           DIVING_LAT: ${{ vars.DIVING_LAT }}
           DIVING_LON: ${{ vars.DIVING_LON }}
+          PARCEL_API_KEY: ${{ secrets.PARCEL_API_KEY }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ integrations/media.py       # Shared media display helpers
 integrations/message.py     # Friend message webhook integration
 integrations/moon.py        # Moon phase calculation
 integrations/notion.py      # Notion webhook integration
+integrations/parcel.py      # Parcel package delivery tracking
 integrations/tmdb.py        # TMDb metadata lookups (used by plex, trakt)
 content/
   README.md                 # Content author reference: JSON format, priority, schedule coordination
@@ -96,6 +97,7 @@ content/
     message.json / .md      # Friend messages via webhook
     morning_night.json / .md  # Morning weather visual + good night
     notion.json / .md       # Notion webhook notifications
+    parcel.json / .md       # Upcoming package delivery from Parcel
     plex.json / .md         # Plex Media Server now-playing (webhook-only)
     scheduler.md            # Software-side quiet mode (webhook-only, no JSON)
     trakt.json / .md        # Trakt.tv calendar and now-playing
@@ -341,13 +343,14 @@ come from GitHub secrets env vars directly.
   - Trakt: `TRAKT_CLIENT_ID`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`
   - Discogs: `DISCOGS_TOKEN`
   - Diving: `DIVING_NDBC_STATION`, `DIVING_LAT`, `DIVING_LON`
+  - Parcel: `PARCEL_API_KEY`
 - CI runs the `integration` job on `main` pushes only; it is advisory
   (`continue-on-error: true`) and not required by the branch ruleset
 - GitHub secrets/vars needed — store as **environment secrets** (or vars) on the
   `integration` environment (Settings → Environments), restricted to the `main`
   branch; this scopes them tighter than repo secrets and prevents any PR branch
   from accessing them even if a workflow runs there:
-  - Secrets: `VESTABOARD_VIRTUAL_API_KEY`, `CALENDAR_URL`, `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `DISCOGS_TOKEN`
+  - Secrets: `VESTABOARD_VIRTUAL_API_KEY`, `CALENDAR_URL`, `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `DISCOGS_TOKEN`, `PARCEL_API_KEY`
   - Variables: `TRAKT_CLIENT_ID` (non-sensitive); `DIVING_NDBC_STATION`, `DIVING_LAT`, `DIVING_LON` (public NOAA station and coordinates)
 - If any integration test is skipped, the pytest session exits with code 5
   (NO_TESTS_COLLECTED), making the advisory job visibly fail rather than silently pass

--- a/config.example.toml
+++ b/config.example.toml
@@ -171,6 +171,17 @@ token = "your-discogs-personal-access-token"
 # timeout = 60
 # priority = 8
 
+[parcel]
+# Parcel package tracking — shows the soonest active delivery.
+# Requires Parcel Premium ($4.99/year). Generate a key at web.parcelapp.net.
+api_key = "your-parcel-api-key"
+
+# [parcel.schedules.deliveries]
+# cron = "15 9,15 * * *"
+# hold = 600
+# timeout = 1800
+# priority = 5
+
 [plex]
 # Optional: seconds to wait after a media.stop event before showing the stopped
 # card. If a media.play or media.resume arrives in this window (e.g. between

--- a/content/README.md
+++ b/content/README.md
@@ -245,6 +245,7 @@ new integrations in overnight windows unless there's a specific reason
 | `:30` every hour | `calendar.today` | Logistics | 5 | 300 s | 1800 s | |
 | `8:30` daily | `discogs.morning_spin` | Hobbies | 5 | 600 s | 3600 s | Queues behind calendar at `:30` |
 | `9:00` daily | `birthdays.today` | Social | 6 | 600 s | 3600 s | Queues behind weather; no-op when no birthdays |
+| `:15` at 09/15 | `parcel.deliveries` | Logistics | 5 | 600 s | 1800 s | Private; no-op when no active deliveries |
 | `10:00` daily | `diving.last_dive` | Hobbies | 3 | 300 s | 3600 s | Skipped when no dive date recorded |
 | `:00` at 12/20 | `trakt.next_up` | Entertainment | 4 | 1200 s | 1800 s | Private; noon = plan for evening, 20:00 = settle in |
 | `21:00` daily | `morning_night.good_night` | Ambient | 4 | 300 s | 3600 s | Moon phase visual; queues behind weather |
@@ -393,6 +394,7 @@ guidelines above.
 | [`message.json`](contrib/message.md) | Friend messages via iOS Shortcuts → webhook |
 | [`morning_night.json`](contrib/morning_night.md) | Good morning and good night messages with moon phase visual |
 | [`notion.json`](contrib/notion.md) | Notion automation notifications via webhook |
+| [`parcel.json`](contrib/parcel.md) | Upcoming package delivery from Parcel |
 | [`plex.json`](contrib/plex.md) | Plex Media Server now-playing via webhook |
 | (no JSON) [`scheduler`](contrib/scheduler.md) | Software-side quiet mode — webhook-only, no display content |
 | [`trakt.json`](contrib/trakt.md) | Trakt.tv upcoming calendar and now-playing |

--- a/content/contrib/parcel.json
+++ b/content/contrib/parcel.json
@@ -1,0 +1,24 @@
+{
+  "templates": {
+    "deliveries": {
+      "schedule": {
+        "cron": "15 9,15 * * *",
+        "hold": 600,
+        "timeout": 1800
+      },
+      "priority": 5,
+      "private": true,
+      "truncation": "ellipsis",
+      "integration": "parcel",
+      "templates": [
+        {
+          "format": [
+            "{status_line}",
+            "{description}",
+            "{detail}"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/content/contrib/parcel.md
+++ b/content/contrib/parcel.md
@@ -1,0 +1,111 @@
+# parcel.json
+
+Upcoming package delivery from Parcel (parcelapp.net). Logistics — fires
+twice daily showing the soonest active delivery.
+
+## Schedule
+
+### `deliveries` — soonest active package
+
+**Cron:** `15 9,15 * * *` — fires at 09:15 and 15:15 daily.
+**Hold:** 600 s | **Timeout:** 1800 s | **Priority:** 5 (Logistics)
+
+Private template. Fires in the `:15` slot at hours that don't overlap with
+diving (07/12/16). Solo hold budget at both slots: 600 s — well within the
+1800 s ceiling. No `refresh_interval` — delivery status doesn't change
+minute-to-minute.
+
+To override schedule fields without editing this file:
+
+```toml
+[parcel.schedules.deliveries]
+cron = "15 8,12,18 * * *"  # check three times daily
+hold = 300
+timeout = 900
+disabled = true             # skip entirely
+```
+
+## Configuration
+
+Add the following to your `config.toml`:
+
+```toml
+[parcel]
+api_key = "your-parcel-api-key"
+```
+
+| Key | Required | Description |
+|---|---|---|
+| `api_key` | Yes | API key from web.parcelapp.net (requires Parcel Premium) |
+
+### Getting an API key
+
+1. Subscribe to [Parcel Premium](https://parcelapp.net/) ($4.99/year)
+2. Sign in at [web.parcelapp.net](https://web.parcelapp.net)
+3. Generate an API key in your account settings
+4. Copy the key into your `config.toml`
+
+## Display format
+
+The template shows the soonest active delivery with a carrier-colored header:
+
+```
+[X] ON THE WAY
+PACKAGE NAME
+TOMORROW
+```
+
+### Carrier color mapping
+
+The header color square reflects the shipping carrier's brand:
+
+| Carrier | Code(s) | Color |
+|---|---|---|
+| USPS | `usps` | `[B]` blue |
+| UPS | `ups` | `[O]` orange |
+| FedEx | `fedex` | `[V]` violet |
+| DHL | `dhl` | `[Y]` yellow |
+| Amazon | `amzl*` (prefix) | `[B]` blue |
+| OnTrac | `ontrac`, `laser` | `[B]` blue |
+| All others | — | `[O]` orange (Parcel default) |
+
+### Detail line
+
+| Condition | Display |
+|---|---|
+| Out for delivery (status 4) | `OUT FOR DELIVERY` |
+| Expected today | `TODAY` |
+| Expected tomorrow | `TOMORROW` |
+| Expected in N days | `IN N DAYS` |
+| No expected date | (blank) |
+
+### Selection logic
+
+When multiple deliveries are active, the soonest `date_expected` is shown.
+Ties are broken alphabetically by package name. No active deliveries → the
+template is silently skipped.
+
+## API details
+
+**Endpoint:** `GET https://api.parcel.app/external/deliveries/?filter_mode=active`
+**Auth:** `api-key` header
+**Rate limit:** 20 requests/hour (server-cached responses)
+
+Active status codes used: 2 (in transit), 3 (pickup awaiting), 4 (out for
+delivery), 8 (information received).
+
+## Keeping data current
+
+### Carrier codes
+
+Authoritative source: https://api.parcel.app/external/supported_carriers.json
+
+The carrier color mapping in `integrations/parcel.py` covers major US carriers.
+If a new carrier becomes common (or an existing one is renamed), update the
+`_CARRIER_COLORS` dict and this table.
+
+### API changes
+
+Parcel does not maintain a public changelog. Monitor the API response format
+periodically — the integration parses `deliveries[].status_code`,
+`date_expected`, `carrier_code`, and `description` fields.

--- a/integrations/parcel.py
+++ b/integrations/parcel.py
@@ -1,0 +1,148 @@
+# integrations/parcel.py
+#
+# Upcoming package delivery integration via Parcel (parcelapp.net).
+#
+# Fetches active deliveries from the Parcel REST API and returns the
+# soonest-arriving package for display. Requires Parcel Premium and an
+# API key generated at web.parcelapp.net.
+#
+# Required config.toml keys ([parcel]):
+#   api_key — API key from web.parcelapp.net
+
+import logging
+from datetime import date, datetime
+
+import requests
+
+from exceptions import IntegrationDataUnavailableError
+from integrations.http import CacheEntry, fetch_with_retry
+
+logger = logging.getLogger(__name__)
+
+_API_URL = 'https://api.parcel.app/external/deliveries/'
+
+# Cache TTL: 30 minutes. The Parcel API is server-cached and rate-limited
+# to 20 requests/hour; a generous local TTL avoids unnecessary calls
+# during cron + refresh cycles.
+_CACHE_TTL = 30 * 60
+
+_cache: CacheEntry | None = None
+
+# Carrier code → color tag mapping. Prefix-matched for Amazon variants.
+_CARRIER_COLORS: dict[str, str] = {
+  'usps': '[B]',
+  'ups': '[O]',
+  'fedex': '[V]',
+  'dhl': '[Y]',
+  'ontrac': '[B]',
+  'laser': '[B]',
+}
+
+# Amazon carrier codes all start with 'amzl'.
+_AMAZON_PREFIX = 'amzl'
+_AMAZON_COLOR = '[B]'
+
+_DEFAULT_COLOR = '[O]'
+
+# Parcel API status codes that represent active deliveries.
+_ACTIVE_STATUSES = {2, 3, 4, 8}  # in transit, pickup, out for delivery, info received
+
+# Status code for "out for delivery".
+_OUT_FOR_DELIVERY = 4
+
+
+def _carrier_color(carrier_code: str) -> str:
+  """Return the display color tag for a carrier code."""
+  code = carrier_code.lower()
+  if code.startswith(_AMAZON_PREFIX):
+    return _AMAZON_COLOR
+  return _CARRIER_COLORS.get(code, _DEFAULT_COLOR)
+
+
+def _detail_line(status_code: int, date_expected: str | None) -> str:
+  """Build the detail line (row 3) from status and expected date."""
+  if status_code == _OUT_FOR_DELIVERY:
+    return 'OUT FOR DELIVERY'
+  if not date_expected:
+    return ''
+  try:
+    expected = datetime.strptime(date_expected, '%Y-%m-%d').date()
+  except ValueError:
+    return ''
+  today = date.today()
+  delta = (expected - today).days
+  if delta <= 0:
+    return 'TODAY'
+  if delta == 1:
+    return 'TOMORROW'
+  return f'IN {delta} DAYS'
+
+
+def _sort_key(delivery: dict) -> tuple:
+  """Sort key: soonest date first (nulls last), then alphabetical name."""
+  date_expected = delivery.get('date_expected') or ''
+  description = (delivery.get('description') or '').upper()
+  # Empty dates sort after all real dates.
+  return (0 if date_expected else 1, date_expected, description)
+
+
+def get_variables() -> dict[str, list[list[str]]]:
+  """Fetch active deliveries and return variables for the soonest one.
+
+  Returns keys: status_line, description, detail.
+  Raises IntegrationDataUnavailableError when there are no active deliveries.
+  """
+  global _cache
+
+  import config as _config_mod
+
+  api_key = _config_mod.get('parcel', 'api_key')
+
+  if _cache is not None and _cache.is_valid(_CACHE_TTL):
+    logger.debug('Parcel: cache hit')
+    return _cache.value
+
+  try:
+    r = fetch_with_retry(
+      'GET',
+      _API_URL,
+      params={'filter_mode': 'active'},
+      headers={'api-key': api_key},
+      timeout=10,
+    )
+    r.raise_for_status()
+  except requests.RequestException as e:
+    logger.warning('Parcel: API request failed — %s', e)
+    if _cache is not None:
+      logger.debug('Parcel: serving stale cache after error')
+      return _cache.value
+    raise IntegrationDataUnavailableError(f'Parcel: API request failed — {e}') from None
+
+  deliveries = r.json().get('deliveries', [])
+
+  # Filter to active statuses only.
+  active = [d for d in deliveries if d.get('status_code') in _ACTIVE_STATUSES]
+
+  if not active:
+    raise IntegrationDataUnavailableError('Parcel: no active deliveries')
+
+  active.sort(key=_sort_key)
+  chosen = active[0]
+
+  carrier_code = chosen.get('carrier_code') or ''
+  color = _carrier_color(carrier_code)
+  description = (chosen.get('description') or 'PACKAGE').upper()
+  detail = _detail_line(
+    chosen.get('status_code', 0),
+    chosen.get('date_expected'),
+  )
+
+  result: dict[str, list[list[str]]] = {
+    'status_line': [[f'{color} ON THE WAY']],
+    'description': [[description]],
+    'detail': [[detail]],
+  }
+
+  _cache = CacheEntry(result)
+  logger.debug('Parcel: selected %r (%s)', description, carrier_code)
+  return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.4.1"
+version = "1.5.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -77,6 +77,7 @@ _KNOWN_INTEGRATIONS: frozenset[str] = frozenset(
     'moon',
     'morning',
     'notion',
+    'parcel',
     'plex',
     'scheduler',
     'trakt',

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -19,6 +19,7 @@ _INTEGRATION_VARS: list[tuple[str, str]] = [
   ('DIVING_NDBC_STATION', 'Dive conditions integration (NDBC)'),
   ('DIVING_LAT', 'Dive conditions integration (Open-Meteo fallback)'),
   ('DIVING_LON', 'Dive conditions integration (Open-Meteo fallback)'),
+  ('PARCEL_API_KEY', 'Parcel integration'),
 ]
 
 _skipped = 0

--- a/tests/integrations/test_parcel_integration.py
+++ b/tests/integrations/test_parcel_integration.py
@@ -1,0 +1,56 @@
+"""Integration tests for integrations/parcel.py.
+
+Requires a Parcel Premium API key.
+
+Run with: uv run pytest -m integration -k parcel -v
+
+Required env vars:
+  PARCEL_API_KEY — API key from web.parcelapp.net
+"""
+
+import os
+
+import pytest
+
+import config as _cfg
+import integrations.parcel as pc
+from exceptions import IntegrationDataUnavailableError
+
+
+@pytest.mark.integration
+@pytest.mark.require_env('PARCEL_API_KEY')
+def test_get_variables_or_no_deliveries(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+  """get_variables() returns valid variables or raises for no active deliveries.
+
+  Both outcomes are valid — the user may or may not have packages in transit.
+  The test verifies the API call succeeds either way.
+  """
+  monkeypatch.setattr(
+    _cfg,
+    '_config',
+    {'parcel': {'api_key': os.environ['PARCEL_API_KEY']}},
+  )
+  pc._cache = None
+
+  try:
+    result = pc.get_variables()
+  except IntegrationDataUnavailableError as e:
+    # No active deliveries — valid state.
+    assert 'no active deliveries' in str(e)
+    pc._cache = None
+    return
+
+  # Active deliveries found — verify shape.
+  assert set(result.keys()) == {'status_line', 'description', 'detail'}
+  for key in ('status_line', 'description', 'detail'):
+    assert len(result[key]) == 1, f'{key}: expected 1 option'
+    assert len(result[key][0]) == 1, f'{key}: expected 1 line'
+
+  status_line = result['status_line'][0][0]
+  assert 'ON THE WAY' in status_line, f'unexpected status_line: {status_line!r}'
+  assert status_line.startswith('['), f'status_line missing color tag: {status_line!r}'
+
+  description = result['description'][0][0]
+  assert description, 'description is empty'
+
+  pc._cache = None

--- a/tests/test_parcel.py
+++ b/tests/test_parcel.py
@@ -1,0 +1,337 @@
+"""Unit tests for integrations/parcel.py."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import integrations.parcel as pc
+from exceptions import IntegrationDataUnavailableError
+from integrations.http import CacheEntry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _delivery(
+  *,
+  description: str = 'Test Package',
+  status_code: int = 2,
+  carrier_code: str = 'usps',
+  date_expected: str | None = '2026-03-20',
+) -> dict:
+  """Build a minimal Parcel delivery dict."""
+  d: dict = {
+    'description': description,
+    'status_code': status_code,
+    'carrier_code': carrier_code,
+  }
+  if date_expected is not None:
+    d['date_expected'] = date_expected
+  return d
+
+
+def _api_response(deliveries: list[dict]) -> MagicMock:
+  resp = MagicMock()
+  resp.json.return_value = {'deliveries': deliveries}
+  resp.raise_for_status = MagicMock()
+  return resp
+
+
+def _patched_config() -> dict:
+  return {'parcel': {'api_key': 'test-key'}}
+
+
+# ---------------------------------------------------------------------------
+# _carrier_color
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+  'carrier_code,expected',
+  [
+    ('usps', '[B]'),
+    ('USPS', '[B]'),
+    ('ups', '[O]'),
+    ('fedex', '[V]'),
+    ('dhl', '[Y]'),
+    ('ontrac', '[B]'),
+    ('laser', '[B]'),
+    ('amzlus', '[B]'),
+    ('amzluk', '[B]'),
+    ('amzlde', '[B]'),
+    ('unknown_carrier', '[O]'),
+    ('', '[O]'),
+  ],
+)
+def test_carrier_color(carrier_code: str, expected: str) -> None:
+  assert pc._carrier_color(carrier_code) == expected
+
+
+# ---------------------------------------------------------------------------
+# _detail_line
+# ---------------------------------------------------------------------------
+
+
+def test_detail_out_for_delivery() -> None:
+  assert pc._detail_line(4, '2026-03-18') == 'OUT FOR DELIVERY'
+
+
+def test_detail_today(monkeypatch: pytest.MonkeyPatch) -> None:
+  from datetime import date
+
+  monkeypatch.setattr(
+    pc,
+    'date',
+    type(
+      'MockDate',
+      (),
+      {
+        'today': staticmethod(lambda: date(2026, 3, 18)),
+      },
+    ),
+  )
+  assert pc._detail_line(2, '2026-03-18') == 'TODAY'
+
+
+def test_detail_tomorrow(monkeypatch: pytest.MonkeyPatch) -> None:
+  from datetime import date
+
+  monkeypatch.setattr(
+    pc,
+    'date',
+    type(
+      'MockDate',
+      (),
+      {
+        'today': staticmethod(lambda: date(2026, 3, 18)),
+      },
+    ),
+  )
+  assert pc._detail_line(2, '2026-03-19') == 'TOMORROW'
+
+
+def test_detail_in_n_days(monkeypatch: pytest.MonkeyPatch) -> None:
+  from datetime import date
+
+  monkeypatch.setattr(
+    pc,
+    'date',
+    type(
+      'MockDate',
+      (),
+      {
+        'today': staticmethod(lambda: date(2026, 3, 18)),
+      },
+    ),
+  )
+  assert pc._detail_line(2, '2026-03-21') == 'IN 3 DAYS'
+
+
+def test_detail_no_date() -> None:
+  assert pc._detail_line(2, None) == ''
+
+
+def test_detail_bad_date() -> None:
+  assert pc._detail_line(2, 'not-a-date') == ''
+
+
+def test_detail_past_date(monkeypatch: pytest.MonkeyPatch) -> None:
+  from datetime import date
+
+  monkeypatch.setattr(
+    pc,
+    'date',
+    type(
+      'MockDate',
+      (),
+      {
+        'today': staticmethod(lambda: date(2026, 3, 18)),
+      },
+    ),
+  )
+  assert pc._detail_line(2, '2026-03-16') == 'TODAY'
+
+
+# ---------------------------------------------------------------------------
+# _sort_key
+# ---------------------------------------------------------------------------
+
+
+def test_sort_key_soonest_first() -> None:
+  d1 = _delivery(description='Alpha', date_expected='2026-03-21')
+  d2 = _delivery(description='Beta', date_expected='2026-03-19')
+  assert sorted([d1, d2], key=pc._sort_key) == [d2, d1]
+
+
+def test_sort_key_alphabetical_tiebreak() -> None:
+  d1 = _delivery(description='Zebra', date_expected='2026-03-20')
+  d2 = _delivery(description='Alpha', date_expected='2026-03-20')
+  assert sorted([d1, d2], key=pc._sort_key) == [d2, d1]
+
+
+def test_sort_key_null_dates_last() -> None:
+  d1 = _delivery(description='No Date', date_expected=None)
+  d2 = _delivery(description='Has Date', date_expected='2026-03-25')
+  assert sorted([d1, d2], key=pc._sort_key) == [d2, d1]
+
+
+# ---------------------------------------------------------------------------
+# get_variables
+# ---------------------------------------------------------------------------
+
+
+def test_get_variables_out_for_delivery(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  pc._cache = None
+
+  resp = _api_response(
+    [
+      _delivery(
+        description='Amazon Order',
+        status_code=4,
+        carrier_code='amzlus',
+        date_expected='2026-03-18',
+      )
+    ]
+  )
+  with patch('integrations.parcel.fetch_with_retry', return_value=resp):
+    result = pc.get_variables()
+
+  assert result['status_line'] == [['[B] ON THE WAY']]
+  assert result['description'] == [['AMAZON ORDER']]
+  assert result['detail'] == [['OUT FOR DELIVERY']]
+  pc._cache = None
+
+
+def test_get_variables_no_active_deliveries(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  pc._cache = None
+
+  resp = _api_response([_delivery(status_code=0)])  # completed
+  with patch('integrations.parcel.fetch_with_retry', return_value=resp):
+    with pytest.raises(IntegrationDataUnavailableError, match='no active deliveries'):
+      pc.get_variables()
+
+  pc._cache = None
+
+
+def test_get_variables_empty_response(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  pc._cache = None
+
+  resp = _api_response([])
+  with patch('integrations.parcel.fetch_with_retry', return_value=resp):
+    with pytest.raises(IntegrationDataUnavailableError, match='no active deliveries'):
+      pc.get_variables()
+
+  pc._cache = None
+
+
+def test_get_variables_selects_soonest(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  pc._cache = None
+
+  resp = _api_response(
+    [
+      _delivery(description='Later', date_expected='2026-03-25', carrier_code='ups'),
+      _delivery(description='Sooner', date_expected='2026-03-19', carrier_code='fedex'),
+    ]
+  )
+  with patch('integrations.parcel.fetch_with_retry', return_value=resp):
+    result = pc.get_variables()
+
+  assert result['description'] == [['SOONER']]
+  assert result['status_line'] == [['[V] ON THE WAY']]
+  pc._cache = None
+
+
+def test_get_variables_no_description_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  pc._cache = None
+
+  resp = _api_response([_delivery(description='')])
+  with patch('integrations.parcel.fetch_with_retry', return_value=resp):
+    result = pc.get_variables()
+
+  assert result['description'] == [['PACKAGE']]
+  pc._cache = None
+
+
+# ---------------------------------------------------------------------------
+# Cache behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_cache_hit_avoids_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+
+  cached_value: dict = {
+    'status_line': [['[B] ON THE WAY']],
+    'description': [['CACHED']],
+    'detail': [['TODAY']],
+  }
+  pc._cache = CacheEntry(cached_value)
+
+  with patch('integrations.parcel.fetch_with_retry') as mock_fetch:
+    result = pc.get_variables()
+    mock_fetch.assert_not_called()
+
+  assert result == cached_value
+  pc._cache = None
+
+
+def test_stale_cache_served_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+  import requests as _requests
+
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+
+  stale_value: dict = {
+    'status_line': [['[O] ON THE WAY']],
+    'description': [['STALE']],
+    'detail': [['TOMORROW']],
+  }
+  pc._cache = CacheEntry(stale_value)
+  # Force cache to appear expired so we attempt a fetch.
+  import time
+
+  pc._cache.cached_at = time.monotonic() - pc._CACHE_TTL - 1
+
+  with patch(
+    'integrations.parcel.fetch_with_retry',
+    side_effect=_requests.RequestException('timeout'),
+  ):
+    result = pc.get_variables()
+
+  assert result == stale_value
+  pc._cache = None
+
+
+def test_no_cache_on_error_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+  import requests as _requests
+
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  pc._cache = None
+
+  with patch(
+    'integrations.parcel.fetch_with_retry',
+    side_effect=_requests.RequestException('timeout'),
+  ):
+    with pytest.raises(IntegrationDataUnavailableError, match='API request failed'):
+      pc.get_variables()

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.4.1"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary
- Add Parcel (parcelapp.net) integration for upcoming package delivery tracking
- Shows soonest active delivery with carrier-branded color header (`[X] ON THE WAY`)
- Carrier colors: USPS `[B]`, UPS `[O]`, FedEx `[V]`, DHL `[Y]`, Amazon `[B]`, OnTrac `[B]`, default `[O]`
- Detail line shows `OUT FOR DELIVERY`, `TODAY`, `TOMORROW`, `IN N DAYS`, or blank
- Polls Parcel REST API twice daily at 09:15 and 15:15 (Logistics, pri 5, private)
- Bumps version 1.4.1 → 1.5.0

## Test plan
- [x] Unit tests: carrier colors, detail line variants, selection logic, cache behavior, error handling
- [x] Integration test: calls real API, passes with or without active deliveries
- [x] Schedule lint passes (slot budget verified)
- [x] Full check suite passes locally (ruff, pyright, bandit, pip-audit, pytest)
- [x] Local integration test passes with real API key
- [x] `PARCEL_API_KEY` added to GitHub `integration` environment secrets

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)
