### PR TITLE
feat(webhook): filter private webhook messages in public mode (#473)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,6 +268,11 @@ parameter (for senders like Plex that cannot set custom headers). All
 `handle_webhook` implementations must accept `credential_name: str | None = None`
 as a keyword argument.
 
+Webhook integrations respect the `private` flag from their JSON template
+definition and `config.toml` overrides automatically — the scheduler resolves
+the effective value during content loading and applies it in the worker. No
+integration-level code is needed to propagate the flag.
+
 When adding a new webhook-capable integration, also add its name to
 `_KNOWN_INTEGRATIONS` in `scheduler.py`. If the integration should auto-generate
 a credential on first startup, also add it to `_WEBHOOK_AUTOGEN` in `scheduler.py`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.11.0"
+version = "1.12.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -93,6 +93,11 @@ _KNOWN_INTEGRATIONS: frozenset[str] = frozenset(
 # Cache of loaded integration modules, keyed by name.
 _integrations: dict[str, Any] = {}
 
+# Resolved private flags for webhook-capable integrations, populated by
+# _load_file.  The webhook handler checks this to set data['private'] so
+# individual integrations don't need to propagate the flag themselves.
+_webhook_private: dict[str, bool] = {}
+
 
 def _get_integration(name: str) -> Any:
   if name not in _KNOWN_INTEGRATIONS:
@@ -412,7 +417,10 @@ def worker() -> None:
     if message is None:
       continue
 
-    if _public_mod.is_public() and message.data.get('private'):
+    is_private = message.data.get('private')
+    if not is_private and message.name.startswith('webhook.'):
+      is_private = _webhook_private.get(message.name.removeprefix('webhook.'), False)
+    if _public_mod.is_public() and is_private:
       logger.debug('Skipping %s — private content hidden in public mode', message.name)
       continue
 
@@ -968,6 +976,8 @@ def _load_file(
       data['integration_fn'] = template['integration_fn']
     schedule = template['schedule']
     is_webhook = bool(template.get('webhook', False))
+    if is_webhook and 'integration' in template:
+      _webhook_private[template['integration']] = _webhook_private.get(template['integration'], False) or private
     has_cron = isinstance(schedule.get('cron'), str) and bool(schedule['cron'].strip())
     if is_webhook and not has_cron:
       webhook_only_jobs.append((f'{stem}.{template_name}', priority, data, schedule))

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -676,6 +676,52 @@ def test_load_file_private_json_field_sets_data_flag(sched: BackgroundScheduler,
   assert jobs[0].args[1].get('private') is True
 
 
+def _make_webhook_private_content(*, private: bool = True) -> dict[str, Any]:
+  template: dict[str, Any] = {
+    'webhook': True,
+    'schedule': {'hold': 60, 'timeout': 30},
+    'priority': 8,
+    'integration': 'plex',
+    'templates': [{'format': ['TEST']}],
+  }
+  if private:
+    template['private'] = True
+  return {'templates': {'now_playing': template}}
+
+
+def test_load_file_webhook_private_populates_dict(
+  sched: BackgroundScheduler, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  monkeypatch.setattr(_mod, '_webhook_private', {})
+  f = tmp_path / 'test.json'
+  f.write_text(json.dumps(_make_webhook_private_content(private=True)))
+  _mod._load_file(sched, f)
+  assert _mod._webhook_private.get('plex') is True
+
+
+def test_load_file_webhook_non_private_not_in_dict(
+  sched: BackgroundScheduler, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  monkeypatch.setattr(_mod, '_webhook_private', {})
+  f = tmp_path / 'test.json'
+  f.write_text(json.dumps(_make_webhook_private_content(private=False)))
+  _mod._load_file(sched, f)
+  assert not _mod._webhook_private.get('plex')
+
+
+def test_load_file_webhook_private_override_false(
+  sched: BackgroundScheduler, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  import config as _cfg
+
+  monkeypatch.setattr(_mod, '_webhook_private', {})
+  monkeypatch.setattr(_cfg, '_config', {'test': {'schedules': {'now_playing': {'private': False}}}})
+  f = tmp_path / 'test.json'
+  f.write_text(json.dumps(_make_webhook_private_content(private=True)))
+  _mod._load_file(sched, f)
+  assert not _mod._webhook_private.get('plex')
+
+
 # --- worker ---
 
 
@@ -711,6 +757,37 @@ def test_worker_skips_private_message_in_public_mode() -> None:
 def test_worker_shows_private_message_in_normal_mode() -> None:
   msg = _make_worker_msg(scheduled_at=time.monotonic(), timeout=3600)
   msg.data['private'] = True
+  with (
+    patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
+    patch('public.is_public', return_value=False),
+    patch('integrations.vestaboard.set_state'),
+    patch('time.sleep'),
+    patch.object(_mod, '_hold_interrupt'),
+  ):
+    with pytest.raises(KeyboardInterrupt):
+      _mod.worker()
+
+
+def test_worker_skips_webhook_private_message_in_public_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Webhook messages from private integrations are skipped in public mode."""
+  monkeypatch.setattr(_mod, '_webhook_private', {'plex': True})
+  msg = _make_worker_msg(scheduled_at=time.monotonic(), timeout=3600)
+  msg.name = 'webhook.plex'
+  with (
+    patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
+    patch('public.is_public', return_value=True),
+    patch('integrations.vestaboard.set_state') as mock_set,
+  ):
+    with pytest.raises(KeyboardInterrupt):
+      _mod.worker()
+  mock_set.assert_not_called()
+
+
+def test_worker_shows_webhook_private_message_in_normal_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Webhook messages from private integrations are shown when public mode is off."""
+  monkeypatch.setattr(_mod, '_webhook_private', {'plex': True})
+  msg = _make_worker_msg(scheduled_at=time.monotonic(), timeout=3600)
+  msg.name = 'webhook.plex'
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
     patch('public.is_public', return_value=False),

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.11.0"
+version = "1.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Centralize private flag resolution for webhook messages in the scheduler — integrations get private filtering automatically with no code changes needed
- `_load_file` populates `_webhook_private` dict during content loading (resolves JSON `private` field + `config.toml` overrides via existing `_coerce_bool`)
- Worker checks `_webhook_private` for `webhook.*` messages alongside the existing `data['private']` check, so future integrations can't accidentally miss it

Closes #473

## Test plan

- [x] `test_load_file_webhook_private_populates_dict` — private webhook template populates `_webhook_private`
- [x] `test_load_file_webhook_non_private_not_in_dict` — non-private webhook template doesn't set flag
- [x] `test_load_file_webhook_private_override_false` — config override `private = false` clears the flag
- [x] `test_worker_skips_webhook_private_message_in_public_mode` — worker skips in public mode
- [x] `test_worker_shows_webhook_private_message_in_normal_mode` — worker shows in normal mode
- [x] Full suite: 1250 passed
