### PR TITLE
feat(morning,docs): skip good_morning on Sep 21, sync content README tables (#458)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -442,7 +442,10 @@ step may be skipped — use judgement.
     Advisory integration job may fail (missing secrets or API issue) — note but not a blocker.
 11. Keep `README.md` and `AGENTS.md` up to date as part of the same PR —
     new env vars, CLI flags, content format fields, project structure changes,
-    and workflow changes should all be reflected before merge
+    and workflow changes should all be reflected before merge. When adding or
+    renaming a template in `content/contrib/`, update both the template mapping
+    table and the schedule map in `content/README.md` (enforced by CI via
+    `test_schedule_lint.py`)
 12. For any TODOs identified during work, create a GitHub issue assigned to
     JasonPuglisi with an appropriate milestone; reference the issue number in
     commit messages and PRs

--- a/content/README.md
+++ b/content/README.md
@@ -31,7 +31,7 @@ When the key is absent, user files always load and no contrib files load.
 When the key is set, the filter applies to both `user/` and `contrib/`.
 
 This filter only affects **cron-scheduled** templates. Webhook-only
-integrations (`plex`, `message`, `notion`) route incoming webhook events
+integrations (`plex`, `message`, `notion`, `scheduler`) route incoming webhook events
 directly through the webhook listener — their `.json` files never need to be
 in `content_enabled` for webhooks to work.
 
@@ -156,7 +156,10 @@ appropriate priority range and informs scheduling decisions:
 | `plex.now_playing`, `plex.paused`, `plex.stopped` | Entertainment | 8 |
 | `trakt.watching` | Entertainment | 7 |
 | `trakt.calendar`, `trakt.next_up` | Entertainment | 4 |
-| `morning_night.good_morning`, `morning_night.good_night` | Ambient | 4 |
+| `parcel.deliveries` | Logistics | 5 |
+| `qbittorrent.status` | Hobbies | 3 |
+| `unraid.status` | Hobbies | 3 |
+| `morning_night.good_morning`, `morning_night.good_morning_september`, `morning_night.good_night` | Ambient | 4 |
 
 When adding a new template, identify its category first — that gives you the
 priority range to start from before tuning for contention.
@@ -237,7 +240,8 @@ new integrations in overnight windows unless there's a specific reason
 
 | Slot | Template | Category | Pri | Hold | Timeout | Notes |
 |---|---|---|---|---|---|---|
-| `7:00` daily | `morning_night.good_morning` | Ambient | 4 | 300 s | 3600 s | Queues behind weather; Sep 21 variant (pri 4) overrides |
+| `7:00` daily | `morning_night.good_morning` | Ambient | 4 | 300 s | 3600 s | Queues behind weather; morning integration skips Sep 21 — static September variant fires instead |
+| `7:00` Sep 21 | `morning_night.good_morning_september` | Ambient | 4 | 300 s | 3600 s | Static; sole morning message on Sep 21 |
 | `:00` every hour | `weather.conditions` | Logistics | 5 | 600 s | 1800 s | Fires first in every `:00` slot |
 | `:15` at 07/12/16 | `diving.conditions` | Hobbies | 5 | 600 s | 1800 s | Refresh 1800 s; dedicated `:15` slot avoids `:00` weather |
 | `8:00` daily | `birthdays.self` | Personal | 9 | 3600 s | 7200 s | No-op on non-birthday days; dominates the display for 1 h on birthday — intentional |
@@ -253,7 +257,7 @@ new integrations in overnight windows unless there's a specific reason
 | `21:00` daily | `morning_night.good_night` | Ambient | 4 | 300 s | 3600 s | Moon phase visual; queues behind weather |
 | `*/5` 07–09 Mon–Fri | `bart.departures` | Logistics | 8 | 290 s | 60 s | Refresh 60 s; dominates weekday mornings |
 | `*/3` 07–23 daily | `trakt.watching` | Entertainment | 7 | 180 s | 120 s | Refresh 30 s; no-op when not watching |
-| webhook only | `plex` (3 templates) | Entertainment | 8 | indef / 60 s | 30 s | Private; interrupts on state change |
+| webhook only | `plex` (3 templates) | Entertainment | 8 | 14400 / 60 s | 30 s | Private; indefinite semantics (14400 s = 4 h safety ceiling); interrupts on state change |
 | webhook only | `message.notification` | Social | 8 | 120 s | 600 s | Queues normally; shows at next hold break |
 | webhook only | `notion.notification` | Social | 7 | 120 s | 120 s | |
 

--- a/content/contrib/morning_night.md
+++ b/content/contrib/morning_night.md
@@ -22,9 +22,9 @@ where the commute window (07:00–09:00) fills the queue.
 **Cron:** `0 7 21 9 *` — fires at 07:00 on September 21st only.
 **Hold:** 300 s | **Timeout:** 3600 s | **Priority:** 4 (Ambient)
 
-Same slot as `good_morning`; at the same priority, the scheduler processes
-whichever was registered first. Use a `config.toml` override to give it
-priority 5 if you want it to appear before weather on that day.
+On September 21st, the morning integration raises `IntegrationDataUnavailableError`,
+so the integration-backed `good_morning` template is skipped. This static
+September variant is the sole morning message that day.
 
 ### `good_night`
 

--- a/integrations/morning.py
+++ b/integrations/morning.py
@@ -13,8 +13,11 @@
 # No config.toml keys required. When [weather] is present, the current
 # WMO weather code drives the visual; otherwise the sunrise grid is used.
 
+import datetime
 import logging
 import random
+
+from exceptions import IntegrationDataUnavailableError
 
 logger = logging.getLogger(__name__)
 
@@ -129,6 +132,9 @@ def _grid_key_from_weather() -> str:
 
 
 def get_variables() -> dict[str, list[list[str]]]:
+  today = datetime.date.today()
+  if today.month == 9 and today.day == 21:
+    raise IntegrationDataUnavailableError('Sep 21 uses static template')
   key = _grid_key_from_weather()
   if key in _RANDOM_GRIDS:
     color, density, min_cells = _RANDOM_GRIDS[key]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.7.2"
+version = "1.8.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/test_morning.py
+++ b/tests/test_morning.py
@@ -1,3 +1,4 @@
+import datetime
 from unittest.mock import patch
 
 import pytest
@@ -147,3 +148,20 @@ def test_get_variables_rows_are_seven_wide() -> None:
     row = result[key][0][0]
     width = _count_visual_width(row)
     assert width == 7, f'{key}: expected 7-wide row, got {row!r}'
+
+
+# --- Sep 21 skip ---
+
+
+def test_get_variables_raises_on_september_21() -> None:
+  with patch('integrations.morning.datetime') as mock_dt:
+    mock_dt.date.today.return_value = datetime.date(2026, 9, 21)
+    with pytest.raises(IntegrationDataUnavailableError, match='Sep 21'):
+      get_variables()
+
+
+def test_get_variables_normal_on_september_20() -> None:
+  with patch('integrations.morning.datetime') as mock_dt:
+    mock_dt.date.today.return_value = datetime.date(2026, 9, 20)
+    result = get_variables()
+    assert set(result.keys()) == {'morning_r1', 'morning_r2', 'morning_r3'}

--- a/tests/test_schedule_lint.py
+++ b/tests/test_schedule_lint.py
@@ -24,6 +24,7 @@ import pytest
 _CONTENT_ROOT = Path(__file__).parent.parent / 'content'
 _CONTRIB_DIR = _CONTENT_ROOT / 'contrib'
 _USER_DIR = _CONTENT_ROOT / 'user'
+_README = _CONTENT_ROOT / 'README.md'
 
 _SLOT_BUDGET_SECS = 1800
 _PERSONAL_PRIORITY_FLOOR = 9  # templates at this priority or above are excluded from slot budget
@@ -188,3 +189,64 @@ def test_slot_hold_budget() -> None:
         )
 
   assert not violations, 'Slot hold budget exceeded:\n' + '\n'.join(violations)
+
+
+# --- Docs sync ---
+
+
+def _collect_contrib_templates() -> set[str]:
+  """Return {file_stem}.{template_name} for every template in contrib/*.json."""
+  templates: set[str] = set()
+  for json_file in sorted(_CONTRIB_DIR.glob('*.json')):
+    with open(json_file) as f:
+      data = json.load(f)
+    stem = json_file.stem
+    for name in data.get('templates', {}):
+      templates.add(f'{stem}.{name}')
+  return templates
+
+
+def _extract_section(readme: str, start_marker: str) -> str:
+  """Return text from start_marker to the next markdown heading (## or ###)."""
+  idx = readme.index(start_marker)
+  rest = readme[idx + len(start_marker) :]
+  m = re.search(r'\n#{2,3}\s', rest)
+  return rest[: m.start()] if m else rest
+
+
+def _parse_template_refs(section: str, all_templates: set[str]) -> set[str]:
+  """Extract template references from a README table section.
+
+  Handles explicit refs like `foo.bar` and shorthands like `foo (N templates)`.
+  """
+  refs: set[str] = set()
+  for m in re.finditer(r'`(\w+\.\w+)`', section):
+    refs.add(m.group(1))
+  for m in re.finditer(r'`(\w+)`\s*\(\d+\s*templates?\)', section):
+    stem = m.group(1)
+    refs.update(t for t in all_templates if t.startswith(f'{stem}.'))
+  return refs
+
+
+def test_contrib_templates_in_readme_tables() -> None:
+  """Every contrib template must appear in both the template mapping table
+  and the schedule map in content/README.md."""
+  contrib = _collect_contrib_templates()
+  readme = _README.read_text()
+
+  mapping_section = _extract_section(readme, '**Existing template mapping:**')
+  schedule_section = _extract_section(readme, '### Schedule map')
+
+  mapping_refs = _parse_template_refs(mapping_section, contrib)
+  schedule_refs = _parse_template_refs(schedule_section, contrib)
+
+  missing_mapping = contrib - mapping_refs
+  missing_schedule = contrib - schedule_refs
+
+  errors: list[str] = []
+  if missing_mapping:
+    errors.append(f'Missing from template mapping table: {sorted(missing_mapping)}')
+  if missing_schedule:
+    errors.append(f'Missing from schedule map: {sorted(missing_schedule)}')
+
+  assert not errors, '\n'.join(errors)

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.7.2"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

Closes #458.

- **Sep 21 morning override**: `morning.get_variables()` raises `IntegrationDataUnavailableError` on Sep 21, so the static Earth, Wind & Fire template (`good_morning_september`) is the sole morning message that day
- **content/README.md sync**: add `parcel.deliveries`, `qbittorrent.status`, `unraid.status`, and `morning_night.good_morning_september` to both the template mapping table and schedule map; fix Plex hold column (`14400`, not `indef`); add `scheduler` to webhook-only integration list
- **CI lint**: new `test_contrib_templates_in_readme_tables` in `test_schedule_lint.py` verifies every contrib template appears in both README tables — prevents future drift
- **AGENTS.md step 11**: call out template mapping table and schedule map explicitly
- **Version**: 1.7.2 → 1.8.0

## Test plan

- [x] `test_get_variables_raises_on_september_21` — verifies Sep 21 skip
- [x] `test_get_variables_normal_on_september_20` — verifies adjacent date works normally
- [x] `test_contrib_templates_in_readme_tables` — verifies all contrib templates in both README tables
- [x] Full check suite passes (1141 tests, ruff, pyright, bandit, pip-audit)
