### PR TITLE
fix(quiet): read correct config path for persisted quiet state

### DIFF
--- a/config.py
+++ b/config.py
@@ -150,8 +150,16 @@ def get_optional_bool(section: str, key: str, default: bool = False) -> bool:
 
   Uses the raw TOML value rather than casting through str, so TOML booleans
   (e.g. `public = true`) are returned as Python bools correctly.
+
+  Supports dotted section names (e.g. ``'scheduler.quiet'``) by traversing
+  nested dicts — matching the TOML nesting produced by ``[scheduler.quiet]``.
   """
-  value = _config.get(section, {}).get(key)
+  node: dict[str, object] = _config
+  for part in section.split('.'):
+    node = node.get(part, {})  # type: ignore[assignment]
+    if not isinstance(node, dict):
+      return default
+  value = node.get(key)
   if value is None:
     return default
   return bool(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.7.1"
+version = "1.7.2"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/quiet.py
+++ b/quiet.py
@@ -34,7 +34,7 @@ def init() -> None:
   """
   global _active
   with _lock:
-    _active = _config_mod.get_optional_bool('scheduler', 'quiet', default=False)
+    _active = _config_mod.get_optional_bool('scheduler.quiet', 'active', default=False)
     if _active:
       logger.info('Quiet mode restored from config (board is quiet)')
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -102,6 +102,21 @@ def test_get_optional_bool_false(monkeypatch: pytest.MonkeyPatch) -> None:
   assert _mod.get_optional_bool('scheduler', 'public') is False
 
 
+def test_get_optional_bool_dotted_section(monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setattr(_mod, '_config', {'scheduler': {'quiet': {'active': True}}})
+  assert _mod.get_optional_bool('scheduler.quiet', 'active') is True
+
+
+def test_get_optional_bool_dotted_section_false(monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setattr(_mod, '_config', {'scheduler': {'quiet': {'active': False}}})
+  assert _mod.get_optional_bool('scheduler.quiet', 'active') is False
+
+
+def test_get_optional_bool_dotted_section_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setattr(_mod, '_config', {'scheduler': {}})
+  assert _mod.get_optional_bool('scheduler.quiet', 'active') is False
+
+
 # --- get_model ---
 
 

--- a/tests/test_quiet.py
+++ b/tests/test_quiet.py
@@ -19,15 +19,29 @@ def _reset_state() -> None:
 
 
 def test_init_defaults_to_inactive(tmp_path: Path) -> None:
-  with patch('quiet._config_mod.get_optional_bool', return_value=False):
+  with patch('quiet._config_mod.get_optional_bool', return_value=False) as mock:
     _mod.init()
+  mock.assert_called_once_with('scheduler.quiet', 'active', default=False)
   assert not _mod.is_active()
 
 
 def test_init_restores_active_state(tmp_path: Path) -> None:
-  with patch('quiet._config_mod.get_optional_bool', return_value=True):
+  with patch('quiet._config_mod.get_optional_bool', return_value=True) as mock:
     _mod.init()
+  mock.assert_called_once_with('scheduler.quiet', 'active', default=False)
   assert _mod.is_active()
+
+
+def test_init_active_false_stays_inactive() -> None:
+  """Regression: [scheduler.quiet] active = false must not activate quiet mode.
+
+  Previously init() read _config['scheduler']['quiet'] which returned the dict
+  {'active': False} — bool of a non-empty dict is True, so quiet mode was
+  always restored as active.  See #456.
+  """
+  with patch.dict('config._config', {'scheduler': {'quiet': {'active': False}}}):
+    _mod.init()
+  assert not _mod.is_active()
 
 
 # --- activate ---

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.7.1"
+version = "1.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- **Fix:** `quiet.init()` read `_config['scheduler']['quiet']` (a dict `{'active': False}`) instead of the nested `active` key. `bool({...})` is `True` for any non-empty dict, so quiet mode activated on every container restart whenever the `[scheduler.quiet]` section existed — even with `active = false`.
- **Root cause:** `get_optional_bool()` only supported flat section names; `quiet.init()` used `('scheduler', 'quiet')` which returned the subtable dict, not the `active` bool.
- **Fix:** Added dotted section name support to `get_optional_bool()`, changed `quiet.init()` to read `('scheduler.quiet', 'active')`.
- **Tests:** Regression test in `test_quiet.py`, dotted-section unit tests in `test_config.py`.

Closes #456

## Test plan

- [x] `uv run pytest` — 1138 passed
- [x] Full check suite (ruff, pyright, bandit) — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
