### PR TITLE
feat(morning,moon): refine weather and moon phase grids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -455,6 +455,7 @@ PR contains **release-worthy** changes:
 | Runtime dependency changes | Dev-only dependency changes |
 | `Dockerfile` changes | Docs-only changes |
 | Security fixes | Repo config / tooling changes |
+|  | Test-only changes (`tests/`) |
 
 Semver rules (strict post-1.0):
 - **Patch** (`x.y.z+1`): bug fixes, dependency updates, security fixes

--- a/integrations/moon.py
+++ b/integrations/moon.py
@@ -26,18 +26,18 @@ _SYNODIC_PERIOD = 29.53059
 # Each entry is (row1, row2, row3).
 _GRIDS: dict[str, tuple[str, str, str]] = {
   'NEW MOON': (
-    '[K][W][W][W][K]',
-    '[W][K][K][K][W]',
-    '[K][W][W][W][K]',
+    '[K][K][K][K][K]',
+    '[K][K][K][K][K]',
+    '[K][K][K][K][K]',
   ),
   'WAXING CRESCENT': (
-    '[K][K][W][K][K]',
-    '[K][K][W][W][K]',
-    '[K][K][W][K][K]',
+    '[K][K][K][W][K]',
+    '[K][K][K][W][W]',
+    '[K][K][K][W][K]',
   ),
   'FIRST QUARTER': (
     '[K][K][W][W][K]',
-    '[K][K][W][W][K]',
+    '[K][K][W][W][W]',
     '[K][K][W][W][K]',
   ),
   'WAXING GIBBOUS': (
@@ -57,13 +57,13 @@ _GRIDS: dict[str, tuple[str, str, str]] = {
   ),
   'LAST QUARTER': (
     '[K][W][W][K][K]',
-    '[K][W][W][K][K]',
+    '[W][W][W][K][K]',
     '[K][W][W][K][K]',
   ),
   'WANING CRESCENT': (
-    '[K][K][W][K][K]',
-    '[K][W][W][K][K]',
-    '[K][K][W][K][K]',
+    '[K][W][K][K][K]',
+    '[W][W][K][K][K]',
+    '[K][W][K][K][K]',
   ),
 }
 

--- a/integrations/morning.py
+++ b/integrations/morning.py
@@ -14,48 +14,63 @@
 # WMO weather code drives the visual; otherwise the sunrise grid is used.
 
 import logging
+import random
 
 logger = logging.getLogger(__name__)
 
-# 7×3 [color] grids for each weather condition group.
+_GRID_COLS = 7
+_GRID_ROWS = 3
+_GRID_CELLS = _GRID_COLS * _GRID_ROWS
+
+# 7×3 [color] grids for static weather condition groups.
 # Each entry is (r1, r2, r3) — three 7-cell color-tag strings.
 _GRIDS: dict[str, tuple[str, str, str]] = {
   'CLEAR': (
-    '[K][K][K][Y][K][K][K]',
+    '[K][K][O][O][O][K][K]',
     '[K][O][Y][Y][Y][O][K]',
     '[O][Y][Y][Y][Y][Y][O]',
   ),
   'PARTLY': (
-    '[W][W][K][K][K][W][W]',
+    '[W][W][O][O][O][W][W]',
     '[K][O][Y][Y][Y][O][K]',
     '[O][Y][Y][Y][Y][Y][O]',
   ),
   'CLOUDY': (
     '[K][W][W][W][W][W][K]',
     '[W][W][W][W][W][W][W]',
-    '[W][W][W][W][W][W][W]',
-  ),
-  'RAIN_LIGHT': (
-    '[B][K][B][K][B][K][B]',
-    '[K][B][K][B][K][B][K]',
-    '[B][K][B][K][B][K][B]',
-  ),
-  'RAIN_HEAVY': (
-    '[B][B][K][B][B][K][B]',
-    '[B][K][B][B][K][B][B]',
-    '[K][B][B][K][B][B][K]',
-  ),
-  'SNOW': (
-    '[W][K][W][K][W][K][W]',
-    '[K][W][K][W][K][W][K]',
-    '[W][K][W][K][W][K][W]',
-  ),
-  'STORM': (
-    '[R][R][K][R][K][R][R]',
-    '[R][K][R][R][R][K][R]',
-    '[K][R][R][K][R][R][K]',
+    '[K][W][W][W][W][W][K]',
   ),
 }
+
+# Random scatter grid config: (color_tag, density, min_cells).
+# Each call to get_variables() generates a fresh random pattern.
+_RANDOM_GRIDS: dict[str, tuple[str, float, int]] = {
+  'RAIN_LIGHT': ('B', 0.30, 4),
+  'RAIN_HEAVY': ('B', 0.55, 8),
+  'SNOW': ('W', 0.25, 4),
+  'STORM': ('R', 0.50, 7),
+}
+
+
+def _random_grid(
+  color: str,
+  density: float,
+  min_cells: int,
+) -> tuple[str, str, str]:
+  """Generate a random 7×3 scatter grid with a minimum cell count."""
+  cells = [random.random() < density for _ in range(_GRID_CELLS)]  # nosec B311
+  filled = sum(cells)
+  if filled < min_cells:
+    empty = [i for i, c in enumerate(cells) if not c]
+    random.shuffle(empty)
+    for i in empty[: min_cells - filled]:
+      cells[i] = True
+  rows: list[str] = []
+  for r in range(_GRID_ROWS):
+    row = ''.join(f'[{color}]' if cells[r * _GRID_COLS + c] else '[K]' for c in range(_GRID_COLS))
+    rows.append(row)
+  return (rows[0], rows[1], rows[2])
+
 
 _DEFAULT = 'CLEAR'
 
@@ -115,7 +130,11 @@ def _grid_key_from_weather() -> str:
 
 def get_variables() -> dict[str, list[list[str]]]:
   key = _grid_key_from_weather()
-  r1, r2, r3 = _GRIDS[key]
+  if key in _RANDOM_GRIDS:
+    color, density, min_cells = _RANDOM_GRIDS[key]
+    r1, r2, r3 = _random_grid(color, density, min_cells)
+  else:
+    r1, r2, r3 = _GRIDS[key]
   return {
     'morning_r1': [[r1]],
     'morning_r2': [[r2]],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.5.0"
+version = "1.6.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/test_morning.py
+++ b/tests/test_morning.py
@@ -4,10 +4,20 @@ import pytest
 
 import integrations.weather as weather_mod
 from exceptions import IntegrationDataUnavailableError
-from integrations.morning import _CONDITION_MAP, _DEFAULT, _GRIDS, _grid_key_from_weather, get_variables
+from integrations.morning import (
+  _CONDITION_MAP,
+  _DEFAULT,
+  _GRIDS,
+  _RANDOM_GRIDS,
+  _grid_key_from_weather,
+  _random_grid,
+  get_variables,
+)
 
 _COLOR_TAGS = {'[W]', '[K]', '[R]', '[O]', '[Y]', '[G]', '[B]', '[V]'}
 _TAG_LEN = 3
+
+_ALL_GRID_KEYS = set(_GRIDS) | set(_RANDOM_GRIDS)
 
 
 def _count_visual_width(row: str) -> int:
@@ -22,10 +32,15 @@ def _count_visual_width(row: str) -> int:
   return count
 
 
+def _count_color_cells(grid: tuple[str, str, str], color: str) -> int:
+  tag = f'[{color}]'
+  return sum(row.count(tag) for row in grid)
+
+
 # --- Grid shape ---
 
 
-def test_all_grids_are_seven_wide() -> None:
+def test_all_static_grids_are_seven_wide() -> None:
   for key, (r1, r2, r3) in _GRIDS.items():
     for row in (r1, r2, r3):
       width = _count_visual_width(row)
@@ -33,12 +48,40 @@ def test_all_grids_are_seven_wide() -> None:
 
 
 def test_default_grid_exists() -> None:
-  assert _DEFAULT in _GRIDS
+  assert _DEFAULT in _ALL_GRID_KEYS
 
 
 def test_all_condition_map_values_are_valid_grid_keys() -> None:
   for condition, key in _CONDITION_MAP.items():
-    assert key in _GRIDS, f'{condition!r} maps to unknown grid key {key!r}'
+    assert key in _ALL_GRID_KEYS, f'{condition!r} maps to unknown grid key {key!r}'
+
+
+# --- Random grid generation ---
+
+
+@pytest.mark.parametrize('key,config', _RANDOM_GRIDS.items())
+def test_random_grid_is_seven_wide(key: str, config: tuple[str, float, int]) -> None:
+  color, density, min_cells = config
+  grid = _random_grid(color, density, min_cells)
+  for row in grid:
+    width = _count_visual_width(row)
+    assert width == 7, f'{key}: row {row!r} has width {width}, expected 7'
+
+
+@pytest.mark.parametrize('key,config', _RANDOM_GRIDS.items())
+def test_random_grid_meets_minimum_cells(key: str, config: tuple[str, float, int]) -> None:
+  color, density, min_cells = config
+  for _ in range(20):
+    grid = _random_grid(color, density, min_cells)
+    count = _count_color_cells(grid, color)
+    assert count >= min_cells, f'{key}: got {count} cells, expected >= {min_cells}'
+
+
+def test_random_grid_uses_only_specified_color_and_black() -> None:
+  grid = _random_grid('B', 0.5, 4)
+  for row in grid:
+    stripped = row.replace('[B]', '').replace('[K]', '')
+    assert stripped == '', f'unexpected tags in row: {row!r}'
 
 
 # --- Condition mapping ---

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- **Morning weather grids**: refine clear/partly sun shape (3 orange top for round outline), round cloudy bottom corners, replace static rain/snow/storm checkerboards with random scatter patterns (unique each display cycle)
- **Moon phase grids**: blank new moon, edge-aligned crescents, anchor pixel on quarters for consistent shape language, smooth pixel progression (0→4→7→10→11→10→7→4)
- **AGENTS.md**: add test-only changes to not-release-worthy column in release strategy table

Closes #434

## Test plan

- [x] All 1082 existing tests pass
- [x] New tests for random grid generation (7-wide output, minimum cell counts, color correctness)
- [x] Updated condition map test to cover both static and random grid keys
- [x] Moon grid tests pass (5-wide, waxing right-lit, waning left-lit)
- [x] `ruff check`, `ruff format`, `pyright`, `bandit`, `pre-commit` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
