### PR TITLE
feat(uptimerobot): service outage alerts integration (#234)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,9 @@ DIVING_NDBC_STATION=46014
 DIVING_LAT=36.785
 DIVING_LON=-122.396
 #
+# Required for UptimeRobot integration tests:
+UPTIMEROBOT_API_KEY=your-uptimerobot-api-key
+#
 # Required for YNAB integration tests:
 YNAB_API_KEY=your-ynab-personal-access-token
 YNAB_BUDGET_ID=your-budget-id

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,5 +113,6 @@ jobs:
           DIVING_LAT: ${{ vars.DIVING_LAT }}
           DIVING_LON: ${{ vars.DIVING_LON }}
           PARCEL_API_KEY: ${{ secrets.PARCEL_API_KEY }}
+          UPTIMEROBOT_API_KEY: ${{ secrets.UPTIMEROBOT_API_KEY }}
           YNAB_API_KEY: ${{ secrets.YNAB_API_KEY }}
           YNAB_BUDGET_ID: ${{ secrets.YNAB_BUDGET_ID }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ integrations/parcel.py      # Parcel package delivery tracking
 integrations/qbittorrent.py # qBittorrent seeding stats (Web API v2, local network)
 integrations/tmdb.py        # TMDb metadata lookups (used by plex, trakt)
 integrations/unraid.py      # Unraid server status (GraphQL API, local network)
+integrations/uptimerobot.py # UptimeRobot service outage alerts (REST API, free tier)
 integrations/ynab.py        # YNAB net worth tracker (REST API, personal access token)
 content/
   README.md                 # Content author reference: JSON format, priority, schedule coordination
@@ -106,6 +107,7 @@ content/
     scheduler.md            # Software-side quiet mode (webhook-only, no JSON)
     trakt.json / .md        # Trakt.tv calendar and now-playing
     unraid.json / .md       # Unraid server status
+    uptimerobot.json / .md  # UptimeRobot service outage alerts (API polling)
     ynab.json / .md         # YNAB net worth tracker
   user/                     # Personal content (always loaded, git-ignored)
 docs/
@@ -355,6 +357,7 @@ come from GitHub secrets env vars directly.
   - Discogs: `DISCOGS_TOKEN`
   - Diving: `DIVING_NDBC_STATION`, `DIVING_LAT`, `DIVING_LON`
   - Parcel: `PARCEL_API_KEY`
+  - UptimeRobot: `UPTIMEROBOT_API_KEY`
   - YNAB: `YNAB_API_KEY` (required), `YNAB_BUDGET_ID` (optional — auto-detected for single-budget accounts)
 - CI runs the `integration` job on `main` pushes only; it is advisory
   (`continue-on-error: true`) and not required by the branch ruleset
@@ -362,7 +365,7 @@ come from GitHub secrets env vars directly.
   `integration` environment (Settings → Environments), restricted to the `main`
   branch; this scopes them tighter than repo secrets and prevents any PR branch
   from accessing them even if a workflow runs there:
-  - Secrets: `VESTABOARD_VIRTUAL_API_KEY`, `CALENDAR_URL`, `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD`, `CALENDAR_CARDDAV_URL`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `TMDB_API_READ_ACCESS_TOKEN`, `DISCOGS_TOKEN`, `PARCEL_API_KEY`, `YNAB_API_KEY`, `YNAB_BUDGET_ID`
+  - Secrets: `VESTABOARD_VIRTUAL_API_KEY`, `CALENDAR_URL`, `CALENDAR_CALDAV_URL`, `CALENDAR_USERNAME`, `CALENDAR_PASSWORD`, `CALENDAR_CARDDAV_URL`, `BART_API_KEY`, `TRAKT_CLIENT_SECRET`, `TRAKT_ACCESS_TOKEN`, `TMDB_API_READ_ACCESS_TOKEN`, `DISCOGS_TOKEN`, `PARCEL_API_KEY`, `UPTIMEROBOT_API_KEY`, `YNAB_API_KEY`, `YNAB_BUDGET_ID`
   - Variables: `TRAKT_CLIENT_ID` (non-sensitive); `DIVING_NDBC_STATION`, `DIVING_LAT`, `DIVING_LON` (public NOAA station and coordinates)
 - If any integration test is skipped, the pytest session exits with code 5
   (NO_TESTS_COLLECTED), making the advisory job visibly fail rather than silently pass

--- a/config.example.toml
+++ b/config.example.toml
@@ -221,6 +221,19 @@ api_key = "your-ynab-personal-access-token"
 # timeout = 3600
 # priority = 3
 
+[uptimerobot]
+# Service outage alerts — polls every 5 minutes, displays only during outages.
+# Free plan supports up to 50 monitors at 10 req/min.
+# Get your API key from https://dashboard.uptimerobot.com/integrations
+api_key = "your-uptimerobot-api-key"
+
+# [uptimerobot.schedules.status]
+# cron = "*/5 * * * *"
+# hold = 300
+# timeout = 120
+# priority = 8
+# refresh_interval = 60  # update elapsed downtime every 60s during hold (min 30)
+
 [unraid]
 # Unraid server status — array capacity and uptime. Requires Unraid 7.2+ and
 # an API key from Settings → Management Access → API Keys.

--- a/content/README.md
+++ b/content/README.md
@@ -153,6 +153,7 @@ appropriate priority range and informs scheduling decisions:
 | `diving.conditions` | Hobbies | 5 |
 | `discogs.morning_spin` | Hobbies | 5 |
 | `diving.last_dive` | Hobbies | 3 |
+| `uptimerobot.status` | Logistics | 8 |
 | `plex.now_playing`, `plex.paused`, `plex.stopped` | Entertainment | 8 |
 | `trakt.watching` | Entertainment | 7 |
 | `trakt.calendar`, `trakt.next_up` | Entertainment | 4 |
@@ -262,6 +263,7 @@ new integrations in overnight windows unless there's a specific reason
 | webhook only | `plex` (3 templates) | Entertainment | 8 | 14400 / 60 s | 30 s | Private; indefinite semantics (14400 s = 4 h safety ceiling); interrupts on state change |
 | webhook only | `message.notification` | Social | 8 | 120 s | 600 s | Queues normally; shows at next hold break |
 | webhook only | `notion.notification` | Social | 7 | 120 s | 120 s | |
+| `*/5` daily | `uptimerobot.status` | Logistics | 8 | 300 s | 120 s | Private; refresh 60 s; no-op when all monitors up |
 
 **Personal-tier note:** Priority-9 templates (e.g. `birthdays.self`, or
 personal pet feeding reminders in `content/user/`) are excluded from the slot
@@ -408,5 +410,6 @@ guidelines above.
 | (no JSON) [`scheduler`](contrib/scheduler.md) | Software-side quiet mode — webhook-only, no display content |
 | [`trakt.json`](contrib/trakt.md) | Trakt.tv upcoming calendar and now-playing |
 | [`unraid.json`](contrib/unraid.md) | Unraid server status — array capacity and uptime |
+| [`uptimerobot.json`](contrib/uptimerobot.md) | Service outage alerts from UptimeRobot (API polling) |
 | [`weather.json`](contrib/weather.md) | Current weather conditions via Open-Meteo |
 | [`ynab.json`](contrib/ynab.md) | Net worth tracker from YNAB (You Need A Budget) |

--- a/content/contrib/uptimerobot.json
+++ b/content/contrib/uptimerobot.json
@@ -1,0 +1,25 @@
+{
+  "templates": {
+    "status": {
+      "schedule": {
+        "cron": "*/5 * * * *",
+        "hold": 300,
+        "timeout": 120,
+        "refresh_interval": 60
+      },
+      "priority": 8,
+      "private": true,
+      "truncation": "ellipsis",
+      "integration": "uptimerobot",
+      "templates": [
+        {
+          "format": [
+            "[R] OUTAGE",
+            "{monitor}",
+            "{detail}"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/content/contrib/uptimerobot.md
+++ b/content/contrib/uptimerobot.md
@@ -1,0 +1,88 @@
+# uptimerobot.json
+
+Service outage alerts from UptimeRobot. Logistics — polls every 5 minutes,
+displays only when a monitor is down.
+
+## Schedule
+
+### `status` — outage alert
+
+**Cron:** `*/5 * * * *` — fires every 5 minutes.
+**Hold:** 300 s | **Timeout:** 120 s | **Priority:** 8 (Logistics)
+**Refresh:** 60 s — elapsed downtime updates every minute while on-screen.
+
+No-op when all monitors are up — the template is silently skipped via
+`IntegrationDataUnavailableError`. During an outage, the display refreshes
+every 60 s (duration ticks up), and the next cron fire re-enqueues with
+priority 8 so outages stay prominent.
+
+To override schedule fields without editing this file:
+
+```toml
+[uptimerobot.schedules.status]
+cron = "*/3 * * * *"
+hold = 180
+timeout = 60
+priority = 9
+refresh_interval = 30
+disabled = true   # skip this template entirely
+```
+
+## Configuration
+
+Add the following to your `config.toml`:
+
+```toml
+[uptimerobot]
+api_key = "your-uptimerobot-api-key"
+```
+
+| Key | Required | Description |
+|---|---|---|
+| `api_key` | Yes | UptimeRobot API key — Main API Key or Monitor-Specific API Key from [My Settings](https://dashboard.uptimerobot.com/integrations) |
+
+The free plan supports up to 50 monitors and 10 API requests per minute.
+With the default 5-minute cron and 60-second refresh, API usage stays well
+within the free tier limit.
+
+## Display format
+
+**Outage (one or more monitors down):**
+```
+[R] OUTAGE
+API.EXAMPLE.COM
+DOWN 14 MIN
+```
+
+- Row 1: `[R]` red square + `OUTAGE`
+- Row 2: Friendly name of the monitor that has been down longest (truncated
+  with ellipsis if needed)
+- Row 3: Elapsed downtime since first detection
+
+When all monitors recover, the template is silently skipped and normal
+content resumes on the next cycle.
+
+## API details
+
+**Endpoint:** `POST https://api.uptimerobot.com/v2/getMonitors`
+**Auth:** API key sent as a form parameter in the POST body.
+**Rate limit:** 10 req/min (free plan); 5000 req/min (Pro plan).
+
+**Monitor status codes used:**
+
+| Code | Meaning | Action |
+|---|---|---|
+| 2 | Up | No display (all-up → skip) |
+| 8 | Seems down | Treated as down |
+| 9 | Down | Treated as down |
+| 0, 1 | Paused / Not checked | Ignored |
+
+## Keeping data current
+
+### UptimeRobot API
+
+Authoritative source: [UptimeRobot API documentation](https://uptimerobot.com/api/)
+
+The integration uses the `/getMonitors` endpoint which has been stable across
+API versions. Monitor status codes (0, 1, 2, 8, 9) are part of the core API
+contract. Verify after major UptimeRobot platform updates.

--- a/integrations/uptimerobot.py
+++ b/integrations/uptimerobot.py
@@ -1,0 +1,139 @@
+# integrations/uptimerobot.py
+#
+# UptimeRobot integration — service outage alerts via API polling.
+#
+# Polls the UptimeRobot /getMonitors API on a cron schedule. When all monitors
+# are up, raises IntegrationDataUnavailableError so the template is silently
+# skipped. When any monitor is down (status 8 or 9), returns variables for an
+# outage display card with the monitor name and elapsed downtime.
+#
+# During an active outage, refresh_interval keeps the display current (duration
+# ticks up each refresh). When all monitors recover, the next poll raises
+# IntegrationDataUnavailableError and normal content resumes.
+#
+# Free-tier compatible — uses the /getMonitors REST endpoint (10 req/min limit).
+# No webhook or paid plan features required.
+
+import logging
+import time
+from typing import Any
+
+import requests
+
+import config as _cfg
+import integrations.vestaboard as _vb
+from exceptions import IntegrationDataUnavailableError
+from integrations.http import CacheEntry, fetch_with_retry
+
+logger = logging.getLogger(__name__)
+
+_API_URL = 'https://api.uptimerobot.com/v2/getMonitors'
+
+# Monitor status codes from UptimeRobot API.
+_STATUS_SEEMS_DOWN = 8
+_STATUS_DOWN = 9
+_DOWN_STATUSES = frozenset({_STATUS_SEEMS_DOWN, _STATUS_DOWN})
+
+# Cache API responses for 30 s to avoid redundant calls when the scheduler
+# invokes get_variables() in quick succession (e.g. cron fire + refresh).
+_CACHE_TTL = 30
+_cache: CacheEntry | None = None
+
+# Tracks when each monitor was first observed as down (monotonic clock).
+# Used to compute elapsed downtime for the display. Ephemeral — lost on
+# restart; duration resets to 0 on the next detection.
+_first_seen_down: dict[int, float] = {}
+
+
+def _fmt_duration(seconds: int) -> str:
+  """Format a duration in seconds for display (fits 15-col Note row)."""
+  if seconds < 0:
+    seconds = 0
+  if seconds < 60:
+    return f'{seconds} SEC'
+  if seconds < 3600:
+    return f'{seconds // 60} MIN'
+  hours = seconds // 3600
+  if hours < 24:
+    mins = (seconds % 3600) // 60
+    return f'{hours}H {mins}M' if mins else f'{hours} HR'
+  days = hours // 24
+  return f'{days} DAY' if days == 1 else f'{days} DAYS'
+
+
+def _fetch_monitors() -> list[dict[str, Any]]:
+  """Fetch all monitors from the UptimeRobot API.
+
+  Returns the list of monitor dicts from the response. Raises
+  IntegrationDataUnavailableError on API errors.
+  """
+  api_key = _cfg.get('uptimerobot', 'api_key')
+
+  try:
+    r = fetch_with_retry(
+      'POST',
+      _API_URL,
+      data={'api_key': api_key, 'format': 'json'},
+      timeout=10,
+    )
+    r.raise_for_status()
+  except requests.RequestException as e:
+    raise IntegrationDataUnavailableError(f'UptimeRobot: API request failed — {e}') from None
+
+  data = r.json()
+  if data.get('stat') != 'ok':
+    error_msg = data.get('error', {}).get('message', 'unknown error')
+    raise IntegrationDataUnavailableError(f'UptimeRobot: API returned error — {error_msg}')
+
+  return data.get('monitors', [])
+
+
+def get_variables() -> dict[str, list[list[str]]]:
+  """Fetch monitor statuses and return variables for the outage template.
+
+  Returns outage display variables when any monitor is down. Raises
+  IntegrationDataUnavailableError when all monitors are up (template is
+  silently skipped).
+  """
+  global _cache
+
+  if _cache is not None and _cache.is_valid(_CACHE_TTL):
+    logger.debug('uptimerobot: cache hit')
+    return _cache.value
+
+  monitors = _fetch_monitors()
+
+  # Find monitors in down state.
+  current_down: dict[int, str] = {}
+  for m in monitors:
+    status = m.get('status', 0)
+    if status in _DOWN_STATUSES:
+      current_down[int(m['id'])] = str(m.get('friendly_name', '')).strip()
+
+  if not current_down:
+    # All monitors up — clean up tracking state.
+    _first_seen_down.clear()
+    raise IntegrationDataUnavailableError('UptimeRobot: all monitors up')
+
+  # Track first-seen time for newly down monitors.
+  now = time.monotonic()
+  for mid in current_down:
+    if mid not in _first_seen_down:
+      _first_seen_down[mid] = now
+  # Clean up monitors that recovered.
+  for mid in list(_first_seen_down):
+    if mid not in current_down:
+      del _first_seen_down[mid]
+
+  # Show the monitor that has been down the longest.
+  longest_id = min(_first_seen_down, key=lambda k: _first_seen_down[k])
+  display_name = _vb.truncate_line(current_down[longest_id].upper(), _vb.model.cols, 'ellipsis')
+  duration = int(now - _first_seen_down[longest_id])
+
+  result: dict[str, list[list[str]]] = {
+    'monitor': [[display_name]],
+    'detail': [[f'DOWN {_fmt_duration(duration)}']],
+  }
+
+  _cache = CacheEntry(result)
+  return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.9.2"
+version = "1.10.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -83,6 +83,7 @@ _KNOWN_INTEGRATIONS: frozenset[str] = frozenset(
     'scheduler',
     'trakt',
     'unraid',
+    'uptimerobot',
     'weather',
     'ynab',
   }

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -20,6 +20,7 @@ _INTEGRATION_VARS: list[tuple[str, str]] = [
   ('DIVING_LAT', 'Dive conditions integration (Open-Meteo fallback)'),
   ('DIVING_LON', 'Dive conditions integration (Open-Meteo fallback)'),
   ('PARCEL_API_KEY', 'Parcel integration'),
+  ('UPTIMEROBOT_API_KEY', 'UptimeRobot integration'),
   ('YNAB_API_KEY', 'YNAB integration'),
   ('YNAB_BUDGET_ID', 'YNAB integration (optional — auto-detected for single-budget accounts)'),
 ]

--- a/tests/integrations/test_uptimerobot_integration.py
+++ b/tests/integrations/test_uptimerobot_integration.py
@@ -1,0 +1,43 @@
+import os
+
+import pytest
+
+import config as _cfg
+import integrations.uptimerobot as uptimerobot
+
+
+@pytest.mark.integration
+@pytest.mark.require_env('UPTIMEROBOT_API_KEY')
+def test_get_variables(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+  """get_variables() returns valid data or raises unavailable from the real API.
+
+  When all monitors are up (the normal case), IntegrationDataUnavailableError
+  is raised — this is expected and considered a passing result. When any
+  monitor is down, the returned variables are validated for shape and content.
+  """
+  from exceptions import IntegrationDataUnavailableError
+
+  monkeypatch.setattr(_cfg, '_config', {'uptimerobot': {'api_key': os.environ['UPTIMEROBOT_API_KEY']}})
+  uptimerobot._cache = None
+  uptimerobot._first_seen_down.clear()
+
+  try:
+    result = uptimerobot.get_variables()
+  except IntegrationDataUnavailableError:
+    # All monitors up — expected in normal operation.
+    return
+  finally:
+    uptimerobot._cache = None
+    uptimerobot._first_seen_down.clear()
+
+  # If we got here, at least one monitor is down.
+  assert set(result.keys()) == {'monitor', 'detail'}
+  for key in result:
+    assert len(result[key]) == 1, f'{key}: expected 1 option'
+    assert len(result[key][0]) == 1, f'{key}: expected 1 line'
+
+  monitor = result['monitor'][0][0]
+  assert monitor == monitor.upper(), f'monitor name not uppercased: {monitor!r}'
+
+  detail = result['detail'][0][0]
+  assert detail.startswith('DOWN '), f'unexpected detail format: {detail!r}'

--- a/tests/test_uptimerobot.py
+++ b/tests/test_uptimerobot.py
@@ -1,0 +1,240 @@
+import time
+from typing import Any, Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+import integrations.uptimerobot as uptimerobot
+from exceptions import IntegrationDataUnavailableError
+
+
+def _mock_response(data: dict[str, Any]) -> MagicMock:
+  resp = MagicMock()
+  resp.json.return_value = data
+  resp.raise_for_status = MagicMock()
+  return resp
+
+
+def _api_response(monitors: list[dict[str, Any]]) -> dict[str, Any]:
+  return {
+    'stat': 'ok',
+    'pagination': {'offset': 0, 'limit': 50, 'total': len(monitors)},
+    'monitors': monitors,
+  }
+
+
+def _monitor(
+  id: int = 1,
+  friendly_name: str = 'My API',
+  status: int = 2,
+) -> dict[str, Any]:
+  return {
+    'id': id,
+    'friendly_name': friendly_name,
+    'url': 'https://api.example.com',
+    'status': status,
+  }
+
+
+@pytest.fixture(autouse=True)
+def _mock_config(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+  import config as _cfg
+
+  monkeypatch.setattr(_cfg, '_config', {'uptimerobot': {'api_key': 'test-key'}})
+  yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> Generator[None, None, None]:
+  uptimerobot._cache = None
+  uptimerobot._first_seen_down.clear()
+  yield
+  uptimerobot._cache = None
+  uptimerobot._first_seen_down.clear()
+
+
+# ---------------------------------------------------------------------------
+# All monitors up — template skipped
+# ---------------------------------------------------------------------------
+
+
+def test_all_up_raises_unavailable() -> None:
+  resp = _mock_response(_api_response([_monitor(status=2)]))
+  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
+    with pytest.raises(IntegrationDataUnavailableError):
+      uptimerobot.get_variables()
+
+
+def test_all_up_clears_first_seen_state() -> None:
+  uptimerobot._first_seen_down[1] = time.monotonic() - 600
+  resp = _mock_response(_api_response([_monitor(status=2)]))
+  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
+    with pytest.raises(IntegrationDataUnavailableError):
+      uptimerobot.get_variables()
+  assert len(uptimerobot._first_seen_down) == 0
+
+
+def test_paused_monitor_treated_as_up() -> None:
+  resp = _mock_response(_api_response([_monitor(status=0)]))
+  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
+    with pytest.raises(IntegrationDataUnavailableError):
+      uptimerobot.get_variables()
+
+
+def test_empty_monitors_raises_unavailable() -> None:
+  resp = _mock_response(_api_response([]))
+  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
+    with pytest.raises(IntegrationDataUnavailableError):
+      uptimerobot.get_variables()
+
+
+# ---------------------------------------------------------------------------
+# Outage detection
+# ---------------------------------------------------------------------------
+
+
+def test_down_monitor_returns_variables() -> None:
+  resp = _mock_response(_api_response([_monitor(id=1, friendly_name='Prod API', status=9)]))
+  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
+    result = uptimerobot.get_variables()
+  assert result['monitor'] == [['PROD API']]
+  assert result['detail'][0][0].startswith('DOWN ')
+
+
+def test_seems_down_treated_as_down() -> None:
+  resp = _mock_response(_api_response([_monitor(id=1, friendly_name='Staging', status=8)]))
+  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
+    result = uptimerobot.get_variables()
+  assert result['monitor'] == [['STAGING']]
+
+
+def test_monitor_name_uppercased() -> None:
+  resp = _mock_response(_api_response([_monitor(friendly_name='my api', status=9)]))
+  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
+    result = uptimerobot.get_variables()
+  assert result['monitor'] == [['MY API']]
+
+
+def test_down_monitor_tracks_first_seen() -> None:
+  resp = _mock_response(_api_response([_monitor(id=42, status=9)]))
+  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
+    uptimerobot.get_variables()
+  assert 42 in uptimerobot._first_seen_down
+
+
+def test_duration_increases_on_subsequent_calls() -> None:
+  uptimerobot._first_seen_down[1] = time.monotonic() - 900  # 15 min ago
+  resp = _mock_response(_api_response([_monitor(id=1, status=9)]))
+  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
+    result = uptimerobot.get_variables()
+  assert result['detail'] == [['DOWN 15 MIN']]
+
+
+# ---------------------------------------------------------------------------
+# Multi-monitor state
+# ---------------------------------------------------------------------------
+
+
+def test_shows_longest_down_monitor() -> None:
+  now = time.monotonic()
+  uptimerobot._first_seen_down[1] = now - 600  # 10 min ago
+  uptimerobot._first_seen_down[2] = now - 60  # 1 min ago
+  resp = _mock_response(
+    _api_response(
+      [
+        _monitor(id=1, friendly_name='Old Down', status=9),
+        _monitor(id=2, friendly_name='New Down', status=9),
+      ]
+    )
+  )
+  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
+    result = uptimerobot.get_variables()
+  assert result['monitor'] == [['OLD DOWN']]
+  assert result['detail'] == [['DOWN 10 MIN']]
+
+
+def test_recovered_monitor_removed_from_tracking() -> None:
+  uptimerobot._first_seen_down[1] = time.monotonic() - 300
+  uptimerobot._first_seen_down[2] = time.monotonic() - 60
+  resp = _mock_response(
+    _api_response(
+      [
+        _monitor(id=1, friendly_name='Still Down', status=9),
+        _monitor(id=2, friendly_name='Recovered', status=2),
+      ]
+    )
+  )
+  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
+    uptimerobot.get_variables()
+  assert 1 in uptimerobot._first_seen_down
+  assert 2 not in uptimerobot._first_seen_down
+
+
+# ---------------------------------------------------------------------------
+# API errors
+# ---------------------------------------------------------------------------
+
+
+def test_api_error_raises_unavailable() -> None:
+  with patch(
+    'integrations.uptimerobot.fetch_with_retry',
+    side_effect=requests.ConnectionError('refused'),
+  ):
+    with pytest.raises(IntegrationDataUnavailableError):
+      uptimerobot.get_variables()
+
+
+def test_api_stat_fail_raises_unavailable() -> None:
+  resp = _mock_response({'stat': 'fail', 'error': {'message': 'wrong API key'}})
+  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
+    with pytest.raises(IntegrationDataUnavailableError, match='wrong API key'):
+      uptimerobot.get_variables()
+
+
+# ---------------------------------------------------------------------------
+# Cache
+# ---------------------------------------------------------------------------
+
+
+def test_cache_hit_avoids_fetch() -> None:
+  from integrations.http import CacheEntry
+
+  uptimerobot._cache = CacheEntry(
+    {
+      'monitor': [['CACHED']],
+      'detail': [['DOWN 5 MIN']],
+    }
+  )
+  with patch('integrations.uptimerobot.fetch_with_retry') as mock_fetch:
+    result = uptimerobot.get_variables()
+    mock_fetch.assert_not_called()
+  assert result['monitor'] == [['CACHED']]
+
+
+# ---------------------------------------------------------------------------
+# Duration formatting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+  'seconds,expected',
+  [
+    (0, '0 SEC'),
+    (1, '1 SEC'),
+    (59, '59 SEC'),
+    (60, '1 MIN'),
+    (840, '14 MIN'),
+    (3599, '59 MIN'),
+    (3600, '1 HR'),
+    (3660, '1H 1M'),
+    (7200, '2 HR'),
+    (7380, '2H 3M'),
+    (86400, '1 DAY'),
+    (172800, '2 DAYS'),
+    (90000, '1 DAY'),
+    (-5, '0 SEC'),
+  ],
+)
+def test_fmt_duration(seconds: int, expected: str) -> None:
+  assert uptimerobot._fmt_duration(seconds) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.9.2"
+version = "1.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Add UptimeRobot integration that polls `/getMonitors` every 5 minutes and displays an outage card when any monitor is down (status 8 or 9)
- When all monitors are up, the template is silently skipped — no "all services up" display
- Free-tier compatible: uses the REST API (10 req/min limit), no webhook or paid plan required
- Tracks elapsed downtime via module-level first-seen state; shows the longest-down monitor when multiple are affected

Closes #234

## Changes

| File | Change |
|---|---|
| `integrations/uptimerobot.py` | New integration: `get_variables()` polls API, `_fmt_duration()` for display |
| `content/contrib/uptimerobot.json` | Cron template: `*/5`, hold 300 s, refresh 60 s, priority 8 |
| `content/contrib/uptimerobot.md` | Sidecar doc with setup, display format, API details |
| `tests/test_uptimerobot.py` | 28 unit tests (outage detection, multi-monitor, cache, duration formatting, API errors) |
| `tests/integrations/test_uptimerobot_integration.py` | Integration test against real API |
| `scheduler.py` | Add `uptimerobot` to `_KNOWN_INTEGRATIONS` |
| `config.example.toml` | Add `[uptimerobot]` section with `api_key` |
| `content/README.md` | Add to schedule map and contrib integrations table |
| `AGENTS.md` | Add to project structure and env var lists |
| `.env.example`, `conftest.py`, `ci.yml` | Wire up `UPTIMEROBOT_API_KEY` env var |

## Test plan

- [x] 28 unit tests pass (outage, all-up, multi-monitor, cache, API errors, duration formatting)
- [x] Integration test passes against real UptimeRobot API (all monitors up → `IntegrationDataUnavailableError`)
- [x] Manual verification: API response field names and types match implementation (`id: int`, `friendly_name: str`, `status: int`)
- [x] Full test suite passes (1229 tests)
- [x] pyright, ruff, bandit, pip-audit, JSON format all clean
- [ ] Add `UPTIMEROBOT_API_KEY` to GitHub `integration` environment secrets
