### PR TITLE
fix(unraid): share unit suffix in capacity display

### DIFF
--- a/integrations/unraid.py
+++ b/integrations/unraid.py
@@ -41,23 +41,21 @@ _QUERY = """\
 }"""
 
 
-def _fmt_size(size_bytes: int) -> str:
-  """Format a byte count as a human-readable TB/GB string (decimal/SI units).
+def _fmt_size(size_bytes: int) -> tuple[str, str]:
+  """Format a byte count as (number, unit) using decimal/SI units.
 
   Uses TB (10**12) for >= 1 TB, GB (10**9) otherwise. Rounds to one decimal
-  place and drops a trailing '.0' (e.g. 1.2 TB, 14 TB, 850 GB).
+  place and drops a trailing '.0' (e.g. ('1.2', 'TB'), ('14', 'TB')).
   """
   tb = size_bytes / 10**12
   if tb >= 1.0:
     rounded = round(tb, 1)
-    if rounded == int(rounded):
-      return f'{int(rounded)} TB'
-    return f'{rounded} TB'
+    num = str(int(rounded)) if rounded == int(rounded) else str(rounded)
+    return (num, 'TB')
   gb = size_bytes / 10**9
   rounded = round(gb, 1)
-  if rounded == int(rounded):
-    return f'{int(rounded)} GB'
-  return f'{rounded} GB'
+  num = str(int(rounded)) if rounded == int(rounded) else str(rounded)
+  return (num, 'GB')
 
 
 def _fmt_uptime(seconds: int) -> str:
@@ -147,7 +145,12 @@ def get_variables() -> dict[str, list[list[str]]]:
   if array_state in ('STOPPED', 'DEGRADED'):
     capacity_line = f'[R] {array_state}'
   elif used is not None and total is not None:
-    capacity_line = f'{_fmt_size(int(used) * 1000)} / {_fmt_size(int(total) * 1000)}'
+    used_num, used_unit = _fmt_size(int(used) * 1000)
+    total_num, total_unit = _fmt_size(int(total) * 1000)
+    if used_unit == total_unit:
+      capacity_line = f'{used_num} / {total_num} {total_unit}'
+    else:
+      capacity_line = f'{used_num} {used_unit} / {total_num} {total_unit}'
   else:
     capacity_line = ''
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.8.2"
+version = "1.8.3"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/test_unraid.py
+++ b/tests/test_unraid.py
@@ -69,15 +69,15 @@ def _patched_config() -> dict:
 @pytest.mark.parametrize(
   'size_bytes,expected',
   [
-    (0, '0 GB'),
-    (500 * 10**9, '500 GB'),
-    (10**12, '1 TB'),
-    (int(1.2 * 10**12), '1.2 TB'),
-    (int(14.0 * 10**12), '14 TB'),
-    (20 * 10**12, '20 TB'),
+    (0, ('0', 'GB')),
+    (500 * 10**9, ('500', 'GB')),
+    (10**12, ('1', 'TB')),
+    (int(1.2 * 10**12), ('1.2', 'TB')),
+    (int(14.0 * 10**12), ('14', 'TB')),
+    (20 * 10**12, ('20', 'TB')),
   ],
 )
-def test_fmt_size(size_bytes: int, expected: str) -> None:
+def test_fmt_size(size_bytes: int, expected: tuple[str, str]) -> None:
   assert unraid._fmt_size(size_bytes) == expected
 
 
@@ -122,7 +122,7 @@ def test_get_variables_normal(monkeypatch: pytest.MonkeyPatch) -> None:
     result = unraid.get_variables()
 
   assert result['header'] == [['[O] UNRAID']]
-  assert result['capacity'] == [['14.2 TB / 20 TB']]  # 14200000000 KB * 1000 / 10^12
+  assert result['capacity'] == [['14.2 / 20 TB']]
   # Uptime computed from boot timestamp delta — allow ±1 hour of rounding.
   uptime_str = result['uptime'][0][0]
   assert uptime_str.startswith('UP 3M 2D')

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.8.2"
+version = "1.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Share the unit suffix when both capacity values use the same unit: `13.7 / 20 TB` instead of `13.7 TB / 20 TB`
- Falls back to showing both units if they differ (e.g. `500 GB / 1 TB`)
- `_fmt_size` now returns `(number, unit)` tuple for flexible formatting

Follow-up to #463. Closes #462

## Test plan

- [x] All 28 `test_unraid.py` tests pass
- [x] Full suite passes (1143 tests)
- [ ] Deploy and confirm display renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
