### PR TITLE
fix(tests): fix flaky test_concurrent_activate_deactivate in CI

### DIFF
--- a/tests/test_quiet.py
+++ b/tests/test_quiet.py
@@ -131,18 +131,18 @@ def test_concurrent_activate_deactivate() -> None:
 
   def _toggle(n: int) -> None:
     try:
-      with patch('quiet._config_mod.write_config_section'):
-        for _ in range(n):
-          _mod.activate()
-          _mod.deactivate()
+      for _ in range(n):
+        _mod.activate()
+        _mod.deactivate()
     except Exception as e:  # noqa: BLE001
       errors.append(e)
 
-  threads = [threading.Thread(target=_toggle, args=(50,)) for _ in range(4)]
-  for t in threads:
-    t.start()
-  for t in threads:
-    t.join()
+  with patch('quiet._config_mod.write_config_section'):
+    threads = [threading.Thread(target=_toggle, args=(50,)) for _ in range(4)]
+    for t in threads:
+      t.start()
+    for t in threads:
+      t.join()
   assert not errors
   # Final state should be inactive (all threads did activate+deactivate pairs)
   assert not _mod.is_active()


### PR DESCRIPTION
— *Claude Code*

## Summary
- Move `write_config_section` patch from per-thread to test-level scope in `test_concurrent_activate_deactivate`
- `unittest.mock.patch` is not thread-safe — concurrent patch/unpatch across threads could restore the real function while others were still running, causing `FileNotFoundError` when `config.toml` is absent (CI)

Closes #449

## Test plan
- [x] `uv run pytest tests/test_quiet.py -v` — all 16 tests pass
- [x] Full check suite passes (1073 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
