### PR TITLE
refactor(color): centralize hex-to-color-tag mapping (#482)

### DIFF
--- a/integrations/calendar.py
+++ b/integrations/calendar.py
@@ -37,7 +37,6 @@
 # raises IntegrationDataUnavailableError immediately if carddav_url is absent.
 
 import logging
-import math
 import time
 from datetime import date, datetime, timedelta
 from typing import Any
@@ -50,24 +49,12 @@ from icalendar import Calendar
 from icalendar.cal import Component
 
 from exceptions import IntegrationDataUnavailableError
+from integrations.color import hex_to_color_tag
 from integrations.http import fetch_with_retry
 
 logger = logging.getLogger(__name__)
 
-# Approximate sRGB values for each Vestaboard color letter. Used for
-# nearest-color matching when reading hex color values from ICS/CalDAV data.
-_COLOR_RGB: dict[str, tuple[int, int, int]] = {
-  'R': (255, 59, 48),
-  'O': (255, 149, 0),
-  'Y': (255, 204, 0),
-  'G': (52, 199, 89),
-  'B': (0, 122, 255),
-  'V': (175, 82, 222),
-  'W': (255, 255, 255),
-  'K': (0, 0, 0),
-}
-
-_VALID_COLORS = frozenset(_COLOR_RGB)
+_VALID_COLORS = frozenset('ROYGBVWK')
 
 # Per-URL ICS bytes cache: url → (raw_bytes, monotonic_fetch_time).
 _ics_cache: dict[str, tuple[bytes, float]] = {}
@@ -106,27 +93,6 @@ def _wrap_color(letter: str) -> str:
   if upper not in _VALID_COLORS:
     raise ValueError(f'Invalid calendar color {letter!r} — valid options: R, O, Y, G, B, V, W, K')
   return f'[{upper}]'
-
-
-def _nearest_color_tag(hex_color: str) -> str:
-  """Return the nearest Vestaboard color tag for a hex color string.
-
-  Accepts #RRGGBB or #RRGGBBAA (Apple's format). Alpha channel is ignored.
-  Finds the closest color by Euclidean distance in RGB space.
-  """
-  hex_color = hex_color.strip().lstrip('#')
-  r = int(hex_color[0:2], 16)
-  g = int(hex_color[2:4], 16)
-  b = int(hex_color[4:6], 16)
-
-  best_letter = 'W'
-  best_dist = float('inf')
-  for letter, (cr, cg, cb) in _COLOR_RGB.items():
-    dist = math.sqrt((r - cr) ** 2 + (g - cg) ** 2 + (b - cb) ** 2)
-    if dist < best_dist:
-      best_dist = dist
-      best_letter = letter
-  return f'[{best_letter}]'
 
 
 # ── Timezone ───────────────────────────────────────────────────────────────────
@@ -186,7 +152,7 @@ def _ics_calendar_color(cal: Calendar) -> str | None:
   if not raw:
     return None
   try:
-    return _nearest_color_tag(str(raw))
+    return hex_to_color_tag(str(raw))
   except ValueError, IndexError:
     return None
 
@@ -371,7 +337,7 @@ def _get_caldav_calendars(
       props = cal.get_properties([caldav_ical.CalendarColor()])
       raw_color = props.get('{http://apple.com/ns/ical/}calendar-color') if props else None
       if raw_color:
-        color_tag = _nearest_color_tag(str(raw_color))
+        color_tag = hex_to_color_tag(str(raw_color))
     except Exception:  # noqa: BLE001  # nosec B110 — color is optional; CalDAV property fetch may fail on non-Apple servers
       pass
 

--- a/integrations/color.py
+++ b/integrations/color.py
@@ -1,9 +1,13 @@
 # integrations/color.py
 #
-# Shared utility: derive the dominant color from image bytes and map it to the
-# nearest Vestaboard color square tag.
+# Shared color utilities: map colors to the nearest Vestaboard color square tag.
 #
-# Used by: integrations/discogs.py (album art), and future music integrations.
+# - hex_to_color_tag(): map a hex color string (#RRGGBB / #RRGGBBAA) to a tag
+# - dominant_color_tag(): derive the dominant color from image bytes
+# - fetch_cover_color(): fetch an image URL and return its dominant color tag
+#
+# Used by: integrations/calendar.py (ICS/CalDAV calendar colors),
+#          integrations/discogs.py (album art).
 #
 # Color extraction approach:
 #   1. Decode the image with Pillow, convert to RGB, and resize to at most
@@ -199,6 +203,43 @@ def _kmeans_dominant(pixels: list[tuple[float, float, float]]) -> tuple[float, f
   return centroids[largest]
 
 
+def _oklab_to_tag(L: float, a: float, b: float) -> str:
+  """Classify an Oklab color as the nearest Vestaboard color tag.
+
+  Computes OKLCH chroma from the (a, b) components. Achromatic colors
+  (chroma < _CHROMA_THRESHOLD) map to [W] or [K] by lightness; chromatic
+  colors map to the nearest _CHROMATIC_PALETTE entry by circular hue distance.
+  """
+  chroma = math.sqrt(a**2 + b**2)
+
+  if chroma < _CHROMA_THRESHOLD:
+    tag = '[W]' if L >= _WHITE_L_THRESHOLD else '[K]'
+    logger.debug('color: Oklab L=%.3f C=%.3f → achromatic %s', L, chroma, tag)
+  else:
+    hue = math.degrees(math.atan2(b, a)) % 360
+    tag = min(
+      _CHROMATIC_PALETTE,
+      key=lambda entry: min(abs(entry[0] - hue), 360 - abs(entry[0] - hue)),
+    )[1]
+    logger.debug('color: Oklab L=%.3f C=%.3f hue=%.1f° → %s', L, chroma, hue, tag)
+
+  return tag
+
+
+def hex_to_color_tag(hex_color: str) -> str:
+  """Return the nearest Vestaboard color tag for a hex color string.
+
+  Accepts ``#RRGGBB`` or ``#RRGGBBAA`` (Apple's format — alpha is ignored).
+  Converts to Oklab and classifies via OKLCH hue/chroma/lightness.
+  """
+  hex_color = hex_color.strip().lstrip('#')
+  r = int(hex_color[0:2], 16)
+  g = int(hex_color[2:4], 16)
+  b = int(hex_color[4:6], 16)
+  L, a, b_val = _rgb_to_oklab(r, g, b)
+  return _oklab_to_tag(L, a, b_val)
+
+
 def dominant_color_tag(image_bytes: bytes, *, fallback: str = '[Y]') -> str:
   """Return the Vestaboard color tag for the dominant color in the image.
 
@@ -244,23 +285,7 @@ def dominant_color_tag(image_bytes: bytes, *, fallback: str = '[Y]') -> str:
   # Find dominant color via k-means in Oklab, scored by population × chroma.
   L, a, b_val = _kmeans_dominant(oklab_pixels)
 
-  # Compute OKLCH chroma to decide chromatic vs achromatic.
-  chroma = math.sqrt(a**2 + b_val**2)
-
-  if chroma < _CHROMA_THRESHOLD:
-    # Achromatic: choose [W] or [K] by Oklab lightness.
-    tag = '[W]' if L >= _WHITE_L_THRESHOLD else '[K]'
-    logger.debug('color: Oklab L=%.3f C=%.3f → achromatic %s', L, chroma, tag)
-  else:
-    # Chromatic: compute OKLCH hue angle and find nearest palette entry.
-    hue = math.degrees(math.atan2(b_val, a)) % 360
-    tag = min(
-      _CHROMATIC_PALETTE,
-      key=lambda entry: min(abs(entry[0] - hue), 360 - abs(entry[0] - hue)),
-    )[1]
-    logger.debug('color: Oklab L=%.3f C=%.3f hue=%.1f° → %s', L, chroma, hue, tag)
-
-  return tag
+  return _oklab_to_tag(L, a, b_val)
 
 
 def fetch_cover_color(url: str, *, fallback: str = '[Y]') -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.13.0"
+version = "1.13.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_calendar.py
+++ b/tests/core/test_calendar.py
@@ -116,20 +116,6 @@ def test_wrap_color_invalid() -> None:
     calendar._wrap_color('purple')
 
 
-def test_nearest_color_tag_red() -> None:
-  # Apple red #FF2D30FF → nearest is R
-  assert calendar._nearest_color_tag('#FF2D30FF') == '[R]'
-
-
-def test_nearest_color_tag_blue() -> None:
-  assert calendar._nearest_color_tag('#007AFF') == '[B]'
-
-
-def test_nearest_color_tag_strips_alpha() -> None:
-  # With and without alpha should resolve to the same color
-  assert calendar._nearest_color_tag('#52C755FF') == calendar._nearest_color_tag('#52C755')
-
-
 def test_ics_calendar_color_parsed() -> None:
   cal = Calendar()
   cal.add('X-APPLE-CALENDAR-COLOR', '#007AFFFF')
@@ -408,27 +394,6 @@ def test_get_variables_raises_cold_start_failure(ical_config_ics: None) -> None:
   with patch('integrations.calendar.fetch_with_retry', side_effect=req.ConnectionError('down')):
     with pytest.raises(IntegrationDataUnavailableError, match='fetch failed'):
       calendar._fetch_ics_bytes('https://example.com/cal.ics')
-
-
-# ── CalDAV color ───────────────────────────────────────────────────────────────
-
-
-def test_nearest_color_tag_apple_red() -> None:
-  """Apple's default red #FF2D55FF maps to [R]."""
-  assert calendar._nearest_color_tag('#FF2D55FF') == '[R]'
-
-
-def test_nearest_color_tag_apple_green() -> None:
-  """Apple's default green #34C759FF maps to [G]."""
-  assert calendar._nearest_color_tag('#34C759FF') == '[G]'
-
-
-def test_nearest_color_tag_white() -> None:
-  assert calendar._nearest_color_tag('#FFFFFFFF') == '[W]'
-
-
-def test_nearest_color_tag_black() -> None:
-  assert calendar._nearest_color_tag('#000000FF') == '[K]'
 
 
 # ── Both modes simultaneously ──────────────────────────────────────────────────

--- a/tests/core/test_color.py
+++ b/tests/core/test_color.py
@@ -160,6 +160,38 @@ def test_dominant_color_tag_warm_neutral_maps_to_achromatic() -> None:
   assert tag not in ('[O]', '[Y]')
 
 
+# --- hex_to_color_tag ---
+
+
+def test_hex_to_color_tag_red() -> None:
+  assert color_mod.hex_to_color_tag('#FF2D30FF') == '[R]'
+
+
+def test_hex_to_color_tag_blue() -> None:
+  assert color_mod.hex_to_color_tag('#007AFF') == '[B]'
+
+
+def test_hex_to_color_tag_green() -> None:
+  assert color_mod.hex_to_color_tag('#34C759FF') == '[G]'
+
+
+def test_hex_to_color_tag_white() -> None:
+  assert color_mod.hex_to_color_tag('#FFFFFFFF') == '[W]'
+
+
+def test_hex_to_color_tag_black() -> None:
+  assert color_mod.hex_to_color_tag('#000000FF') == '[K]'
+
+
+def test_hex_to_color_tag_strips_alpha() -> None:
+  assert color_mod.hex_to_color_tag('#52C755FF') == color_mod.hex_to_color_tag('#52C755')
+
+
+def test_hex_to_color_tag_apple_red() -> None:
+  """Apple's default red #FF2D55FF maps to [R]."""
+  assert color_mod.hex_to_color_tag('#FF2D55FF') == '[R]'
+
+
 # --- fetch_cover_color ---
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.13.0"
+version = "1.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Add `hex_to_color_tag()` to `color.py` — converts `#RRGGBB`/`#RRGGBBAA` hex strings to Vestaboard color tags using Oklab/OKLCH perceptual color space
- Extract `_oklab_to_tag()` helper shared by both `hex_to_color_tag()` and `dominant_color_tag()`
- Replace `calendar.py`'s `_nearest_color_tag()` (sRGB Euclidean distance) with the shared function
- Move tests from `test_calendar.py` to `test_color.py`; keep end-to-end calendar color tests

Closes #482

## Test plan

- [x] All 7 new `test_hex_to_color_tag_*` tests pass (red, blue, green, white, black, alpha-stripping, Apple red)
- [x] All existing `test_dominant_color_tag_*` tests still pass (verifies `_oklab_to_tag` extraction)
- [x] Calendar end-to-end tests (`test_ics_calendar_color_parsed`, CalDAV tests) still pass
- [x] Full suite: 1286 passed
- [x] ruff check, ruff format, pyright, bandit all clean
