### PR TITLE
fix(parcel): parse datetime format in date_expected (#466)

### DIFF
--- a/integrations/parcel.py
+++ b/integrations/parcel.py
@@ -66,7 +66,7 @@ def _detail_line(status_code: int, date_expected: str | None) -> str:
   if not date_expected:
     return ''
   try:
-    expected = datetime.strptime(date_expected, '%Y-%m-%d').date()
+    expected = datetime.strptime(date_expected[:10], '%Y-%m-%d').date()
   except ValueError:
     return ''
   today = date.today()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.9.0"
+version = "1.9.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/test_parcel.py
+++ b/tests/test_parcel.py
@@ -128,6 +128,23 @@ def test_detail_in_n_days(monkeypatch: pytest.MonkeyPatch) -> None:
   assert pc._detail_line(2, '2026-03-21') == 'IN 3 DAYS'
 
 
+def test_detail_datetime_format(monkeypatch: pytest.MonkeyPatch) -> None:
+  from datetime import date
+
+  monkeypatch.setattr(
+    pc,
+    'date',
+    type(
+      'MockDate',
+      (),
+      {
+        'today': staticmethod(lambda: date(2026, 3, 18)),
+      },
+    ),
+  )
+  assert pc._detail_line(2, '2026-03-19 00:00:00') == 'TOMORROW'
+
+
 def test_detail_no_date() -> None:
   assert pc._detail_line(2, None) == ''
 

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.9.0"
+version = "1.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- The Parcel API returns `date_expected` as `"2026-03-20 00:00:00"` but `_detail_line` parsed with `%Y-%m-%d` only — the `strptime` silently failed and returned an empty string, rendering row 3 blank
- Fix: truncate to first 10 characters (`[:10]`) before parsing, handling both `YYYY-MM-DD` and `YYYY-MM-DD HH:MM:SS` formats
- Added `test_detail_datetime_format` to cover the datetime variant

## Test plan

- [x] Verified locally against real Parcel API — detail line now shows `TOMORROW`
- [x] 1196 tests pass (31 parcel-specific)
- [ ] CI checks pass

Fixes #466
