### PR TITLE
chore(docs): sync integration test env vars across all docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,9 @@ DISCOGS_TOKEN=your-discogs-personal-access-token
 # Required for TMDb integration tests:
 TMDB_API_READ_ACCESS_TOKEN=your-tmdb-api-read-access-token
 #
+# Required for Parcel integration tests:
+PARCEL_API_KEY=your-parcel-api-key
+#
 # Required for Dive conditions integration tests (not secret — use as GitHub env vars):
 DIVING_NDBC_STATION=46014
 DIVING_LAT=36.785

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,8 +339,10 @@ come from GitHub secrets env vars directly.
   - Vestaboard: `VESTABOARD_VIRTUAL_API_KEY` (use a virtual board, not physical)
   - Calendar (ICS mode): `CALENDAR_URL`
   - Calendar (CalDAV mode): `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD`
+  - Calendar (CardDAV/birthdays mode): `CALENDAR_CARDDAV_URL`
   - BART: `BART_API_KEY`
   - Trakt: `TRAKT_CLIENT_ID`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`
+  - TMDb: `TMDB_API_READ_ACCESS_TOKEN`
   - Discogs: `DISCOGS_TOKEN`
   - Diving: `DIVING_NDBC_STATION`, `DIVING_LAT`, `DIVING_LON`
   - Parcel: `PARCEL_API_KEY`
@@ -350,14 +352,17 @@ come from GitHub secrets env vars directly.
   `integration` environment (Settings → Environments), restricted to the `main`
   branch; this scopes them tighter than repo secrets and prevents any PR branch
   from accessing them even if a workflow runs there:
-  - Secrets: `VESTABOARD_VIRTUAL_API_KEY`, `CALENDAR_URL`, `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `DISCOGS_TOKEN`, `PARCEL_API_KEY`
+  - Secrets: `VESTABOARD_VIRTUAL_API_KEY`, `CALENDAR_URL`, `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD`, `CALENDAR_CARDDAV_URL`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `TMDB_API_READ_ACCESS_TOKEN`, `DISCOGS_TOKEN`, `PARCEL_API_KEY`
   - Variables: `TRAKT_CLIENT_ID` (non-sensitive); `DIVING_NDBC_STATION`, `DIVING_LAT`, `DIVING_LON` (public NOAA station and coordinates)
 - If any integration test is skipped, the pytest session exits with code 5
   (NO_TESTS_COLLECTED), making the advisory job visibly fail rather than silently pass
 - When adding a new integration, also add `tests/integrations/test_<name>_integration.py`,
   add its env vars to the `_INTEGRATION_VARS` list in `tests/integrations/conftest.py`,
   and wire them into the `env:` block of the integration job in `.github/workflows/ci.yml`
-  (use `${{ secrets.VAR }}` for sensitive values, `${{ vars.VAR }}` for non-sensitive ones)
+  (use `${{ secrets.VAR }}` for sensitive values, `${{ vars.VAR }}` for non-sensitive ones).
+  Also update env vars in all five synced locations: `conftest.py`, `ci.yml`,
+  `.env.example`, `README.md` integration test table, and the env var lists in
+  this file (AGENTS.md)
 
 ### Periodic health review
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Required keys:
 | `TRAKT_ACCESS_TOKEN` | run Trakt auth flow once and copy from `config.toml` |
 | `TMDB_API_READ_ACCESS_TOKEN` | [themoviedb.org/settings/api](https://www.themoviedb.org/settings/api) (optional; enhances Plex/Trakt metadata) |
 | `CALENDAR_CARDDAV_URL` | `https://contacts.icloud.com/` for iCloud birthday integration |
+| `PARCEL_API_KEY` | [web.parcelapp.net](https://web.parcelapp.net) → API key (requires Parcel Premium) |
 | `DIVING_NDBC_STATION` | [ndbc.noaa.gov](https://www.ndbc.noaa.gov/) station ID (e.g. `46221`) |
 | `DIVING_LAT` | Station latitude |
 | `DIVING_LON` | Station longitude |


### PR DESCRIPTION
— *Claude Code*

## Summary
- Add missing `PARCEL_API_KEY` to `.env.example` and `README.md` integration test table
- Add missing `CALENDAR_CARDDAV_URL` and `TMDB_API_READ_ACCESS_TOKEN` to AGENTS.md env var lists and GitHub secrets list
- Expand "When adding a new integration" checklist in AGENTS.md to require updating all five synced locations (`conftest.py`, `ci.yml`, `.env.example`, `README.md`, AGENTS.md)

Closes #447

## Test plan
- [x] Full check suite passes (1073 tests)
- [x] Verify env var entries match across `ci.yml`, `conftest.py`, `.env.example`, `README.md`, and `AGENTS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
