### PR TITLE
fix(trakt,parcel): skip unaired on-deck episodes, shorten delivery text

### DIFF
--- a/integrations/parcel.py
+++ b/integrations/parcel.py
@@ -62,7 +62,7 @@ def _carrier_color(carrier_code: str) -> str:
 def _detail_line(status_code: int, date_expected: str | None) -> str:
   """Build the detail line (row 3) from status and expected date."""
   if status_code == _OUT_FOR_DELIVERY:
-    return 'OUT FOR DELIVERY'
+    return 'DELIVERING'
   if not date_expected:
     return ''
   try:

--- a/integrations/trakt.py
+++ b/integrations/trakt.py
@@ -598,7 +598,7 @@ def get_variables_next_up() -> dict[str, list[list[str]]]:
 
   for entry in shows:
     trakt_id = entry['show']['ids']['trakt']
-    progress_url = f'{_TRAKT_API_BASE}/shows/{trakt_id}/progress/watched'
+    progress_url = f'{_TRAKT_API_BASE}/shows/{trakt_id}/progress/watched?extended=full'
     try:
       r2 = fetch_with_retry('GET', progress_url, headers=_request_headers(token, client_id), timeout=10)
       if r2.status_code == 401:
@@ -617,6 +617,19 @@ def get_variables_next_up() -> dict[str, list[list[str]]]:
 
     ep = r2.json().get('next_episode')
     if ep is not None:
+      # Skip episodes that haven't aired yet — the user can't watch them.
+      first_aired = ep.get('first_aired')
+      if not first_aired:
+        logger.debug('Trakt: next-up episode for %s has no air date — skipping', entry['show']['title'])
+        continue
+      aired_dt = datetime.fromisoformat(first_aired.replace('Z', '+00:00'))
+      if aired_dt > datetime.now(timezone.utc):
+        logger.debug(
+          'Trakt: next-up episode for %s airs %s — skipping (not yet aired)',
+          entry['show']['title'],
+          first_aired,
+        )
+        continue
       show_name, season, number, ep_title = _canonicalize_episode(entry['show'], ep)
       episode_ref = _media.format_episode_ref(season, number)
       episode_title = _media.strip_leading_article_if_needed(ep_title.upper(), _vb.model.cols, f'{episode_ref} ')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.12.0"
+version = "1.12.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_trakt.py
+++ b/tests/core/test_trakt.py
@@ -1313,6 +1313,24 @@ _PROGRESS_WITH_NEXT = {
     'season': 3,
     'number': 1,
     'title': 'Box Cutter',
+    'first_aired': '2000-01-01T00:00:00.000Z',
+  }
+}
+
+_PROGRESS_WITH_UNAIRED = {
+  'next_episode': {
+    'season': 4,
+    'number': 1,
+    'title': 'Future Episode',
+    'first_aired': '2099-12-31T00:00:00.000Z',
+  }
+}
+
+_PROGRESS_WITH_NO_AIR_DATE = {
+  'next_episode': {
+    'season': 5,
+    'number': 1,
+    'title': 'TBA',
   }
 }
 
@@ -1449,4 +1467,43 @@ def test_next_up_cache_expired_raises_unavailable(config_with_tokens: Path, monk
 
   with patch('integrations.trakt.fetch_with_retry', side_effect=requests.ConnectionError()):
     with pytest.raises(IntegrationDataUnavailableError):
+      trakt.get_variables_next_up()
+
+
+def test_get_variables_next_up_skips_unaired_episode(config_with_tokens: Path) -> None:
+  """Unaired next episode is skipped; falls through to the next show."""
+  watched = _mock_watched_ok(_WATCHED_SHOWS_RESPONSE)
+  progress_unaired = _mock_progress_ok(_PROGRESS_WITH_UNAIRED)
+  progress_aired = _mock_progress_ok(_PROGRESS_WITH_NEXT)
+
+  with patch('integrations.trakt.fetch_with_retry', side_effect=[watched, progress_unaired, progress_aired]):
+    result = trakt.get_variables_next_up()
+
+  assert result['show_name'] == [['THE WIRE']]
+  assert result['episode_ref'] == [['S3E1']]
+
+
+def test_get_variables_next_up_skips_no_air_date(config_with_tokens: Path) -> None:
+  """Episode with no first_aired is treated as unaired and skipped."""
+  watched = _mock_watched_ok(_WATCHED_SHOWS_RESPONSE)
+  progress_no_date = _mock_progress_ok(_PROGRESS_WITH_NO_AIR_DATE)
+  progress_aired = _mock_progress_ok(_PROGRESS_WITH_NEXT)
+
+  with patch('integrations.trakt.fetch_with_retry', side_effect=[watched, progress_no_date, progress_aired]):
+    result = trakt.get_variables_next_up()
+
+  assert result['show_name'] == [['THE WIRE']]
+
+
+def test_get_variables_next_up_all_unaired_raises_unavailable(config_with_tokens: Path) -> None:
+  """When all shows have unaired next episodes, raises unavailable."""
+  shows = [
+    {'show': {'title': f'Show {i}', 'ids': {'trakt': i}}, 'last_watched_at': '2099-01-01T00:00:00.000Z'}
+    for i in range(5)
+  ]
+  watched = _mock_watched_ok(shows)
+  progress_unaired = _mock_progress_ok(_PROGRESS_WITH_UNAIRED)
+
+  with patch('integrations.trakt.fetch_with_retry', side_effect=[watched] + [progress_unaired] * 5):
+    with pytest.raises(IntegrationDataUnavailableError, match='No next episode'):
       trakt.get_variables_next_up()

--- a/tests/test_parcel.py
+++ b/tests/test_parcel.py
@@ -74,7 +74,7 @@ def test_carrier_color(carrier_code: str, expected: str) -> None:
 
 
 def test_detail_out_for_delivery() -> None:
-  assert pc._detail_line(4, '2026-03-18') == 'OUT FOR DELIVERY'
+  assert pc._detail_line(4, '2026-03-18') == 'DELIVERING'
 
 
 def test_detail_today(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -219,7 +219,7 @@ def test_get_variables_out_for_delivery(monkeypatch: pytest.MonkeyPatch) -> None
 
   assert result['status_line'] == [['[B] ON THE WAY']]
   assert result['description'] == [['AMAZON ORDER']]
-  assert result['detail'] == [['OUT FOR DELIVERY']]
+  assert result['detail'] == [['DELIVERING']]
   pc._cache = None
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.12.0"
+version = "1.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

Closes #476, closes #477.

## Summary

- **Trakt on-deck (#476):** `get_variables_next_up()` now requests `?extended=full` from the progress endpoint and skips episodes whose `first_aired` is missing or in the future. Falls back to the next recently-watched show rather than displaying an unwatchable episode.
- **Parcel detail (#477):** Shortened "OUT FOR DELIVERY" (16 chars) to "DELIVERING" (10 chars) so it fits the Note's 15-column display.

## Test plan

- [x] Three new Trakt tests: skips unaired episode (falls to next show), skips no-air-date episode, all-unaired raises unavailable
- [x] Updated parcel assertions for the shorter string
- [x] Full suite passes (1253 passed)
- [x] `ruff check`, `ruff format`, `pyright` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)