### PR TITLE
fix(unraid): parse uptime as ISO boot timestamp

### DIFF
--- a/content/contrib/unraid.md
+++ b/content/contrib/unraid.md
@@ -86,8 +86,9 @@ or `[R] DEGRADED` instead of usage numbers.
 }
 ```
 
-`uptime` is in seconds. `used` and `total` are in bytes. Months are
-approximated as 30 days.
+`uptime` is an ISO 8601 boot timestamp (e.g. `"2026-02-25T22:24:40.075Z"`).
+The integration computes seconds since boot from the timestamp delta.
+`used` and `total` are in bytes. Months are approximated as 30 days.
 
 ## Keeping data current
 

--- a/integrations/unraid.py
+++ b/integrations/unraid.py
@@ -16,6 +16,7 @@
 
 import logging
 import warnings
+from datetime import datetime, timezone
 
 import requests
 import urllib3
@@ -124,9 +125,18 @@ def get_variables() -> dict[str, list[list[str]]]:
     msg = errors[0].get('message', 'unknown') if errors else 'no data'
     raise IntegrationDataUnavailableError(f'Unraid: GraphQL error — {msg}')
 
-  # Uptime
-  uptime_secs = data.get('info', {}).get('os', {}).get('uptime')
-  uptime_line = _fmt_uptime(int(uptime_secs)) if uptime_secs is not None else ''
+  # Uptime — the API returns a boot timestamp (ISO 8601), not seconds.
+  uptime_raw = data.get('info', {}).get('os', {}).get('uptime')
+  if uptime_raw is not None:
+    try:
+      boot_time = datetime.fromisoformat(str(uptime_raw).replace('Z', '+00:00'))
+      uptime_secs = int((datetime.now(timezone.utc) - boot_time).total_seconds())
+      uptime_line = _fmt_uptime(max(0, uptime_secs))
+    except ValueError, TypeError:
+      logger.warning('Unraid: could not parse uptime %r', uptime_raw)
+      uptime_line = ''
+  else:
+    uptime_line = ''
 
   # Array
   array_state = data.get('array', {}).get('state', '').upper()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.8.0"
+version = "1.8.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/test_unraid.py
+++ b/tests/test_unraid.py
@@ -1,6 +1,7 @@
 """Unit tests for integrations/unraid.py."""
 
 import time
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -28,16 +29,22 @@ def _graphql_response(data: dict | None = None, errors: list | None = None) -> M
   return resp
 
 
+def _boot_timestamp(seconds_ago: int) -> str:
+  """Return an ISO 8601 UTC timestamp for N seconds ago (matches Unraid API)."""
+  boot = datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+  return boot.strftime('%Y-%m-%dT%H:%M:%S.000Z')
+
+
 def _normal_data(
   *,
-  uptime: int = 300_000,
+  uptime_secs: int = 300_000,
   state: str = 'STARTED',
   used: int = int(14.2 * 1024**4),
   total: int = 20 * 1024**4,
 ) -> dict:
   """Build a normal Unraid GraphQL data payload."""
   return {
-    'info': {'os': {'uptime': uptime}},
+    'info': {'os': {'uptime': _boot_timestamp(uptime_secs)}},
     'array': {
       'state': state,
       'capacity': {'disks': {'used': used, 'total': total}},
@@ -110,13 +117,15 @@ def test_get_variables_normal(monkeypatch: pytest.MonkeyPatch) -> None:
   monkeypatch.setattr(_cfg, '_config', _patched_config())
   unraid._cache = None
 
-  data = _normal_data(uptime=3 * 30 * 24 * 3600 + 2 * 24 * 3600 + 8 * 3600)
+  data = _normal_data(uptime_secs=3 * 30 * 24 * 3600 + 2 * 24 * 3600 + 8 * 3600)
   with patch('integrations.unraid.fetch_with_retry', return_value=_graphql_response(data)):
     result = unraid.get_variables()
 
   assert result['header'] == [['[O] UNRAID']]
   assert result['capacity'] == [['14.2 TB / 20 TB']]
-  assert result['uptime'] == [['UP 3M 2D 8H']]
+  # Uptime computed from boot timestamp delta — allow ±1 hour of rounding.
+  uptime_str = result['uptime'][0][0]
+  assert uptime_str.startswith('UP 3M 2D')
   unraid._cache = None
 
 
@@ -258,4 +267,47 @@ def test_verify_tls_default_true(monkeypatch: pytest.MonkeyPatch) -> None:
     unraid.get_variables()
 
   assert mock_fetch.call_args.kwargs['verify'] is True
+  unraid._cache = None
+
+
+# ---------------------------------------------------------------------------
+# Uptime ISO timestamp parsing
+# ---------------------------------------------------------------------------
+
+
+def test_uptime_iso_timestamp(monkeypatch: pytest.MonkeyPatch) -> None:
+  """The API returns a boot timestamp, not seconds — verify parsing works."""
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  unraid._cache = None
+
+  data = _normal_data(uptime_secs=3600)
+  with patch('integrations.unraid.fetch_with_retry', return_value=_graphql_response(data)):
+    result = unraid.get_variables()
+
+  uptime_str = result['uptime'][0][0]
+  assert uptime_str.startswith('UP ')
+  assert 'H' in uptime_str
+  unraid._cache = None
+
+
+def test_uptime_unparseable_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Unparseable uptime value should produce an empty line, not crash."""
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  unraid._cache = None
+
+  data = {
+    'info': {'os': {'uptime': 'not-a-timestamp'}},
+    'array': {
+      'state': 'STARTED',
+      'capacity': {'disks': {'used': 1024**4, 'total': 2 * 1024**4}},
+    },
+  }
+  with patch('integrations.unraid.fetch_with_retry', return_value=_graphql_response(data)):
+    result = unraid.get_variables()
+
+  assert result['uptime'] == [['']]
   unraid._cache = None

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.8.0"
+version = "1.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

The Unraid GraphQL API returns `info.os.uptime` as an ISO 8601 boot timestamp (e.g. `"2026-02-25T22:24:40.075Z"`), not integer seconds as assumed. The integration was calling `int()` on this string, causing `ValueError`.

- Parse the timestamp with `datetime.fromisoformat()` and compute delta from UTC now
- Gracefully handle unparseable values (empty uptime line, logged warning)
- Updated sidecar doc to document the actual API format

Closes #460.

## Test plan

- [x] New test: ISO timestamp parsed correctly
- [x] New test: unparseable uptime returns empty string
- [x] Existing tests updated to use timestamps instead of raw seconds
- [x] Full suite: 1143 passed
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
