### PR TITLE
fix(unraid): query kilobytes instead of disks for array capacity

### DIFF
--- a/content/contrib/unraid.md
+++ b/content/contrib/unraid.md
@@ -81,14 +81,18 @@ or `[R] DEGRADED` instead of usage numbers.
   info { os { uptime } }
   array {
     state
-    capacity { disks { used, total } }
+    capacity { kilobytes { used, total } }
   }
 }
 ```
 
 `uptime` is an ISO 8601 boot timestamp (e.g. `"2026-02-25T22:24:40.075Z"`).
-The integration computes seconds since boot from the timestamp delta.
-`used` and `total` are in bytes. Months are approximated as 30 days.
+The integration computes seconds since boot from the timestamp delta. Note:
+this timestamp reflects when the Unraid management API started, not the OS
+boot — expect ~1 hour less than the dashboard's uptime.
+`used` and `total` are in SI kilobytes. Sizes are displayed in decimal
+TB/GB units to match the Unraid dashboard. Months are approximated as
+30 days.
 
 ## Keeping data current
 
@@ -98,5 +102,5 @@ Authoritative source: https://docs.unraid.net/API/
 
 The Unraid API is under active development. Monitor the docs and the
 [unraid/api](https://github.com/unraid/api) repository for schema changes.
-The integration queries `info.os.uptime` and `array.capacity.disks` — verify
-these fields exist after major Unraid updates.
+The integration queries `info.os.uptime` and `array.capacity.kilobytes` —
+verify these fields exist after major Unraid updates.

--- a/integrations/unraid.py
+++ b/integrations/unraid.py
@@ -36,24 +36,24 @@ _QUERY = """\
   info { os { uptime } }
   array {
     state
-    capacity { disks { used, total } }
+    capacity { kilobytes { used, total } }
   }
 }"""
 
 
 def _fmt_size(size_bytes: int) -> str:
-  """Format a byte count as a human-readable TB/GB string.
+  """Format a byte count as a human-readable TB/GB string (decimal/SI units).
 
-  Uses TB for >= 1 TB, GB otherwise. Rounds to one decimal place and drops
-  a trailing '.0' (e.g. 1.2 TB, 14 TB, 850 GB).
+  Uses TB (10**12) for >= 1 TB, GB (10**9) otherwise. Rounds to one decimal
+  place and drops a trailing '.0' (e.g. 1.2 TB, 14 TB, 850 GB).
   """
-  tb = size_bytes / (1024**4)
+  tb = size_bytes / 10**12
   if tb >= 1.0:
     rounded = round(tb, 1)
     if rounded == int(rounded):
       return f'{int(rounded)} TB'
     return f'{rounded} TB'
-  gb = size_bytes / (1024**3)
+  gb = size_bytes / 10**9
   rounded = round(gb, 1)
   if rounded == int(rounded):
     return f'{int(rounded)} GB'
@@ -140,14 +140,14 @@ def get_variables() -> dict[str, list[list[str]]]:
 
   # Array
   array_state = data.get('array', {}).get('state', '').upper()
-  disks = data.get('array', {}).get('capacity', {}).get('disks', {})
-  used = disks.get('used')
-  total = disks.get('total')
+  kb = data.get('array', {}).get('capacity', {}).get('kilobytes', {})
+  used = kb.get('used')
+  total = kb.get('total')
 
   if array_state in ('STOPPED', 'DEGRADED'):
     capacity_line = f'[R] {array_state}'
   elif used is not None and total is not None:
-    capacity_line = f'{_fmt_size(int(used))} / {_fmt_size(int(total))}'
+    capacity_line = f'{_fmt_size(int(used) * 1000)} / {_fmt_size(int(total) * 1000)}'
   else:
     capacity_line = ''
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.8.1"
+version = "1.8.2"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/test_unraid.py
+++ b/tests/test_unraid.py
@@ -39,15 +39,15 @@ def _normal_data(
   *,
   uptime_secs: int = 300_000,
   state: str = 'STARTED',
-  used: int = int(14.2 * 1024**4),
-  total: int = 20 * 1024**4,
+  used_kb: str = '14200000000',
+  total_kb: str = '20000000000',
 ) -> dict:
   """Build a normal Unraid GraphQL data payload."""
   return {
     'info': {'os': {'uptime': _boot_timestamp(uptime_secs)}},
     'array': {
       'state': state,
-      'capacity': {'disks': {'used': used, 'total': total}},
+      'capacity': {'kilobytes': {'used': used_kb, 'total': total_kb}},
     },
   }
 
@@ -70,11 +70,11 @@ def _patched_config() -> dict:
   'size_bytes,expected',
   [
     (0, '0 GB'),
-    (500 * 1024**3, '500 GB'),
-    (1024**4, '1 TB'),
-    (int(1.2 * 1024**4), '1.2 TB'),
-    (int(14.0 * 1024**4), '14 TB'),
-    (20 * 1024**4, '20 TB'),
+    (500 * 10**9, '500 GB'),
+    (10**12, '1 TB'),
+    (int(1.2 * 10**12), '1.2 TB'),
+    (int(14.0 * 10**12), '14 TB'),
+    (20 * 10**12, '20 TB'),
   ],
 )
 def test_fmt_size(size_bytes: int, expected: str) -> None:
@@ -122,7 +122,7 @@ def test_get_variables_normal(monkeypatch: pytest.MonkeyPatch) -> None:
     result = unraid.get_variables()
 
   assert result['header'] == [['[O] UNRAID']]
-  assert result['capacity'] == [['14.2 TB / 20 TB']]
+  assert result['capacity'] == [['14.2 TB / 20 TB']]  # 14200000000 KB * 1000 / 10^12
   # Uptime computed from boot timestamp delta — allow ±1 hour of rounding.
   uptime_str = result['uptime'][0][0]
   assert uptime_str.startswith('UP 3M 2D')
@@ -303,7 +303,7 @@ def test_uptime_unparseable_returns_empty(monkeypatch: pytest.MonkeyPatch) -> No
     'info': {'os': {'uptime': 'not-a-timestamp'}},
     'array': {
       'state': 'STARTED',
-      'capacity': {'disks': {'used': 1024**4, 'total': 2 * 1024**4}},
+      'capacity': {'kilobytes': {'used': '1000000000', 'total': '2000000000'}},
     },
   }
   with patch('integrations.unraid.fetch_with_retry', return_value=_graphql_response(data)):

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.8.1"
+version = "1.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Switch GraphQL query from `array.capacity.disks` (disk slot count) to `array.capacity.kilobytes` (storage capacity) — fixes `0 GB / 0 GB` display
- Switch `_fmt_size` from binary (1024-based) to decimal/SI (1000-based) units to match the Unraid dashboard and fit the Note's 15-column width
- Document that `info.os.uptime` reflects management API start time, not OS boot (~1h behind dashboard uptime)

Closes #462

## Test plan

- [x] All 28 `test_unraid.py` tests pass (including updated `_fmt_size` decimal expectations and `kilobytes` field path)
- [x] Full suite passes (1143 tests)
- [x] Verified with live API: `13.7 TB / 20 TB` (15 chars, exact Note width)
- [ ] Deploy and confirm display renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
