### PR TITLE
fix(qbittorrent,unraid): support self-signed TLS certificates

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -190,6 +190,10 @@ url = "http://192.168.1.50:8080"
 username = "admin"
 password = "your-webui-password"
 
+# Skip TLS certificate verification (e.g. for self-signed certs).
+# Only relevant when using https:// URLs. Default: true.
+# verify_tls = false
+
 # [qbittorrent.schedules.status]
 # cron = "45 10 * * *"
 # hold = 300
@@ -208,6 +212,10 @@ password = "your-webui-password"
 # ⚠  Local network only — do not expose the Unraid API to the internet.
 url = "http://192.168.1.10"
 api_key = "your-unraid-api-key"
+
+# Skip TLS certificate verification (e.g. for self-signed certs).
+# Only relevant when using https:// URLs. Default: true.
+# verify_tls = false
 
 # [unraid.schedules.status]
 # cron = "45 11 * * *"

--- a/content/contrib/qbittorrent.md
+++ b/content/contrib/qbittorrent.md
@@ -39,6 +39,7 @@ password = "your-password"
 | `url` | Yes | Web UI base URL — must be a **local network** address |
 | `username` | Yes | Web UI username |
 | `password` | Yes | Web UI password |
+| `verify_tls` | No | Set to `false` to skip TLS cert verification (self-signed certs). Default: `true` |
 
 ### Security — local network only
 

--- a/content/contrib/unraid.md
+++ b/content/contrib/unraid.md
@@ -36,6 +36,7 @@ api_key = "your-unraid-api-key"
 |---|---|---|
 | `url` | Yes | Server base URL — must be a **local network** address |
 | `api_key` | Yes | API key from Settings → Management Access → API Keys |
+| `verify_tls` | No | Set to `false` to skip TLS cert verification (self-signed certs). Default: `true` |
 
 ### Security — local network only
 

--- a/integrations/qbittorrent.py
+++ b/integrations/qbittorrent.py
@@ -10,10 +10,16 @@
 #   url      — Web UI base URL (e.g. "http://192.168.1.50:8080")
 #   username — Web UI username
 #   password — Web UI password
+#
+# Optional config.toml keys:
+#   verify_tls — set to false to skip TLS certificate verification
+#                (e.g. for self-signed certs). Default: true.
 
 import logging
+import warnings
 
 import requests
+import urllib3
 
 from exceptions import IntegrationDataUnavailableError
 from integrations.http import CacheEntry, fetch_with_retry
@@ -45,9 +51,10 @@ def _fmt_size(size_bytes: int) -> str:
   return f'{rounded} GB'
 
 
-def _login(base_url: str, username: str, password: str) -> requests.Session:
+def _login(base_url: str, username: str, password: str, *, verify: bool = True) -> requests.Session:
   """Authenticate with the qBittorrent Web API and return a session."""
   session = requests.Session()
+  session.verify = verify
   r = session.post(
     f'{base_url}/api/v2/auth/login',
     data={'username': username, 'password': password},
@@ -77,9 +84,13 @@ def get_variables() -> dict[str, list[list[str]]]:
   base_url = _cfg.get('qbittorrent', 'url').rstrip('/')
   username = _cfg.get('qbittorrent', 'username')
   password = _cfg.get('qbittorrent', 'password')
+  verify = _cfg.get_optional_bool('qbittorrent', 'verify_tls', default=True)
 
   try:
-    session = _login(base_url, username, password)
+    with warnings.catch_warnings():
+      if not verify:
+        warnings.simplefilter('ignore', urllib3.exceptions.InsecureRequestWarning)
+      session = _login(base_url, username, password, verify=verify)
   except requests.RequestException as e:
     if _cache is not None:
       logger.warning('qBittorrent: login failed — serving stale cache — %s', e)
@@ -87,13 +98,17 @@ def get_variables() -> dict[str, list[list[str]]]:
     raise IntegrationDataUnavailableError(f'qBittorrent: login failed — {e}') from None
 
   try:
-    r = fetch_with_retry(
-      'GET',
-      f'{base_url}/api/v2/torrents/info',
-      params={'filter': 'seeding'},
-      cookies=session.cookies,
-      timeout=10,
-    )
+    with warnings.catch_warnings():
+      if not verify:
+        warnings.simplefilter('ignore', urllib3.exceptions.InsecureRequestWarning)
+      r = fetch_with_retry(
+        'GET',
+        f'{base_url}/api/v2/torrents/info',
+        params={'filter': 'seeding'},
+        cookies=session.cookies,
+        timeout=10,
+        verify=verify,
+      )
     r.raise_for_status()
   except requests.RequestException as e:
     if _cache is not None:

--- a/integrations/unraid.py
+++ b/integrations/unraid.py
@@ -9,10 +9,16 @@
 # Required config.toml keys ([unraid]):
 #   url     — server base URL (e.g. "http://192.168.1.10")
 #   api_key — API key from Settings → Management Access → API Keys
+#
+# Optional config.toml keys:
+#   verify_tls — set to false to skip TLS certificate verification
+#                (e.g. for self-signed certs). Default: true.
 
 import logging
+import warnings
 
 import requests
+import urllib3
 
 from exceptions import IntegrationDataUnavailableError
 from integrations.http import CacheEntry, fetch_with_retry
@@ -91,15 +97,20 @@ def get_variables() -> dict[str, list[list[str]]]:
 
   base_url = _cfg.get('unraid', 'url').rstrip('/')
   api_key = _cfg.get('unraid', 'api_key')
+  verify = _cfg.get_optional_bool('unraid', 'verify_tls', default=True)
 
   try:
-    r = fetch_with_retry(
-      'POST',
-      f'{base_url}/graphql',
-      headers={'x-api-key': api_key},
-      json={'query': _QUERY},
-      timeout=10,
-    )
+    with warnings.catch_warnings():
+      if not verify:
+        warnings.simplefilter('ignore', urllib3.exceptions.InsecureRequestWarning)
+      r = fetch_with_retry(
+        'POST',
+        f'{base_url}/graphql',
+        headers={'x-api-key': api_key},
+        json={'query': _QUERY},
+        timeout=10,
+        verify=verify,
+      )
     r.raise_for_status()
   except requests.RequestException as e:
     if _cache is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.7.0"
+version = "1.7.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/test_qbittorrent.py
+++ b/tests/test_qbittorrent.py
@@ -203,3 +203,54 @@ def test_stale_cache_served_on_login_error(monkeypatch: pytest.MonkeyPatch) -> N
 
   assert result == stale_value
   qbt._cache = None
+
+
+# ---------------------------------------------------------------------------
+# verify_tls
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tls_false_passes_verify(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  cfg = _patched_config()
+  cfg['qbittorrent']['verify_tls'] = False
+  monkeypatch.setattr(_cfg, '_config', cfg)
+  qbt._cache = None
+
+  session_mock = MagicMock()
+  session_mock.post.return_value = _login_response_ok()
+  session_mock.cookies = MagicMock()
+
+  torrents = [_torrent()]
+  with (
+    patch('integrations.qbittorrent.requests.Session', return_value=session_mock),
+    patch('integrations.qbittorrent.fetch_with_retry', return_value=_torrents_response(torrents)) as mock_fetch,
+  ):
+    qbt.get_variables()
+
+  assert session_mock.verify is False
+  assert mock_fetch.call_args.kwargs['verify'] is False
+  qbt._cache = None
+
+
+def test_verify_tls_default_true(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  qbt._cache = None
+
+  session_mock = MagicMock()
+  session_mock.post.return_value = _login_response_ok()
+  session_mock.cookies = MagicMock()
+
+  torrents = [_torrent()]
+  with (
+    patch('integrations.qbittorrent.requests.Session', return_value=session_mock),
+    patch('integrations.qbittorrent.fetch_with_retry', return_value=_torrents_response(torrents)) as mock_fetch,
+  ):
+    qbt.get_variables()
+
+  assert session_mock.verify is True
+  assert mock_fetch.call_args.kwargs['verify'] is True
+  qbt._cache = None

--- a/tests/test_unraid.py
+++ b/tests/test_unraid.py
@@ -224,3 +224,38 @@ def test_stale_cache_served_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
 
   assert result == stale_value
   unraid._cache = None
+
+
+# ---------------------------------------------------------------------------
+# verify_tls
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tls_false_passes_verify(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  cfg = _patched_config()
+  cfg['unraid']['verify_tls'] = False
+  monkeypatch.setattr(_cfg, '_config', cfg)
+  unraid._cache = None
+
+  data = _normal_data()
+  with patch('integrations.unraid.fetch_with_retry', return_value=_graphql_response(data)) as mock_fetch:
+    unraid.get_variables()
+
+  assert mock_fetch.call_args.kwargs['verify'] is False
+  unraid._cache = None
+
+
+def test_verify_tls_default_true(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  unraid._cache = None
+
+  data = _normal_data()
+  with patch('integrations.unraid.fetch_with_retry', return_value=_graphql_response(data)) as mock_fetch:
+    unraid.get_variables()
+
+  assert mock_fetch.call_args.kwargs['verify'] is True
+  unraid._cache = None

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.7.0"
+version = "1.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Add `verify_tls` config option to both `[qbittorrent]` and `[unraid]` sections
- Default `true`; set to `false` to skip TLS certificate verification (self-signed certs)
- Suppresses `InsecureRequestWarning` scoped to those requests only
- Updated sidecar docs and `config.example.toml`

Closes #454.

## Test plan

- [x] New tests: `verify_tls = false` passes `verify=False` to requests
- [x] New tests: default (absent) passes `verify=True`
- [x] Full suite: 1134 passed
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
