### PR TITLE
feat(ynab): net worth tracker integration (#231)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,7 @@ PARCEL_API_KEY=your-parcel-api-key
 DIVING_NDBC_STATION=46014
 DIVING_LAT=36.785
 DIVING_LON=-122.396
+#
+# Required for YNAB integration tests:
+YNAB_API_KEY=your-ynab-personal-access-token
+YNAB_BUDGET_ID=your-budget-id

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,5 @@ jobs:
           DIVING_LAT: ${{ vars.DIVING_LAT }}
           DIVING_LON: ${{ vars.DIVING_LON }}
           PARCEL_API_KEY: ${{ secrets.PARCEL_API_KEY }}
+          YNAB_API_KEY: ${{ secrets.YNAB_API_KEY }}
+          YNAB_BUDGET_ID: ${{ secrets.YNAB_BUDGET_ID }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ integrations/parcel.py      # Parcel package delivery tracking
 integrations/qbittorrent.py # qBittorrent seeding stats (Web API v2, local network)
 integrations/tmdb.py        # TMDb metadata lookups (used by plex, trakt)
 integrations/unraid.py      # Unraid server status (GraphQL API, local network)
+integrations/ynab.py        # YNAB net worth tracker (REST API, personal access token)
 content/
   README.md                 # Content author reference: JSON format, priority, schedule coordination
   DESIGN.md                 # Visual/design conventions: layout, color, tone, character set
@@ -105,6 +106,7 @@ content/
     scheduler.md            # Software-side quiet mode (webhook-only, no JSON)
     trakt.json / .md        # Trakt.tv calendar and now-playing
     unraid.json / .md       # Unraid server status
+    ynab.json / .md         # YNAB net worth tracker
   user/                     # Personal content (always loaded, git-ignored)
 docs/
   webhook-reverse-proxy.md  # Webhook TLS setup guide (Cloudflare Tunnel, reverse proxy)
@@ -353,13 +355,14 @@ come from GitHub secrets env vars directly.
   - Discogs: `DISCOGS_TOKEN`
   - Diving: `DIVING_NDBC_STATION`, `DIVING_LAT`, `DIVING_LON`
   - Parcel: `PARCEL_API_KEY`
+  - YNAB: `YNAB_API_KEY` (required), `YNAB_BUDGET_ID` (optional — auto-detected for single-budget accounts)
 - CI runs the `integration` job on `main` pushes only; it is advisory
   (`continue-on-error: true`) and not required by the branch ruleset
 - GitHub secrets/vars needed — store as **environment secrets** (or vars) on the
   `integration` environment (Settings → Environments), restricted to the `main`
   branch; this scopes them tighter than repo secrets and prevents any PR branch
   from accessing them even if a workflow runs there:
-  - Secrets: `VESTABOARD_VIRTUAL_API_KEY`, `CALENDAR_URL`, `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD`, `CALENDAR_CARDDAV_URL`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `TMDB_API_READ_ACCESS_TOKEN`, `DISCOGS_TOKEN`, `PARCEL_API_KEY`
+  - Secrets: `VESTABOARD_VIRTUAL_API_KEY`, `CALENDAR_URL`, `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD`, `CALENDAR_CARDDAV_URL`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `TMDB_API_READ_ACCESS_TOKEN`, `DISCOGS_TOKEN`, `PARCEL_API_KEY`, `YNAB_API_KEY`, `YNAB_BUDGET_ID`
   - Variables: `TRAKT_CLIENT_ID` (non-sensitive); `DIVING_NDBC_STATION`, `DIVING_LAT`, `DIVING_LON` (public NOAA station and coordinates)
 - If any integration test is skipped, the pytest session exits with code 5
   (NO_TESTS_COLLECTED), making the advisory job visibly fail rather than silently pass
@@ -420,19 +423,23 @@ step may be skipped — use judgement.
 
 1. `git checkout -b feat/description`
 2. Make changes; run the full check suite
-3. If release-worthy (see below), bump `version` in `pyproject.toml` **in the
+3. For new integrations or API-dependent changes, verify locally against the
+   real API before committing — unit test mocks cannot catch API contract
+   mismatches. Use `config.toml` with real credentials and confirm the
+   integration returns the expected output.
+4. If release-worthy (see below), bump `version` in `pyproject.toml` **in the
    same commit as the source change** — never a follow-up PR. Rule of thumb:
    if any `.py` or `.json` file is staged, check whether a bump is needed. Always stage
    `uv.lock` alongside `pyproject.toml` to avoid pre-commit stash conflicts.
-4. Commit with `Co-Authored-By: Claude <model> <noreply@anthropic.com>`
+5. Commit with `Co-Authored-By: Claude <model> <noreply@anthropic.com>`
    (use your current model name, e.g. `Opus 4.6` or `Sonnet 4.6`;
    commits are auto-signed via `commit.gpgsign = true` in global git config)
-5. Verify signing succeeded: `git log -1 --show-signature` must show a valid signature before pushing
-6. `git push -u origin feat/description`
-7. `gh pr create --label <label> --assignee JasonPuglisi`
-8. Enable auto-merge: `gh pr merge --squash --delete-branch --auto`
-9. Wait for merge: `gh pr checks <number> --watch`; once all pass and the PR merges, proceed
-10. After merge: `git checkout main && git pull && git branch -d feat/description`;
+6. Verify signing succeeded: `git log -1 --show-signature` must show a valid signature before pushing
+7. `git push -u origin feat/description`
+8. `gh pr create --label <label> --assignee JasonPuglisi`
+9. Enable auto-merge: `gh pr merge --squash --delete-branch --auto`
+10. Wait for merge: `gh pr checks <number> --watch`; once all pass and the PR merges, proceed
+11. After merge: `git checkout main && git pull && git branch -d feat/description`;
     get merge SHA via `git rev-parse HEAD`; run `gh run list --branch main --commit <sha>`
     and watch all in-progress runs to completion (`gh run watch <id>`). This step is
     non-negotiable — run it even when PR checks looked clean.
@@ -440,13 +447,13 @@ step may be skipped — use judgement.
     "Analyze (actions)", "Analyze (python)", and "CodeQL" checks (GitHub's built-in
     code scanning — runs automatically, not defined in `ci.yml`).
     Advisory integration job may fail (missing secrets or API issue) — note but not a blocker.
-11. Keep `README.md` and `AGENTS.md` up to date as part of the same PR —
+12. Keep `README.md` and `AGENTS.md` up to date as part of the same PR —
     new env vars, CLI flags, content format fields, project structure changes,
     and workflow changes should all be reflected before merge. When adding or
     renaming a template in `content/contrib/`, update both the template mapping
     table and the schedule map in `content/README.md` (enforced by CI via
     `test_schedule_lint.py`)
-12. For any TODOs identified during work, create a GitHub issue assigned to
+13. For any TODOs identified during work, create a GitHub issue assigned to
     JasonPuglisi with an appropriate milestone; reference the issue number in
     commit messages and PRs
 

--- a/README.md
+++ b/README.md
@@ -244,5 +244,7 @@ Required keys:
 | `DIVING_NDBC_STATION` | [ndbc.noaa.gov](https://www.ndbc.noaa.gov/) station ID (e.g. `46221`) |
 | `DIVING_LAT` | Station latitude |
 | `DIVING_LON` | Station longitude |
+| `YNAB_API_KEY` | [app.ynab.com/settings/developer](https://app.ynab.com/settings/developer) → Personal Access Token |
+| `YNAB_BUDGET_ID` | Budget UUID from the YNAB web app URL |
 
 `.env` is git-ignored — never commit it.

--- a/config.example.toml
+++ b/config.example.toml
@@ -206,6 +206,21 @@ password = "your-webui-password"
 # back-to-back episodes), the stopped card is suppressed entirely. Default: 3.
 # stop_debounce = 3
 
+[ynab]
+# Net worth tracker — sums all account balances from your YNAB budget.
+# Personal access token — generate at https://app.ynab.com/settings/developer
+api_key = "your-ynab-personal-access-token"
+
+# Budget UUID — optional if you have only one budget (auto-detected).
+# Find in the YNAB web app URL: app.ynab.com/<budget_id>/budget
+# budget_id = "your-budget-id"
+
+# [ynab.schedules.net_worth]
+# cron = "15 11 * * *"
+# hold = 300
+# timeout = 3600
+# priority = 3
+
 [unraid]
 # Unraid server status — array capacity and uptime. Requires Unraid 7.2+ and
 # an API key from Settings → Management Access → API Keys.

--- a/content/README.md
+++ b/content/README.md
@@ -159,6 +159,7 @@ appropriate priority range and informs scheduling decisions:
 | `parcel.deliveries` | Logistics | 5 |
 | `qbittorrent.status` | Hobbies | 3 |
 | `unraid.status` | Hobbies | 3 |
+| `ynab.net_worth` | Hobbies | 3 |
 | `morning_night.good_morning`, `morning_night.good_morning_september`, `morning_night.good_night` | Ambient | 4 |
 
 When adding a new template, identify its category first — that gives you the
@@ -252,6 +253,7 @@ new integrations in overnight windows unless there's a specific reason
 | `:15` at 09/15 | `parcel.deliveries` | Logistics | 5 | 600 s | 1800 s | Private; no-op when no active deliveries |
 | `10:00` daily | `diving.last_dive` | Hobbies | 3 | 300 s | 3600 s | Skipped when no dive date recorded |
 | `10:45` daily | `qbittorrent.status` | Hobbies | 3 | 300 s | 3600 s | Private; solo `:45` slot; skipped when nothing seeding |
+| `11:15` daily | `ynab.net_worth` | Hobbies | 3 | 300 s | 3600 s | Private; solo `:15` slot |
 | `11:45` daily | `unraid.status` | Hobbies | 3 | 300 s | 3600 s | Private; solo `:45` slot |
 | `:00` at 12/20 | `trakt.next_up` | Entertainment | 4 | 1200 s | 1800 s | Private; noon = plan for evening, 20:00 = settle in |
 | `21:00` daily | `morning_night.good_night` | Ambient | 4 | 300 s | 3600 s | Moon phase visual; queues behind weather |
@@ -407,3 +409,4 @@ guidelines above.
 | [`trakt.json`](contrib/trakt.md) | Trakt.tv upcoming calendar and now-playing |
 | [`unraid.json`](contrib/unraid.md) | Unraid server status — array capacity and uptime |
 | [`weather.json`](contrib/weather.md) | Current weather conditions via Open-Meteo |
+| [`ynab.json`](contrib/ynab.md) | Net worth tracker from YNAB (You Need A Budget) |

--- a/content/contrib/ynab.json
+++ b/content/contrib/ynab.json
@@ -1,0 +1,23 @@
+{
+  "templates": {
+    "net_worth": {
+      "schedule": {
+        "cron": "15 11 * * *",
+        "hold": 300,
+        "timeout": 3600
+      },
+      "priority": 3,
+      "private": true,
+      "integration": "ynab",
+      "templates": [
+        {
+          "format": [
+            "{header}",
+            "{amount}",
+            "{delta}"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/content/contrib/ynab.md
+++ b/content/contrib/ynab.md
@@ -1,0 +1,86 @@
+# ynab.json
+
+Net worth tracker from YNAB (You Need A Budget). Hobbies — fires once daily.
+
+## Schedule
+
+### `net_worth` — net worth and monthly change
+
+**Cron:** `15 11 * * *` — fires daily at 11:15.
+**Hold:** 300 s | **Timeout:** 3600 s | **Priority:** 3 (Hobbies)
+
+Private template. Fires in a solo `:15` slot with a 300 s hold budget — well
+within the 1800 s ceiling.
+
+To override schedule fields without editing this file:
+
+```toml
+[ynab.schedules.net_worth]
+cron = "15 8,20 * * *"  # check twice daily
+hold = 300
+timeout = 3600
+disabled = true           # skip entirely
+```
+
+## Configuration
+
+Add the following to your `config.toml`:
+
+```toml
+[ynab]
+api_key = "your-personal-access-token"
+# budget_id = "your-budget-id"  # optional if you have only one budget
+```
+
+| Key | Required | Description |
+|---|---|---|
+| `api_key` | Yes | Personal access token from YNAB Settings → Developer Settings |
+| `budget_id` | No | Budget UUID — auto-detected when you have one budget. Required when you have multiple. Find via the YNAB web app URL (`app.ynab.com/<budget_id>/budget`) |
+
+## Display format
+
+```
+[G] NET WORTH
+$124,832
++2.6% / MAR
+```
+
+- Header color is data-driven: `[G]` green when month-over-month delta is
+  non-negative, `[R]` red when negative (or when net worth itself is negative)
+- Net worth with commas for amounts under $10K; K/M/B suffix above that
+  ($50.5K, $1.2M) — one decimal, `.0` dropped
+- Percent change with `+`/`-` prefix, three-letter month abbreviation
+- All amounts rounded to whole dollars (no cents)
+
+## Net worth calculation
+
+Net worth = sum of `balance` across all non-closed, non-deleted accounts
+(on-budget and tracking). YNAB stores liabilities as negative balances, so a
+straight sum gives the correct number.
+
+Monthly delta = sum of all non-deleted transaction `amount` values since the
+1st of the current month. Internal transfers cancel out (matching +/- entries).
+
+## API details
+
+**Auth:** `Authorization: Bearer <token>` with a personal access token.
+
+**Rate limit:** 200 requests per hour (rolling window). A daily cron with
+30-minute cache uses at most 2 requests per invocation — well within budget.
+
+**Endpoints:**
+- `GET /v1/budgets/{budget_id}/accounts` — all account balances (milliunits)
+- `GET /v1/budgets/{budget_id}/transactions?since_date=YYYY-MM-01` — current
+  month transactions for delta calculation
+
+Amounts are in milliunits (1,000 milliunits = $1).
+
+## Keeping data current
+
+### API changes
+
+Authoritative source: https://api.ynab.com
+
+YNAB recently rebranded "budgets" to "plans" in the app UI. The API v1 paths
+(`/budgets/`) remain supported. Monitor YNAB developer announcements for any
+endpoint deprecation.

--- a/integrations/ynab.py
+++ b/integrations/ynab.py
@@ -1,0 +1,228 @@
+# integrations/ynab.py
+#
+# YNAB (You Need A Budget) net worth tracker.
+#
+# Fetches all account balances and current-month transactions from the
+# YNAB API v1 to compute net worth and month-over-month percent change.
+#
+# Required config.toml keys ([ynab]):
+#   api_key   — personal access token (free for all YNAB subscribers)
+#
+# Optional config.toml keys:
+#   budget_id — budget UUID. Omit if you have only one budget (auto-detected).
+
+import logging
+from datetime import date
+
+import requests
+
+from exceptions import IntegrationDataUnavailableError
+from integrations.http import CacheEntry, fetch_with_retry, user_agent
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = 'https://api.ynab.com/v1'
+
+# Cache TTL: 30 minutes. Account balances change infrequently.
+_CACHE_TTL = 30 * 60
+
+_cache: CacheEntry | None = None
+_resolved_budget_id: str | None = None
+
+
+def _headers(api_key: str) -> dict[str, str]:
+  return {
+    'Authorization': f'Bearer {api_key}',
+    'User-Agent': user_agent(),
+  }
+
+
+def _fmt_dollars(milliunits: int) -> str:
+  """Format milliunits as a dollar string.
+
+  Rules:
+  - Always round to whole dollars (no cents).
+  - Under $10,000: full number with commas ($9,999).
+  - $10,000–$999,999: K suffix with up to one decimal, drop .0 ($10K, $50.5K).
+  - $1,000,000+: M suffix with up to one decimal, drop .0 ($1M, $1.5M).
+  - $1,000,000,000+: B suffix with up to one decimal, drop .0 ($1B).
+  - Negative values: prefix with - ($-5,000, $-50.5K).
+  """
+  dollars = round(milliunits / 1000)
+  negative = dollars < 0
+  abs_dollars = abs(dollars)
+  prefix = '-' if negative else ''
+
+  if abs_dollars >= 1_000_000_000:
+    val = round(abs_dollars / 1_000_000_000, 1)
+    if val >= 1000:
+      # Overflow — shouldn't happen, but safety
+      s = f'${prefix}{val:.0f}B'
+    elif val == int(val):
+      s = f'${prefix}{int(val)}B'
+    else:
+      s = f'${prefix}{val}B'
+  elif abs_dollars >= 1_000_000:
+    val = round(abs_dollars / 1_000_000, 1)
+    if val >= 1000:
+      # Rounded up to 1B
+      s = f'${prefix}1B'
+    elif val == int(val):
+      s = f'${prefix}{int(val)}M'
+    else:
+      s = f'${prefix}{val}M'
+  elif abs_dollars >= 10_000:
+    val = round(abs_dollars / 1_000, 1)
+    if val >= 1000:
+      # Rounded up to 1M
+      s = f'${prefix}1M'
+    elif val == int(val):
+      s = f'${prefix}{int(val)}K'
+    else:
+      s = f'${prefix}{val}K'
+  else:
+    s = f'${prefix}{abs_dollars:,}'
+
+  return s
+
+
+def _fmt_pct(delta: int, start: int) -> str:
+  """Format month-over-month change as a percent string.
+
+  Returns e.g. '+2.6%', '-0.3%', '+0%'. One decimal, drop .0.
+  Falls back to '+$0' when start-of-month net worth is zero.
+  """
+  if start == 0:
+    sign = '+' if delta >= 0 else '-'
+    return f'{sign}$0'
+
+  pct = (delta / start) * 100
+  rounded = round(pct, 1)
+
+  if rounded == 0:
+    return '+0%'
+
+  sign = '+' if rounded > 0 else ''
+  if rounded == int(rounded):
+    return f'{sign}{int(rounded)}%'
+  return f'{sign}{rounded}%'
+
+
+def _resolve_budget_id(api_key: str) -> str:
+  """Return the budget ID from config, or auto-detect if only one budget exists."""
+  global _resolved_budget_id
+
+  import config as _cfg
+
+  explicit = _cfg.get_optional('ynab', 'budget_id')
+  if explicit:
+    return explicit
+
+  if _resolved_budget_id is not None:
+    return _resolved_budget_id
+
+  try:
+    resp = fetch_with_retry(
+      'GET',
+      f'{_BASE_URL}/budgets',
+      headers=_headers(api_key),
+      timeout=10,
+    )
+    resp.raise_for_status()
+  except requests.RequestException as e:
+    raise IntegrationDataUnavailableError(f'YNAB: failed to list budgets — {e}') from None
+
+  budgets = [b for b in resp.json().get('data', {}).get('budgets', []) if not b.get('deleted')]
+  if not budgets:
+    raise IntegrationDataUnavailableError('YNAB: no budgets found')
+  if len(budgets) > 1:
+    names = ', '.join(b.get('name', b['id']) for b in budgets)
+    raise IntegrationDataUnavailableError(f'YNAB: multiple budgets found ({names}) — set budget_id in config.toml')
+
+  bid: str = budgets[0]['id']
+  _resolved_budget_id = bid
+  logger.info('YNAB: auto-detected budget %s (%s)', budgets[0].get('name', ''), bid)
+  return bid
+
+
+def get_variables() -> dict[str, list[list[str]]]:
+  """Fetch YNAB data and return variables for template rendering.
+
+  Returns keys: header, amount, delta.
+  Raises IntegrationDataUnavailableError when the API is unreachable.
+  """
+  global _cache
+
+  import config as _cfg
+
+  if _cache is not None and _cache.is_valid(_CACHE_TTL):
+    logger.debug('YNAB: cache hit')
+    return _cache.value
+
+  api_key = _cfg.get('ynab', 'api_key')
+  budget_id = _resolve_budget_id(api_key)
+  hdrs = _headers(api_key)
+
+  # Fetch accounts
+  try:
+    accounts_resp = fetch_with_retry(
+      'GET',
+      f'{_BASE_URL}/budgets/{budget_id}/accounts',
+      headers=hdrs,
+      timeout=10,
+    )
+    accounts_resp.raise_for_status()
+  except requests.RequestException as e:
+    if _cache is not None:
+      logger.warning('YNAB: accounts request failed — serving stale cache — %s', e)
+      return _cache.value
+    raise IntegrationDataUnavailableError(f'YNAB: accounts request failed — {e}') from None
+
+  accounts_data = accounts_resp.json().get('data', {}).get('accounts', [])
+
+  # Sum all non-closed, non-deleted account balances (milliunits)
+  net_worth = sum(a['balance'] for a in accounts_data if not a.get('closed') and not a.get('deleted'))
+
+  # Fetch current month transactions for delta
+  first_of_month = date.today().replace(day=1).isoformat()
+  try:
+    txn_resp = fetch_with_retry(
+      'GET',
+      f'{_BASE_URL}/budgets/{budget_id}/transactions',
+      headers=hdrs,
+      params={'since_date': first_of_month},
+      timeout=10,
+    )
+    txn_resp.raise_for_status()
+  except requests.RequestException as e:
+    if _cache is not None:
+      logger.warning('YNAB: transactions request failed — serving stale cache — %s', e)
+      return _cache.value
+    raise IntegrationDataUnavailableError(f'YNAB: transactions request failed — {e}') from None
+
+  transactions = txn_resp.json().get('data', {}).get('transactions', [])
+
+  # Monthly delta = sum of all non-deleted transaction amounts
+  monthly_delta = sum(t['amount'] for t in transactions if not t.get('deleted'))
+
+  # Start-of-month net worth = current - delta
+  start_of_month = net_worth - monthly_delta
+
+  # Format
+  color = '[G]' if monthly_delta >= 0 else '[R]'
+  if net_worth < 0 and monthly_delta >= 0:
+    color = '[R]'
+
+  amount_line = _fmt_dollars(net_worth)
+  month_abbr = date.today().strftime('%b').upper()
+  pct_line = f'{_fmt_pct(monthly_delta, start_of_month)} / {month_abbr}'
+
+  result: dict[str, list[list[str]]] = {
+    'header': [[f'{color} NET WORTH']],
+    'amount': [[amount_line]],
+    'delta': [[pct_line]],
+  }
+
+  _cache = CacheEntry(result)
+  logger.debug('YNAB: net_worth=%s, delta=%s', amount_line, pct_line)
+  return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.8.3"
+version = "1.9.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -84,6 +84,7 @@ _KNOWN_INTEGRATIONS: frozenset[str] = frozenset(
     'trakt',
     'unraid',
     'weather',
+    'ynab',
   }
 )
 

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -20,6 +20,8 @@ _INTEGRATION_VARS: list[tuple[str, str]] = [
   ('DIVING_LAT', 'Dive conditions integration (Open-Meteo fallback)'),
   ('DIVING_LON', 'Dive conditions integration (Open-Meteo fallback)'),
   ('PARCEL_API_KEY', 'Parcel integration'),
+  ('YNAB_API_KEY', 'YNAB integration'),
+  ('YNAB_BUDGET_ID', 'YNAB integration (optional — auto-detected for single-budget accounts)'),
 ]
 
 _skipped = 0

--- a/tests/integrations/test_ynab_integration.py
+++ b/tests/integrations/test_ynab_integration.py
@@ -1,0 +1,53 @@
+"""Integration tests for integrations/ynab.py.
+
+Requires a YNAB personal access token.
+
+Run with: uv run pytest -m integration -k ynab -v
+
+Required env vars:
+  YNAB_API_KEY   — personal access token from YNAB Settings → Developer Settings
+
+Optional env vars:
+  YNAB_BUDGET_ID — budget UUID (auto-detected when you have one budget)
+"""
+
+import os
+
+import pytest
+
+import config as _cfg
+import integrations.ynab as ynab
+
+
+@pytest.mark.integration
+@pytest.mark.require_env('YNAB_API_KEY')
+def test_get_variables(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+  """get_variables() returns valid net worth data from the real YNAB API."""
+  cfg: dict = {'ynab': {'api_key': os.environ['YNAB_API_KEY']}}
+  budget_id = os.environ.get('YNAB_BUDGET_ID', '').strip()
+  if budget_id:
+    cfg['ynab']['budget_id'] = budget_id
+
+  monkeypatch.setattr(_cfg, '_config', cfg)
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+  result = ynab.get_variables()
+
+  assert set(result.keys()) == {'header', 'amount', 'delta'}
+  for key in ('header', 'amount', 'delta'):
+    assert len(result[key]) == 1, f'{key}: expected 1 option'
+    assert len(result[key][0]) == 1, f'{key}: expected 1 line'
+
+  header = result['header'][0][0]
+  assert 'NET WORTH' in header, f'unexpected header: {header!r}'
+  assert header.startswith('['), f'header missing color tag: {header!r}'
+
+  amount = result['amount'][0][0]
+  assert amount.startswith('$'), f'amount missing $ prefix: {amount!r}'
+
+  delta = result['delta'][0][0]
+  assert '/' in delta, f'delta missing month separator: {delta!r}'
+
+  ynab._cache = None
+  ynab._resolved_budget_id = None

--- a/tests/test_ynab.py
+++ b/tests/test_ynab.py
@@ -1,0 +1,471 @@
+"""Unit tests for integrations/ynab.py."""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests as _requests
+
+import integrations.ynab as ynab
+from exceptions import IntegrationDataUnavailableError
+from integrations.http import CacheEntry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _accounts_response(accounts: list[dict]) -> MagicMock:
+  resp = MagicMock()
+  resp.json.return_value = {'data': {'accounts': accounts}}
+  resp.raise_for_status = MagicMock()
+  return resp
+
+
+def _txn_response(transactions: list[dict]) -> MagicMock:
+  resp = MagicMock()
+  resp.json.return_value = {'data': {'transactions': transactions}}
+  resp.raise_for_status = MagicMock()
+  return resp
+
+
+def _account(balance: int, *, closed: bool = False, deleted: bool = False) -> dict:
+  return {'balance': balance, 'closed': closed, 'deleted': deleted}
+
+
+def _txn(amount: int, *, deleted: bool = False) -> dict:
+  return {'amount': amount, 'deleted': deleted}
+
+
+def _budgets_response(budgets: list[dict]) -> MagicMock:
+  resp = MagicMock()
+  resp.json.return_value = {'data': {'budgets': budgets}}
+  resp.raise_for_status = MagicMock()
+  return resp
+
+
+def _patched_config(*, include_budget_id: bool = True) -> dict:
+  cfg: dict = {'ynab': {'api_key': 'test-key'}}
+  if include_budget_id:
+    cfg['ynab']['budget_id'] = 'test-budget-id'
+  return cfg
+
+
+def _mock_fetch(accounts: list[dict], transactions: list[dict]):
+  """Return a side_effect function that returns accounts then transactions."""
+  responses = [_accounts_response(accounts), _txn_response(transactions)]
+  return MagicMock(side_effect=responses)
+
+
+# ---------------------------------------------------------------------------
+# _fmt_dollars
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+  'milliunits,expected',
+  [
+    (0, '$0'),
+    (1_000_000, '$1,000'),
+    (5_500_000, '$5,500'),
+    (9_999_000, '$9,999'),
+    (10_000_000, '$10K'),
+    (10_500_000, '$10.5K'),
+    (50_000_000, '$50K'),
+    (50_500_000, '$50.5K'),
+    (100_000_000, '$100K'),
+    (124_832_000, '$124.8K'),
+    (999_900_000, '$999.9K'),
+    (999_950_000, '$1M'),
+    (1_000_000_000, '$1M'),
+    (1_200_000_000, '$1.2M'),
+    (1_500_000_000, '$1.5M'),
+    (10_000_000_000, '$10M'),
+    (999_950_000_000, '$1B'),
+    (1_000_000_000_000, '$1B'),
+    (1_500_000_000_000, '$1.5B'),
+    # Negative
+    (-5_000_000, '$-5,000'),
+    (-50_500_000, '$-50.5K'),
+    (-1_200_000_000, '$-1.2M'),
+    # Rounding to whole dollars
+    (1_499, '$1'),
+    (1_500, '$2'),
+  ],
+)
+def test_fmt_dollars(milliunits: int, expected: str) -> None:
+  assert ynab._fmt_dollars(milliunits) == expected
+
+
+# ---------------------------------------------------------------------------
+# _fmt_pct
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+  'delta,start,expected',
+  [
+    (2600, 100_000, '+2.6%'),
+    (-300, 100_000, '-0.3%'),
+    (3000, 100_000, '+3%'),
+    (0, 100_000, '+0%'),
+    (100, 0, '+$0'),
+    (-100, 0, '-$0'),
+    (100_000, 100_000, '+100%'),
+    (-50_000, 100_000, '-50%'),
+  ],
+)
+def test_fmt_pct(delta: int, start: int, expected: str) -> None:
+  assert ynab._fmt_pct(delta, start) == expected
+
+
+# ---------------------------------------------------------------------------
+# get_variables
+# ---------------------------------------------------------------------------
+
+
+def test_get_variables_positive_delta(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+  accounts = [_account(100_000_000), _account(50_000_000)]  # $100K + $50K
+  transactions = [_txn(5_000_000)]  # +$5K this month
+
+  with patch('integrations.ynab.fetch_with_retry', _mock_fetch(accounts, transactions)):
+    result = ynab.get_variables()
+
+  assert result['header'] == [['[G] NET WORTH']]
+  assert result['amount'] == [['$150K']]
+  assert '/' in result['delta'][0][0]
+  assert result['delta'][0][0].startswith('+')
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+
+def test_get_variables_negative_delta(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+  accounts = [_account(100_000_000)]
+  transactions = [_txn(-10_000_000)]  # -$10K this month
+
+  with patch('integrations.ynab.fetch_with_retry', _mock_fetch(accounts, transactions)):
+    result = ynab.get_variables()
+
+  assert result['header'] == [['[R] NET WORTH']]
+  assert result['delta'][0][0].startswith('-')
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+
+def test_get_variables_zero_start_of_month(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+  # Net worth = $5K, all from this month's transactions
+  accounts = [_account(5_000_000)]
+  transactions = [_txn(5_000_000)]
+
+  with patch('integrations.ynab.fetch_with_retry', _mock_fetch(accounts, transactions)):
+    result = ynab.get_variables()
+
+  # start_of_month = 5000 - 5000 = 0 → fallback format
+  assert '+$0' in result['delta'][0][0]
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+
+def test_get_variables_negative_net_worth(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+  accounts = [_account(-20_000_000)]  # -$20K (liabilities > assets)
+  transactions = [_txn(1_000_000)]  # +$1K this month
+
+  with patch('integrations.ynab.fetch_with_retry', _mock_fetch(accounts, transactions)):
+    result = ynab.get_variables()
+
+  assert result['header'] == [['[R] NET WORTH']]
+  assert result['amount'] == [['$-20K']]
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+
+def test_get_variables_filters_closed_deleted(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+  accounts = [
+    _account(100_000_000),
+    _account(50_000_000, closed=True),
+    _account(25_000_000, deleted=True),
+  ]
+  transactions = [_txn(1_000_000), _txn(-500_000, deleted=True)]
+
+  with patch('integrations.ynab.fetch_with_retry', _mock_fetch(accounts, transactions)):
+    result = ynab.get_variables()
+
+  # Only the first account ($100K) should count
+  assert result['amount'] == [['$100K']]
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+
+def test_get_variables_large_numbers(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+  accounts = [_account(1_500_000_000)]  # $1.5M
+  transactions = [_txn(50_000_000)]  # +$50K
+
+  with patch('integrations.ynab.fetch_with_retry', _mock_fetch(accounts, transactions)):
+    result = ynab.get_variables()
+
+  assert result['amount'] == [['$1.5M']]
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_api_error_no_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+  with patch(
+    'integrations.ynab.fetch_with_retry',
+    side_effect=_requests.ConnectionError('refused'),
+  ):
+    with pytest.raises(IntegrationDataUnavailableError, match='accounts request failed'):
+      ynab.get_variables()
+
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+
+def test_api_error_serves_stale_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+
+  stale_value: dict = {
+    'header': [['[G] NET WORTH']],
+    'amount': [['$100K']],
+    'delta': [['+5% / MAR']],
+  }
+  ynab._cache = CacheEntry(stale_value)
+  ynab._cache.cached_at = time.monotonic() - ynab._CACHE_TTL - 1
+
+  with patch(
+    'integrations.ynab.fetch_with_retry',
+    side_effect=_requests.ConnectionError('refused'),
+  ):
+    result = ynab.get_variables()
+
+  assert result == stale_value
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+
+def test_txn_error_serves_stale_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Transaction fetch fails after accounts succeed — stale cache returned."""
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+
+  stale_value: dict = {
+    'header': [['[G] NET WORTH']],
+    'amount': [['$50K']],
+    'delta': [['+2% / JAN']],
+  }
+  ynab._cache = CacheEntry(stale_value)
+  ynab._cache.cached_at = time.monotonic() - ynab._CACHE_TTL - 1
+
+  # Accounts succeed, transactions fail
+  accounts_resp = _accounts_response([_account(50_000_000)])
+  call_count = 0
+
+  def side_effect(*args: object, **kwargs: object) -> MagicMock:  # noqa: ARG001
+    nonlocal call_count
+    if call_count == 0:
+      call_count += 1
+      return accounts_resp
+    raise _requests.ConnectionError('refused')
+
+  with patch('integrations.ynab.fetch_with_retry', side_effect=side_effect):
+    result = ynab.get_variables()
+
+  assert result == stale_value
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+
+# ---------------------------------------------------------------------------
+# Cache behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_cache_hit_avoids_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config())
+
+  cached_value: dict = {
+    'header': [['[G] NET WORTH']],
+    'amount': [['$100K']],
+    'delta': [['+3% / MAR']],
+  }
+  ynab._cache = CacheEntry(cached_value)
+
+  with patch('integrations.ynab.fetch_with_retry') as mock_fetch:
+    result = ynab.get_variables()
+    mock_fetch.assert_not_called()
+
+  assert result == cached_value
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+
+# ---------------------------------------------------------------------------
+# Budget auto-detection
+# ---------------------------------------------------------------------------
+
+
+def test_auto_detect_single_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config(include_budget_id=False))
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+  budgets_resp = _budgets_response([{'id': 'auto-id', 'name': 'My Budget'}])
+  accounts = [_account(50_000_000)]
+  transactions = [_txn(1_000_000)]
+
+  responses = [budgets_resp, _accounts_response(accounts), _txn_response(transactions)]
+
+  with patch('integrations.ynab.fetch_with_retry', MagicMock(side_effect=responses)):
+    result = ynab.get_variables()
+
+  assert result['amount'] == [['$50K']]
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+
+def test_auto_detect_multiple_budgets_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config(include_budget_id=False))
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+  budgets_resp = _budgets_response(
+    [
+      {'id': 'id-1', 'name': 'Budget A'},
+      {'id': 'id-2', 'name': 'Budget B'},
+    ]
+  )
+
+  with patch('integrations.ynab.fetch_with_retry', return_value=budgets_resp):
+    with pytest.raises(IntegrationDataUnavailableError, match='multiple budgets'):
+      ynab.get_variables()
+
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+
+def test_auto_detect_no_budgets_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config(include_budget_id=False))
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+  budgets_resp = _budgets_response([])
+
+  with patch('integrations.ynab.fetch_with_retry', return_value=budgets_resp):
+    with pytest.raises(IntegrationDataUnavailableError, match='no budgets found'):
+      ynab.get_variables()
+
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+
+def test_auto_detect_cached_on_second_call(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Second call should reuse the resolved budget ID, not hit /budgets again."""
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config(include_budget_id=False))
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+  budgets_resp = _budgets_response([{'id': 'auto-id', 'name': 'My Budget'}])
+  accounts = [_account(10_000_000)]
+  transactions = [_txn(0)]
+
+  # First call: budgets + accounts + transactions = 3 requests
+  responses_1 = [budgets_resp, _accounts_response(accounts), _txn_response(transactions)]
+  with patch('integrations.ynab.fetch_with_retry', MagicMock(side_effect=responses_1)):
+    ynab.get_variables()
+
+  # Expire the data cache but keep the resolved budget ID
+  ynab._cache = None
+
+  # Second call: only accounts + transactions = 2 requests (no /budgets)
+  responses_2 = [_accounts_response(accounts), _txn_response(transactions)]
+  mock = MagicMock(side_effect=responses_2)
+  with patch('integrations.ynab.fetch_with_retry', mock):
+    ynab.get_variables()
+
+  assert mock.call_count == 2
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+
+def test_auto_detect_skips_deleted_budgets(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', _patched_config(include_budget_id=False))
+  ynab._cache = None
+  ynab._resolved_budget_id = None
+
+  budgets_resp = _budgets_response(
+    [
+      {'id': 'deleted-id', 'name': 'Old Budget', 'deleted': True},
+      {'id': 'active-id', 'name': 'Active Budget'},
+    ]
+  )
+  accounts = [_account(10_000_000)]
+  transactions = [_txn(0)]
+
+  responses = [budgets_resp, _accounts_response(accounts), _txn_response(transactions)]
+  with patch('integrations.ynab.fetch_with_retry', MagicMock(side_effect=responses)):
+    result = ynab.get_variables()
+
+  assert result['amount'] == [['$10K']]
+  ynab._cache = None
+  ynab._resolved_budget_id = None

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.8.3"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- New `integrations/ynab.py` — fetches net worth (sum of all non-closed, non-deleted account balances) and month-over-month percent change from the YNAB API v1
- `budget_id` is optional — auto-detected at runtime when the account has a single budget; required (with a clear error) when multiple budgets exist
- Dollar formatting: commas under $10K, K suffix $10K–$999K, M suffix $1M+, B suffix $1B+ (one decimal, `.0` dropped, never cents)
- Header color is data-driven: green when delta >= 0, red when negative or net worth is negative
- Adds execution step 3 to the development workflow: verify locally against real API data before committing

## Display

```
[G] NET WORTH
$833.5K
+0.7% / MAR
```

## Test plan

- [x] 47 unit tests covering formatting, auto-detect, caching, error handling, and edge cases (1195 total pass)
- [x] Integration test (`test_ynab_integration.py`) — skips when env vars absent
- [x] Verified locally against real YNAB API with and without `budget_id` in config
- [x] Schedule lint passes (solo `:15` slot at 11:15, 300 s hold)
- [ ] CI checks pass

Closes #231
