### PR TITLE
fix(weather): swap condition and city rows

### DIFF
--- a/content/contrib/weather.json
+++ b/content/contrib/weather.json
@@ -12,8 +12,8 @@
       "templates": [
         {
           "format": [
-            "{city}",
             "{condition}",
+            "{city}",
             "{temp} H:{high} L:{low}"
           ]
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.9.1"
+version = "1.9.2"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.9.1"
+version = "1.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary
- Swap the condition and city rows in the weather template so the condition line (with its color square) serves as the header row, matching design system conventions
- City name moves to row 2 where it gets the full 15-column width

Closes #468

## Test plan
- [x] `uv run pytest tests/core/test_weather.py` — all passing
- [x] `uv run pytest tests/test_schedule_lint.py` — all passing
- [x] Pre-commit hooks pass
- [ ] Verify on physical Note display
