### PR TITLE
feat(qbittorrent,unraid): add homelab status integrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,9 @@ integrations/message.py     # Friend message webhook integration
 integrations/moon.py        # Moon phase calculation
 integrations/notion.py      # Notion webhook integration
 integrations/parcel.py      # Parcel package delivery tracking
+integrations/qbittorrent.py # qBittorrent seeding stats (Web API v2, local network)
 integrations/tmdb.py        # TMDb metadata lookups (used by plex, trakt)
+integrations/unraid.py      # Unraid server status (GraphQL API, local network)
 content/
   README.md                 # Content author reference: JSON format, priority, schedule coordination
   DESIGN.md                 # Visual/design conventions: layout, color, tone, character set
@@ -99,8 +101,10 @@ content/
     notion.json / .md       # Notion webhook notifications
     parcel.json / .md       # Upcoming package delivery from Parcel
     plex.json / .md         # Plex Media Server now-playing (webhook-only)
+    qbittorrent.json / .md  # qBittorrent seeding stats
     scheduler.md            # Software-side quiet mode (webhook-only, no JSON)
     trakt.json / .md        # Trakt.tv calendar and now-playing
+    unraid.json / .md       # Unraid server status
   user/                     # Personal content (always loaded, git-ignored)
 docs/
   webhook-reverse-proxy.md  # Webhook TLS setup guide (Cloudflare Tunnel, reverse proxy)

--- a/config.example.toml
+++ b/config.example.toml
@@ -182,11 +182,38 @@ api_key = "your-parcel-api-key"
 # timeout = 1800
 # priority = 5
 
+[qbittorrent]
+# Seeding stats from qBittorrent Web UI. Shows active seeding count and total
+# seeded size. Requires the Web UI to be enabled in qBittorrent settings.
+# ⚠  Local network only — do not expose the Web UI to the internet.
+url = "http://192.168.1.50:8080"
+username = "admin"
+password = "your-webui-password"
+
+# [qbittorrent.schedules.status]
+# cron = "45 10 * * *"
+# hold = 300
+# timeout = 3600
+# priority = 3
+
 [plex]
 # Optional: seconds to wait after a media.stop event before showing the stopped
 # card. If a media.play or media.resume arrives in this window (e.g. between
 # back-to-back episodes), the stopped card is suppressed entirely. Default: 3.
 # stop_debounce = 3
+
+[unraid]
+# Unraid server status — array capacity and uptime. Requires Unraid 7.2+ and
+# an API key from Settings → Management Access → API Keys.
+# ⚠  Local network only — do not expose the Unraid API to the internet.
+url = "http://192.168.1.10"
+api_key = "your-unraid-api-key"
+
+# [unraid.schedules.status]
+# cron = "45 11 * * *"
+# hold = 300
+# timeout = 3600
+# priority = 3
 
 [tmdb]
 # Optional: canonical media metadata authority for the Plex and Trakt integrations.

--- a/content/README.md
+++ b/content/README.md
@@ -247,6 +247,8 @@ new integrations in overnight windows unless there's a specific reason
 | `9:00` daily | `birthdays.today` | Social | 6 | 600 s | 3600 s | Queues behind weather; no-op when no birthdays |
 | `:15` at 09/15 | `parcel.deliveries` | Logistics | 5 | 600 s | 1800 s | Private; no-op when no active deliveries |
 | `10:00` daily | `diving.last_dive` | Hobbies | 3 | 300 s | 3600 s | Skipped when no dive date recorded |
+| `10:45` daily | `qbittorrent.status` | Hobbies | 3 | 300 s | 3600 s | Private; solo `:45` slot; skipped when nothing seeding |
+| `11:45` daily | `unraid.status` | Hobbies | 3 | 300 s | 3600 s | Private; solo `:45` slot |
 | `:00` at 12/20 | `trakt.next_up` | Entertainment | 4 | 1200 s | 1800 s | Private; noon = plan for evening, 20:00 = settle in |
 | `21:00` daily | `morning_night.good_night` | Ambient | 4 | 300 s | 3600 s | Moon phase visual; queues behind weather |
 | `*/5` 07–09 Mon–Fri | `bart.departures` | Logistics | 8 | 290 s | 60 s | Refresh 60 s; dominates weekday mornings |
@@ -396,6 +398,8 @@ guidelines above.
 | [`notion.json`](contrib/notion.md) | Notion automation notifications via webhook |
 | [`parcel.json`](contrib/parcel.md) | Upcoming package delivery from Parcel |
 | [`plex.json`](contrib/plex.md) | Plex Media Server now-playing via webhook |
+| [`qbittorrent.json`](contrib/qbittorrent.md) | Seeding stats from qBittorrent Web UI |
 | (no JSON) [`scheduler`](contrib/scheduler.md) | Software-side quiet mode — webhook-only, no display content |
 | [`trakt.json`](contrib/trakt.md) | Trakt.tv upcoming calendar and now-playing |
+| [`unraid.json`](contrib/unraid.md) | Unraid server status — array capacity and uptime |
 | [`weather.json`](contrib/weather.md) | Current weather conditions via Open-Meteo |

--- a/content/contrib/qbittorrent.json
+++ b/content/contrib/qbittorrent.json
@@ -1,0 +1,23 @@
+{
+  "templates": {
+    "status": {
+      "schedule": {
+        "cron": "45 10 * * *",
+        "hold": 300,
+        "timeout": 3600
+      },
+      "priority": 3,
+      "private": true,
+      "integration": "qbittorrent",
+      "templates": [
+        {
+          "format": [
+            "{header}",
+            "{count}",
+            "{size}"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/content/contrib/qbittorrent.md
+++ b/content/contrib/qbittorrent.md
@@ -1,0 +1,86 @@
+# qbittorrent.json
+
+Seeding stats from qBittorrent Web UI. Hobbies — fires once daily showing
+active seeding count and total seeded size.
+
+## Schedule
+
+### `status` — seeding count and total size
+
+**Cron:** `45 10 * * *` — fires daily at 10:45.
+**Hold:** 300 s | **Timeout:** 3600 s | **Priority:** 3 (Hobbies)
+
+Private template. Fires in a solo `:45` slot with a 300 s hold budget — well
+within the 1800 s ceiling.
+
+To override schedule fields without editing this file:
+
+```toml
+[qbittorrent.schedules.status]
+cron = "45 10,16 * * *"  # check twice daily
+hold = 300
+timeout = 3600
+disabled = true           # skip entirely
+```
+
+## Configuration
+
+Add the following to your `config.toml`:
+
+```toml
+[qbittorrent]
+url = "http://192.168.1.50:8080"
+username = "admin"
+password = "your-password"
+```
+
+| Key | Required | Description |
+|---|---|---|
+| `url` | Yes | Web UI base URL — must be a **local network** address |
+| `username` | Yes | Web UI username |
+| `password` | Yes | Web UI password |
+
+### Security — local network only
+
+The qBittorrent Web API transmits credentials in plaintext and is designed
+for LAN access only. **Do not expose the Web UI to the internet.**
+
+Use a local IP address or hostname (e.g. `http://192.168.1.50:8080`,
+`http://tower:8080`). If e-note-ion runs in Docker, the container must have
+network access to the qBittorrent host — use host network mode or configure
+Docker networking to reach the LAN.
+
+## Display format
+
+```
+[B] TORRENTS
+4 SEEDING
+1.2 TB
+```
+
+- `[B]` blue — qBittorrent brand color
+- Seeding count: number of torrents in seeding state
+- Total size of seeded content (not uploaded amount)
+- Size uses TB for >= 1 TB, GB otherwise; one decimal place, `.0` dropped
+
+When nothing is seeding, the template is silently skipped.
+
+## API details
+
+**Auth:** `POST /api/v2/auth/login` with form-encoded username/password.
+Returns a session cookie used for subsequent requests.
+
+**Data:** `GET /api/v2/torrents/info?filter=seeding` — returns per-torrent
+objects. The integration sums the `size` field across all results.
+
+Per-torrent stats (including `size`) persist across qBittorrent restarts.
+Session-level stats (`/api/v2/transfer/info`) do not persist and are not used.
+
+## Keeping data current
+
+### API changes
+
+Authoritative source: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)
+
+The integration uses `/api/v2/auth/login` and `/api/v2/torrents/info` — both
+stable since qBittorrent 4.1. Monitor the wiki for deprecation notices.

--- a/content/contrib/unraid.json
+++ b/content/contrib/unraid.json
@@ -1,0 +1,23 @@
+{
+  "templates": {
+    "status": {
+      "schedule": {
+        "cron": "45 11 * * *",
+        "hold": 300,
+        "timeout": 3600
+      },
+      "priority": 3,
+      "private": true,
+      "integration": "unraid",
+      "templates": [
+        {
+          "format": [
+            "{header}",
+            "{capacity}",
+            "{uptime}"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/content/contrib/unraid.md
+++ b/content/contrib/unraid.md
@@ -1,0 +1,100 @@
+# unraid.json
+
+Unraid server status — array capacity and uptime. Hobbies — fires once daily.
+
+## Schedule
+
+### `status` — array capacity and uptime
+
+**Cron:** `45 11 * * *` — fires daily at 11:45.
+**Hold:** 300 s | **Timeout:** 3600 s | **Priority:** 3 (Hobbies)
+
+Private template. Fires in a solo `:45` slot with a 300 s hold budget — well
+within the 1800 s ceiling.
+
+To override schedule fields without editing this file:
+
+```toml
+[unraid.schedules.status]
+cron = "45 10,16 * * *"  # check twice daily
+hold = 300
+timeout = 3600
+disabled = true           # skip entirely
+```
+
+## Configuration
+
+Add the following to your `config.toml`:
+
+```toml
+[unraid]
+url = "http://192.168.1.10"
+api_key = "your-unraid-api-key"
+```
+
+| Key | Required | Description |
+|---|---|---|
+| `url` | Yes | Server base URL — must be a **local network** address |
+| `api_key` | Yes | API key from Settings → Management Access → API Keys |
+
+### Security — local network only
+
+The Unraid API exposes full server control and should only be accessed over
+the local network. **Do not expose the Unraid API to the internet.**
+
+Use a local IP address or hostname (e.g. `http://192.168.1.10`,
+`http://tower`). If e-note-ion runs in Docker, the container must have
+network access to the Unraid host — use host network mode or configure
+Docker networking to reach the LAN.
+
+### Unraid version requirement
+
+The GraphQL API requires **Unraid 7.2 or later**. Earlier versions do not
+expose the `/graphql` endpoint.
+
+## Display format
+
+```
+[O] UNRAID
+14 / 20 TB
+UP 3M 2D 8H
+```
+
+- `[O]` orange — Unraid brand color
+- Array used / total capacity
+- Uptime: `#M #D #H` (months, days, hours); no weeks, no minutes, no
+  zero-padding; zero-value components are skipped
+- Size uses TB for >= 1 TB, GB otherwise; one decimal place, `.0` dropped
+
+When the array is stopped or degraded, the capacity line shows `[R] STOPPED`
+or `[R] DEGRADED` instead of usage numbers.
+
+## API details
+
+**Auth:** `x-api-key` header with the API key.
+
+**Data:** Single GraphQL POST to `{url}/graphql`:
+
+```graphql
+{
+  info { os { uptime } }
+  array {
+    state
+    capacity { disks { used, total } }
+  }
+}
+```
+
+`uptime` is in seconds. `used` and `total` are in bytes. Months are
+approximated as 30 days.
+
+## Keeping data current
+
+### API changes
+
+Authoritative source: https://docs.unraid.net/API/
+
+The Unraid API is under active development. Monitor the docs and the
+[unraid/api](https://github.com/unraid/api) repository for schema changes.
+The integration queries `info.os.uptime` and `array.capacity.disks` — verify
+these fields exist after major Unraid updates.

--- a/integrations/qbittorrent.py
+++ b/integrations/qbittorrent.py
@@ -1,0 +1,119 @@
+# integrations/qbittorrent.py
+#
+# qBittorrent seeding stats integration.
+#
+# Fetches the list of actively seeding torrents from the qBittorrent Web API
+# v2 and returns the count and total size for display. Connects over the local
+# network — do not expose the qBittorrent Web UI to the internet.
+#
+# Required config.toml keys ([qbittorrent]):
+#   url      — Web UI base URL (e.g. "http://192.168.1.50:8080")
+#   username — Web UI username
+#   password — Web UI password
+
+import logging
+
+import requests
+
+from exceptions import IntegrationDataUnavailableError
+from integrations.http import CacheEntry, fetch_with_retry
+
+logger = logging.getLogger(__name__)
+
+# Cache TTL: 30 minutes. Seeding stats change slowly.
+_CACHE_TTL = 30 * 60
+
+_cache: CacheEntry | None = None
+
+
+def _fmt_size(size_bytes: int) -> str:
+  """Format a byte count as a human-readable size string.
+
+  Uses TB for >= 1 TB, GB otherwise. Rounds to one decimal place and drops
+  a trailing '.0' (e.g. 1.2 TB, 14 TB, 850 GB).
+  """
+  tb = size_bytes / (1024**4)
+  if tb >= 1.0:
+    rounded = round(tb, 1)
+    if rounded == int(rounded):
+      return f'{int(rounded)} TB'
+    return f'{rounded} TB'
+  gb = size_bytes / (1024**3)
+  rounded = round(gb, 1)
+  if rounded == int(rounded):
+    return f'{int(rounded)} GB'
+  return f'{rounded} GB'
+
+
+def _login(base_url: str, username: str, password: str) -> requests.Session:
+  """Authenticate with the qBittorrent Web API and return a session."""
+  session = requests.Session()
+  r = session.post(
+    f'{base_url}/api/v2/auth/login',
+    data={'username': username, 'password': password},
+    timeout=10,
+  )
+  r.raise_for_status()
+  if r.text.strip() != 'Ok.':
+    raise IntegrationDataUnavailableError('qBittorrent: login failed — check credentials')
+  return session
+
+
+def get_variables() -> dict[str, list[list[str]]]:
+  """Fetch seeding stats and return variables for template rendering.
+
+  Returns keys: header, count, size.
+  Raises IntegrationDataUnavailableError when there are no seeding torrents
+  or the API is unreachable.
+  """
+  global _cache
+
+  import config as _cfg
+
+  if _cache is not None and _cache.is_valid(_CACHE_TTL):
+    logger.debug('qBittorrent: cache hit')
+    return _cache.value
+
+  base_url = _cfg.get('qbittorrent', 'url').rstrip('/')
+  username = _cfg.get('qbittorrent', 'username')
+  password = _cfg.get('qbittorrent', 'password')
+
+  try:
+    session = _login(base_url, username, password)
+  except requests.RequestException as e:
+    if _cache is not None:
+      logger.warning('qBittorrent: login failed — serving stale cache — %s', e)
+      return _cache.value
+    raise IntegrationDataUnavailableError(f'qBittorrent: login failed — {e}') from None
+
+  try:
+    r = fetch_with_retry(
+      'GET',
+      f'{base_url}/api/v2/torrents/info',
+      params={'filter': 'seeding'},
+      cookies=session.cookies,
+      timeout=10,
+    )
+    r.raise_for_status()
+  except requests.RequestException as e:
+    if _cache is not None:
+      logger.warning('qBittorrent: API request failed — serving stale cache — %s', e)
+      return _cache.value
+    raise IntegrationDataUnavailableError(f'qBittorrent: API request failed — {e}') from None
+
+  torrents = r.json()
+  if not torrents:
+    raise IntegrationDataUnavailableError('qBittorrent: no seeding torrents')
+
+  count = len(torrents)
+  total_size = sum(t.get('size', 0) for t in torrents)
+
+  result: dict[str, list[list[str]]] = {
+    'header': [['[B] TORRENTS']],
+    'count': [[f'{count} SEEDING']],
+    'size': [[_fmt_size(total_size)]],
+  }
+
+  _cache = CacheEntry(result)
+  logger.debug('qBittorrent: %d seeding, %s', count, _fmt_size(total_size))
+  return result

--- a/integrations/unraid.py
+++ b/integrations/unraid.py
@@ -1,0 +1,141 @@
+# integrations/unraid.py
+#
+# Unraid server status integration.
+#
+# Fetches array capacity and system uptime from the Unraid GraphQL API
+# (available on Unraid 7.2+). Connects over the local network — do not
+# expose the Unraid API to the internet.
+#
+# Required config.toml keys ([unraid]):
+#   url     — server base URL (e.g. "http://192.168.1.10")
+#   api_key — API key from Settings → Management Access → API Keys
+
+import logging
+
+import requests
+
+from exceptions import IntegrationDataUnavailableError
+from integrations.http import CacheEntry, fetch_with_retry
+
+logger = logging.getLogger(__name__)
+
+# Cache TTL: 30 minutes. Array capacity and uptime change slowly.
+_CACHE_TTL = 30 * 60
+
+_cache: CacheEntry | None = None
+
+_QUERY = """\
+{
+  info { os { uptime } }
+  array {
+    state
+    capacity { disks { used, total } }
+  }
+}"""
+
+
+def _fmt_size(size_bytes: int) -> str:
+  """Format a byte count as a human-readable TB/GB string.
+
+  Uses TB for >= 1 TB, GB otherwise. Rounds to one decimal place and drops
+  a trailing '.0' (e.g. 1.2 TB, 14 TB, 850 GB).
+  """
+  tb = size_bytes / (1024**4)
+  if tb >= 1.0:
+    rounded = round(tb, 1)
+    if rounded == int(rounded):
+      return f'{int(rounded)} TB'
+    return f'{rounded} TB'
+  gb = size_bytes / (1024**3)
+  rounded = round(gb, 1)
+  if rounded == int(rounded):
+    return f'{int(rounded)} GB'
+  return f'{rounded} GB'
+
+
+def _fmt_uptime(seconds: int) -> str:
+  """Format uptime as '#M #D #H' — months, days, hours.
+
+  No weeks, nothing finer than hours, no zero-padding, skip zero-value
+  components. Months are approximated as 30 days.
+  """
+  months, remainder = divmod(seconds, 30 * 24 * 3600)
+  days, remainder = divmod(remainder, 24 * 3600)
+  hours = remainder // 3600
+
+  parts: list[str] = []
+  if months:
+    parts.append(f'{months}M')
+  if days:
+    parts.append(f'{days}D')
+  # Always show hours if no other components, so bare "UP 0H" is possible.
+  if hours or not parts:
+    parts.append(f'{hours}H')
+
+  return f'UP {" ".join(parts)}'
+
+
+def get_variables() -> dict[str, list[list[str]]]:
+  """Fetch Unraid status and return variables for template rendering.
+
+  Returns keys: header, capacity, uptime.
+  Raises IntegrationDataUnavailableError when the API is unreachable.
+  """
+  global _cache
+
+  import config as _cfg
+
+  if _cache is not None and _cache.is_valid(_CACHE_TTL):
+    logger.debug('Unraid: cache hit')
+    return _cache.value
+
+  base_url = _cfg.get('unraid', 'url').rstrip('/')
+  api_key = _cfg.get('unraid', 'api_key')
+
+  try:
+    r = fetch_with_retry(
+      'POST',
+      f'{base_url}/graphql',
+      headers={'x-api-key': api_key},
+      json={'query': _QUERY},
+      timeout=10,
+    )
+    r.raise_for_status()
+  except requests.RequestException as e:
+    if _cache is not None:
+      logger.warning('Unraid: API request failed — serving stale cache — %s', e)
+      return _cache.value
+    raise IntegrationDataUnavailableError(f'Unraid: API request failed — {e}') from None
+
+  data = r.json().get('data')
+  if not data:
+    errors = r.json().get('errors', [])
+    msg = errors[0].get('message', 'unknown') if errors else 'no data'
+    raise IntegrationDataUnavailableError(f'Unraid: GraphQL error — {msg}')
+
+  # Uptime
+  uptime_secs = data.get('info', {}).get('os', {}).get('uptime')
+  uptime_line = _fmt_uptime(int(uptime_secs)) if uptime_secs is not None else ''
+
+  # Array
+  array_state = data.get('array', {}).get('state', '').upper()
+  disks = data.get('array', {}).get('capacity', {}).get('disks', {})
+  used = disks.get('used')
+  total = disks.get('total')
+
+  if array_state in ('STOPPED', 'DEGRADED'):
+    capacity_line = f'[R] {array_state}'
+  elif used is not None and total is not None:
+    capacity_line = f'{_fmt_size(int(used))} / {_fmt_size(int(total))}'
+  else:
+    capacity_line = ''
+
+  result: dict[str, list[list[str]]] = {
+    'header': [['[O] UNRAID']],
+    'capacity': [[capacity_line]],
+    'uptime': [[uptime_line]],
+  }
+
+  _cache = CacheEntry(result)
+  logger.debug('Unraid: array=%s, %s', array_state, uptime_line)
+  return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.6.0"
+version = "1.7.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -79,8 +79,10 @@ _KNOWN_INTEGRATIONS: frozenset[str] = frozenset(
     'notion',
     'parcel',
     'plex',
+    'qbittorrent',
     'scheduler',
     'trakt',
+    'unraid',
     'weather',
   }
 )

--- a/tests/test_qbittorrent.py
+++ b/tests/test_qbittorrent.py
@@ -1,0 +1,205 @@
+"""Unit tests for integrations/qbittorrent.py."""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests as _requests
+
+import integrations.qbittorrent as qbt
+from exceptions import IntegrationDataUnavailableError
+from integrations.http import CacheEntry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _torrent(*, size: int = 1_000_000_000) -> dict:
+  """Build a minimal qBittorrent torrent dict."""
+  return {'size': size, 'name': 'test.torrent', 'state': 'uploading'}
+
+
+def _login_response_ok() -> MagicMock:
+  resp = MagicMock()
+  resp.text = 'Ok.'
+  resp.raise_for_status = MagicMock()
+  return resp
+
+
+def _login_response_fail() -> MagicMock:
+  resp = MagicMock()
+  resp.text = 'Fails.'
+  resp.raise_for_status = MagicMock()
+  return resp
+
+
+def _torrents_response(torrents: list[dict]) -> MagicMock:
+  resp = MagicMock()
+  resp.json.return_value = torrents
+  resp.raise_for_status = MagicMock()
+  return resp
+
+
+def _patched_config() -> dict:
+  return {
+    'qbittorrent': {
+      'url': 'http://192.168.1.50:8080',
+      'username': 'admin',
+      'password': 'test',
+    }
+  }
+
+
+# ---------------------------------------------------------------------------
+# _fmt_size
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+  'size_bytes,expected',
+  [
+    (0, '0 GB'),
+    (500 * 1024**3, '500 GB'),
+    (1024**4, '1 TB'),
+    (int(1.2 * 1024**4), '1.2 TB'),
+    (int(14.0 * 1024**4), '14 TB'),
+    (int(2.5 * 1024**3), '2.5 GB'),
+    (int(0.1 * 1024**3), '0.1 GB'),
+  ],
+)
+def test_fmt_size(size_bytes: int, expected: str) -> None:
+  assert qbt._fmt_size(size_bytes) == expected
+
+
+# ---------------------------------------------------------------------------
+# _login
+# ---------------------------------------------------------------------------
+
+
+def test_login_success() -> None:
+  session_mock = MagicMock()
+  session_mock.post.return_value = _login_response_ok()
+  with patch('integrations.qbittorrent.requests.Session', return_value=session_mock):
+    session = qbt._login('http://localhost:8080', 'admin', 'test')
+  assert session is session_mock
+
+
+def test_login_bad_credentials() -> None:
+  session_mock = MagicMock()
+  session_mock.post.return_value = _login_response_fail()
+  with patch('integrations.qbittorrent.requests.Session', return_value=session_mock):
+    with pytest.raises(IntegrationDataUnavailableError, match='login failed'):
+      qbt._login('http://localhost:8080', 'admin', 'wrong')
+
+
+# ---------------------------------------------------------------------------
+# get_variables
+# ---------------------------------------------------------------------------
+
+
+def test_get_variables_normal(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  qbt._cache = None
+
+  session_mock = MagicMock()
+  session_mock.post.return_value = _login_response_ok()
+  session_mock.cookies = MagicMock()
+
+  torrents = [_torrent(size=500 * 1024**3), _torrent(size=700 * 1024**3)]
+  with (
+    patch('integrations.qbittorrent.requests.Session', return_value=session_mock),
+    patch('integrations.qbittorrent.fetch_with_retry', return_value=_torrents_response(torrents)),
+  ):
+    result = qbt.get_variables()
+
+  assert result['header'] == [['[B] TORRENTS']]
+  assert result['count'] == [['2 SEEDING']]
+  assert result['size'] == [['1.2 TB']]
+  qbt._cache = None
+
+
+def test_get_variables_no_seeders(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  qbt._cache = None
+
+  session_mock = MagicMock()
+  session_mock.post.return_value = _login_response_ok()
+  session_mock.cookies = MagicMock()
+
+  with (
+    patch('integrations.qbittorrent.requests.Session', return_value=session_mock),
+    patch('integrations.qbittorrent.fetch_with_retry', return_value=_torrents_response([])),
+  ):
+    with pytest.raises(IntegrationDataUnavailableError, match='no seeding'):
+      qbt.get_variables()
+
+  qbt._cache = None
+
+
+def test_get_variables_login_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  qbt._cache = None
+
+  session_mock = MagicMock()
+  session_mock.post.side_effect = _requests.ConnectionError('refused')
+
+  with patch('integrations.qbittorrent.requests.Session', return_value=session_mock):
+    with pytest.raises(IntegrationDataUnavailableError, match='login failed'):
+      qbt.get_variables()
+
+  qbt._cache = None
+
+
+# ---------------------------------------------------------------------------
+# Cache behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_cache_hit_avoids_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+
+  cached_value: dict = {
+    'header': [['[B] TORRENTS']],
+    'count': [['5 SEEDING']],
+    'size': [['2 TB']],
+  }
+  qbt._cache = CacheEntry(cached_value)
+
+  with patch('integrations.qbittorrent.requests.Session') as mock_session:
+    result = qbt.get_variables()
+    mock_session.assert_not_called()
+
+  assert result == cached_value
+  qbt._cache = None
+
+
+def test_stale_cache_served_on_login_error(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+
+  stale_value: dict = {
+    'header': [['[B] TORRENTS']],
+    'count': [['3 SEEDING']],
+    'size': [['1 TB']],
+  }
+  qbt._cache = CacheEntry(stale_value)
+  qbt._cache.cached_at = time.monotonic() - qbt._CACHE_TTL - 1
+
+  session_mock = MagicMock()
+  session_mock.post.side_effect = _requests.ConnectionError('refused')
+
+  with patch('integrations.qbittorrent.requests.Session', return_value=session_mock):
+    result = qbt.get_variables()
+
+  assert result == stale_value
+  qbt._cache = None

--- a/tests/test_unraid.py
+++ b/tests/test_unraid.py
@@ -1,0 +1,226 @@
+"""Unit tests for integrations/unraid.py."""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests as _requests
+
+import integrations.unraid as unraid
+from exceptions import IntegrationDataUnavailableError
+from integrations.http import CacheEntry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _graphql_response(data: dict | None = None, errors: list | None = None) -> MagicMock:
+  """Build a mock GraphQL response."""
+  body: dict = {}
+  if data is not None:
+    body['data'] = data
+  if errors is not None:
+    body['errors'] = errors
+  resp = MagicMock()
+  resp.json.return_value = body
+  resp.raise_for_status = MagicMock()
+  return resp
+
+
+def _normal_data(
+  *,
+  uptime: int = 300_000,
+  state: str = 'STARTED',
+  used: int = int(14.2 * 1024**4),
+  total: int = 20 * 1024**4,
+) -> dict:
+  """Build a normal Unraid GraphQL data payload."""
+  return {
+    'info': {'os': {'uptime': uptime}},
+    'array': {
+      'state': state,
+      'capacity': {'disks': {'used': used, 'total': total}},
+    },
+  }
+
+
+def _patched_config() -> dict:
+  return {
+    'unraid': {
+      'url': 'http://192.168.1.10',
+      'api_key': 'test-key',
+    }
+  }
+
+
+# ---------------------------------------------------------------------------
+# _fmt_size
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+  'size_bytes,expected',
+  [
+    (0, '0 GB'),
+    (500 * 1024**3, '500 GB'),
+    (1024**4, '1 TB'),
+    (int(1.2 * 1024**4), '1.2 TB'),
+    (int(14.0 * 1024**4), '14 TB'),
+    (20 * 1024**4, '20 TB'),
+  ],
+)
+def test_fmt_size(size_bytes: int, expected: str) -> None:
+  assert unraid._fmt_size(size_bytes) == expected
+
+
+# ---------------------------------------------------------------------------
+# _fmt_uptime
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+  'seconds,expected',
+  [
+    (0, 'UP 0H'),
+    (3600, 'UP 1H'),
+    (23 * 3600, 'UP 23H'),
+    (24 * 3600, 'UP 1D'),
+    (25 * 3600, 'UP 1D 1H'),
+    (3 * 24 * 3600 + 8 * 3600, 'UP 3D 8H'),
+    (30 * 24 * 3600, 'UP 1M'),
+    (30 * 24 * 3600 + 2 * 24 * 3600 + 8 * 3600, 'UP 1M 2D 8H'),
+    (90 * 24 * 3600, 'UP 3M'),
+    (11 * 30 * 24 * 3600 + 29 * 24 * 3600 + 23 * 3600, 'UP 11M 29D 23H'),
+    (30 * 24 * 3600 + 5 * 3600, 'UP 1M 5H'),
+  ],
+)
+def test_fmt_uptime(seconds: int, expected: str) -> None:
+  assert unraid._fmt_uptime(seconds) == expected
+
+
+# ---------------------------------------------------------------------------
+# get_variables
+# ---------------------------------------------------------------------------
+
+
+def test_get_variables_normal(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  unraid._cache = None
+
+  data = _normal_data(uptime=3 * 30 * 24 * 3600 + 2 * 24 * 3600 + 8 * 3600)
+  with patch('integrations.unraid.fetch_with_retry', return_value=_graphql_response(data)):
+    result = unraid.get_variables()
+
+  assert result['header'] == [['[O] UNRAID']]
+  assert result['capacity'] == [['14.2 TB / 20 TB']]
+  assert result['uptime'] == [['UP 3M 2D 8H']]
+  unraid._cache = None
+
+
+def test_get_variables_array_stopped(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  unraid._cache = None
+
+  data = _normal_data(state='STOPPED')
+  with patch('integrations.unraid.fetch_with_retry', return_value=_graphql_response(data)):
+    result = unraid.get_variables()
+
+  assert result['capacity'] == [['[R] STOPPED']]
+  unraid._cache = None
+
+
+def test_get_variables_array_degraded(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  unraid._cache = None
+
+  data = _normal_data(state='DEGRADED')
+  with patch('integrations.unraid.fetch_with_retry', return_value=_graphql_response(data)):
+    result = unraid.get_variables()
+
+  assert result['capacity'] == [['[R] DEGRADED']]
+  unraid._cache = None
+
+
+def test_get_variables_graphql_error(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  unraid._cache = None
+
+  resp = _graphql_response(errors=[{'message': 'not authorized'}])
+  with patch('integrations.unraid.fetch_with_retry', return_value=resp):
+    with pytest.raises(IntegrationDataUnavailableError, match='GraphQL error'):
+      unraid.get_variables()
+
+  unraid._cache = None
+
+
+def test_get_variables_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  unraid._cache = None
+
+  with patch(
+    'integrations.unraid.fetch_with_retry',
+    side_effect=_requests.ConnectionError('refused'),
+  ):
+    with pytest.raises(IntegrationDataUnavailableError, match='API request failed'):
+      unraid.get_variables()
+
+  unraid._cache = None
+
+
+# ---------------------------------------------------------------------------
+# Cache behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_cache_hit_avoids_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+
+  cached_value: dict = {
+    'header': [['[O] UNRAID']],
+    'capacity': [['14 / 20 TB']],
+    'uptime': [['UP 3D 8H']],
+  }
+  unraid._cache = CacheEntry(cached_value)
+
+  with patch('integrations.unraid.fetch_with_retry') as mock_fetch:
+    result = unraid.get_variables()
+    mock_fetch.assert_not_called()
+
+  assert result == cached_value
+  unraid._cache = None
+
+
+def test_stale_cache_served_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+
+  stale_value: dict = {
+    'header': [['[O] UNRAID']],
+    'capacity': [['10 / 20 TB']],
+    'uptime': [['UP 1M']],
+  }
+  unraid._cache = CacheEntry(stale_value)
+  unraid._cache.cached_at = time.monotonic() - unraid._CACHE_TTL - 1
+
+  with patch(
+    'integrations.unraid.fetch_with_retry',
+    side_effect=_requests.ConnectionError('refused'),
+  ):
+    result = unraid.get_variables()
+
+  assert result == stale_value
+  unraid._cache = None

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Add **qBittorrent** integration (`integrations/qbittorrent.py`) — seeding count + total seeded size via Web API v2
- Add **Unraid** integration (`integrations/unraid.py`) — array capacity + uptime via GraphQL API (7.2+)
- Both are daily vanity stats (priority 3, Hobbies) in dedicated `:45` slots (10:45 and 11:45)
- Both are local-network-only — sidecar docs explicitly warn against internet exposure
- No new PyPI dependencies (both use `requests` only)

Closes #227, closes #228.

## Display format

```
[B] TORRENTS        [O] UNRAID
4 SEEDING           14 / 20 TB
1.2 TB              UP 3M 2D 8H
```

## Test plan

- [x] `uv run ruff check .` — pass
- [x] `uv run ruff format --check .` — pass
- [x] `uv run pyright` — pass
- [x] `uv run bandit -c pyproject.toml -r .` — pass
- [x] `uv run pre-commit run pretty-format-json --all-files` — pass
- [x] `uv run pytest` — 1130 passed
- [x] Schedule lint validates new templates fit slot budgets
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
