### PR TITLE
chore(docs): add format-change test grep rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,6 +319,9 @@ PR labels (apply one or more):
 - CI runs `uv run pytest` — tests must pass before merge
 - When working on existing code that lacks tests, add retroactive coverage as
   part of the same PR where feasible
+- When a change affects output format or data shape, grep all test directories
+  (`tests/`, `tests/core/`, `tests/integrations/`) for assertions on the old
+  format before committing — not just the files being directly edited
 
 #### Integration tests
 


### PR DESCRIPTION
— *Claude Code*

## Summary
- Add format-change test grep rule to AGENTS.md Tests section — when changing output formats, grep all test dirs for old-format assertions before committing
- Codifies the lesson from #435 (birthday format change broke integration test)

This was previously stored only in a Claude Code memory file. Moving it to AGENTS.md makes it durable and visible to all contributors.

## Test plan
- [x] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
