### PR TITLE
fix(vestaboard): normalize smart quotes and Unicode punctuation (#471)

### DIFF
--- a/integrations/vestaboard.py
+++ b/integrations/vestaboard.py
@@ -177,6 +177,29 @@ _ESC_BRACE_OPEN = '\x00'  # replacement for {{ (escaped literal {)
 _ESC_BRACE_CLOSE = '\x01'  # replacement for }} (escaped literal })
 
 
+# Unicode punctuation that iOS/macOS auto-substitute but Vestaboard can't
+# display. Mapped to their ASCII equivalents via str.translate().
+_UNICODE_PUNCT_TABLE = str.maketrans(
+  {
+    '\u2018': "'",  # ' left single quotation mark
+    '\u2019': "'",  # ' right single quotation mark
+    '\u201a': "'",  # ‚ single low-9 quotation mark
+    '\u201b': "'",  # ‛ single high-reversed-9 quotation mark
+    '\u2032': "'",  # ′ prime
+    '\u201c': '"',  # " left double quotation mark
+    '\u201d': '"',  # " right double quotation mark
+    '\u201e': '"',  # „ double low-9 quotation mark
+    '\u201f': '"',  # ‟ double high-reversed-9 quotation mark
+    '\u2033': '"',  # ″ double prime
+    '\u2012': '-',  # ‒ figure dash
+    '\u2013': '-',  # – en dash
+    '\u2014': '-',  # — em dash
+    '\u2015': '-',  # ― horizontal bar
+    '\u2026': '...',  # … horizontal ellipsis
+  }
+)
+
+
 def _next_token(text: str, i: int) -> tuple[str, int]:
   """Return (raw_token, chars_consumed) for the source token starting at i.
 
@@ -296,6 +319,7 @@ def _strip_unsupported(text: str) -> str:
   Multiple spaces produced by stripping are collapsed to one, and
   leading/trailing whitespace is removed.
   """
+  text = text.translate(_UNICODE_PUNCT_TABLE)
   tokens: list[str] = []
   i = 0
   while i < len(text):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.10.0"
+version = "1.10.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_vestaboard.py
+++ b/tests/core/test_vestaboard.py
@@ -286,6 +286,38 @@ def test_strip_unsupported_preserves_ascii() -> None:
   assert result == 'ANIMAL CROSSING: NEW HORIZONS'
 
 
+def test_strip_unsupported_normalizes_smart_single_quotes() -> None:
+  # iOS/macOS auto-replace ' with \u2018/\u2019 smart quotes.
+  result = vb._strip_unsupported('\u2018HELLO\u2019')  # noqa: SLF001
+  assert result == "'HELLO'"
+
+
+def test_strip_unsupported_normalizes_smart_double_quotes() -> None:
+  result = vb._strip_unsupported('\u201cWORLD\u201d')  # noqa: SLF001
+  assert result == '"WORLD"'
+
+
+def test_strip_unsupported_normalizes_em_dash() -> None:
+  result = vb._strip_unsupported('A\u2014B')  # noqa: SLF001
+  assert result == 'A-B'
+
+
+def test_strip_unsupported_normalizes_en_dash() -> None:
+  result = vb._strip_unsupported('3\u20135')  # noqa: SLF001
+  assert result == '3-5'
+
+
+def test_strip_unsupported_normalizes_ellipsis() -> None:
+  result = vb._strip_unsupported('WAIT\u2026')  # noqa: SLF001
+  assert result == 'WAIT...'
+
+
+def test_strip_unsupported_normalizes_mixed_unicode_punct() -> None:
+  # Combined: smart quotes + em dash + ellipsis in one string.
+  result = vb._strip_unsupported('\u201cHI\u201d \u2014 BYE\u2026')  # noqa: SLF001
+  assert result == '"HI" - BYE...'
+
+
 def test_wrap_lines_strips_unsupported_before_wrap() -> None:
   # Japanese prefix + English suffix: unsupported chars stripped, English visible.
   lines = ['あつまれ どうぶつの森 = ANIMAL CROSSING']

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.10.0"
+version = "1.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Add `_UNICODE_PUNCT_TABLE` translation table mapping iOS/macOS smart quotes, en/em dashes, ellipsis, and similar Unicode punctuation to ASCII equivalents
- Apply `str.translate()` at the top of `_strip_unsupported()` so normalization covers all text entering the render pipeline (static content, integration output, webhook payloads)

Closes #471

## Test plan

- [x] 6 new tests covering smart single/double quotes, en dash, em dash, ellipsis, and mixed input
- [x] Full check suite passes (ruff, pyright, bandit, 1235 tests)