### PR TITLE
refactor(quiet,config): migrate quiet config to flat key, standardize config alias (#484, #487, #488)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -20,6 +20,10 @@
 # is in a shared or guest-visible space.
 # public = true
 
+# Quiet mode: render content to virtual state instead of sending to the board.
+# Written by the scheduler webhook — can also be set manually before startup.
+# quiet = true
+
 # Content filter. When absent, all user content loads and no contrib content
 # loads. When set, the filter applies to both user and contrib directories:
 #   ["*"]              — all user + all contrib

--- a/config.py
+++ b/config.py
@@ -418,6 +418,35 @@ def delete_config_section(section: str) -> None:
   d.pop(parts[-1], None)
 
 
+def migrate_quiet_config() -> None:
+  """Migrate old [scheduler.quiet] section to flat [scheduler].quiet key.
+
+  Detects the old ``[scheduler.quiet]`` subsection with an ``active`` key,
+  rewrites it as ``quiet = true/false`` under ``[scheduler]``, and removes the
+  old section. Logs a deprecation warning when migration occurs.
+
+  No-op if the old section does not exist (fresh install or already migrated).
+  This migration shim is removed in 2.0 (#483).
+  """
+  import logging
+
+  quiet_section = _config.get('scheduler', {}).get('quiet')
+  if not isinstance(quiet_section, dict):
+    return  # already flat key or absent
+
+  value = bool(quiet_section.get('active', False))
+  delete_config_section('scheduler.quiet')
+  write_config_section('scheduler', {'quiet': value})
+
+  logger = logging.getLogger(__name__)
+  logger.warning(
+    'Migrated [scheduler.quiet] active = %s → [scheduler] quiet = %s '
+    '— the old format is deprecated and will be removed in 2.0',
+    str(value).lower(),
+    str(value).lower(),
+  )
+
+
 def migrate_message_credentials() -> int:
   """Migrate old-style flat message credentials to the nested namespace.
 

--- a/content/contrib/scheduler.md
+++ b/content/contrib/scheduler.md
@@ -59,12 +59,11 @@ and persist it for future restarts.
 Both modes are controlled via webhook. Persisted state is stored automatically:
 
 ```toml
-# Written by quiet.activate() / quiet.deactivate() — do not edit manually.
-[scheduler.quiet]
-active = false
+[scheduler]
+# Written by quiet.set_quiet() — can also be set manually before startup.
+quiet = false
 
 # Written by public.set_public() — can also be set manually before startup.
-[scheduler]
 public = false
 ```
 

--- a/integrations/calendar.py
+++ b/integrations/calendar.py
@@ -104,9 +104,9 @@ def _display_tz() -> Any:
   Reads [scheduler].timezone from config. Returns None to use system local
   timezone, matching the behaviour of config.get_timezone().
   """
-  import config as _cfg
+  import config as _config_mod
 
-  return _cfg.get_timezone()
+  return _config_mod.get_timezone()
 
 
 def _get_now(tz: Any) -> datetime:
@@ -763,9 +763,9 @@ def get_variables() -> dict[str, list[list[str]]]:
   Collects from ICS URLs and/or CalDAV if configured (both may be active).
   Raises IntegrationDataUnavailableError if no events are available.
   """
-  import config as _cfg
+  import config as _config_mod
 
-  cal_cfg: dict[str, Any] = _cfg._config.get('calendar', {})
+  cal_cfg: dict[str, Any] = _config_mod._config.get('calendar', {})
   if not cal_cfg:
     raise IntegrationDataUnavailableError('calendar: no [calendar] section in config.toml')
 
@@ -807,9 +807,9 @@ def get_variables_birthdays() -> dict[str, list[list[str]]]:
   Raises IntegrationDataUnavailableError if not configured or no birthdays
   fall within the lookahead window.
   """
-  import config as _cfg
+  import config as _config_mod
 
-  cal_cfg: dict[str, Any] = _cfg._config.get('calendar', {})
+  cal_cfg: dict[str, Any] = _config_mod._config.get('calendar', {})
   carddav_url = cal_cfg.get('carddav_url', '')
   username = cal_cfg.get('username', '')
   password = cal_cfg.get('password', '')
@@ -864,9 +864,9 @@ def get_variables_self_birthday() -> dict[str, list[list[str]]]:
   CalendarServer extension). Raises IntegrationDataUnavailableError when
   not configured, me-card unavailable, or today is not the owner's birthday.
   """
-  import config as _cfg
+  import config as _config_mod
 
-  cal_cfg: dict[str, Any] = _cfg._config.get('calendar', {})
+  cal_cfg: dict[str, Any] = _config_mod._config.get('calendar', {})
   carddav_url = cal_cfg.get('carddav_url', '')
   username = cal_cfg.get('username', '')
   password = cal_cfg.get('password', '')

--- a/integrations/diving.py
+++ b/integrations/diving.py
@@ -261,10 +261,10 @@ def get_variables() -> dict[str, list[list[str]]]:
   """
   global _cache
 
-  import config as _cfg
+  import config as _config_mod
 
-  station_id = _cfg.get_optional('diving', 'ndbc_station_id')
-  units = _cfg.get_optional('diving', 'units') or 'imperial'
+  station_id = _config_mod.get_optional('diving', 'ndbc_station_id')
+  units = _config_mod.get_optional('diving', 'units') or 'imperial'
 
   if _cache is not None and _cache.is_valid(_CACHE_TTL):
     logger.debug('Dive conditions: cache hit')
@@ -275,8 +275,8 @@ def get_variables() -> dict[str, list[list[str]]]:
       data = _fetch_ndbc(station_id)
     else:
       try:
-        lat = float(_cfg.get('diving', 'latitude'))
-        lon = float(_cfg.get('diving', 'longitude'))
+        lat = float(_config_mod.get('diving', 'latitude'))
+        lon = float(_config_mod.get('diving', 'longitude'))
       except ValueError, KeyError:
         raise IntegrationDataUnavailableError(
           'Dive conditions: set ndbc_station_id or latitude/longitude in config.toml'
@@ -322,9 +322,9 @@ def get_variables_last_dive() -> dict[str, list[list[str]]]:
 
   Returns key: days_ago — 'TODAY', '1 DAY AGO', or 'N DAYS AGO'.
   """
-  import config as _cfg
+  import config as _config_mod
 
-  raw = _cfg.get_optional('diving', 'last_dived_on')
+  raw = _config_mod.get_optional('diving', 'last_dived_on')
   if not raw:
     raise IntegrationDataUnavailableError('Dive conditions: last_dived_on not set — send a webhook to record a dive')
 
@@ -353,7 +353,7 @@ def handle_webhook(payload: dict[str, Any], credential_name: str | None = None) 
   [diving] last_dived_on. Returns None — display is driven by the
   daily cron template, not the webhook itself.
   """
-  import config as _cfg
+  import config as _config_mod
 
   dived_on = payload.get('dived_on')
   if not dived_on or not isinstance(dived_on, str):
@@ -366,6 +366,6 @@ def handle_webhook(payload: dict[str, Any], credential_name: str | None = None) 
     logger.warning('Dive conditions webhook: invalid dived_on %r — expected YYYY-MM-DD', dived_on)
     return None
 
-  _cfg.write_config_section('diving', {'last_dived_on': dived_on})
+  _config_mod.write_config_section('diving', {'last_dived_on': dived_on})
   logger.info('Dive conditions: recorded last dive date %s (credential=%r)', dived_on, credential_name)
   return None

--- a/integrations/qbittorrent.py
+++ b/integrations/qbittorrent.py
@@ -75,16 +75,16 @@ def get_variables() -> dict[str, list[list[str]]]:
   """
   global _cache
 
-  import config as _cfg
+  import config as _config_mod
 
   if _cache is not None and _cache.is_valid(_CACHE_TTL):
     logger.debug('qBittorrent: cache hit')
     return _cache.value
 
-  base_url = _cfg.get('qbittorrent', 'url').rstrip('/')
-  username = _cfg.get('qbittorrent', 'username')
-  password = _cfg.get('qbittorrent', 'password')
-  verify = _cfg.get_optional_bool('qbittorrent', 'verify_tls', default=True)
+  base_url = _config_mod.get('qbittorrent', 'url').rstrip('/')
+  username = _config_mod.get('qbittorrent', 'username')
+  password = _config_mod.get('qbittorrent', 'password')
+  verify = _config_mod.get_optional_bool('qbittorrent', 'verify_tls', default=True)
 
   try:
     with warnings.catch_warnings():

--- a/integrations/scheduler.py
+++ b/integrations/scheduler.py
@@ -35,9 +35,9 @@ def handle_webhook(
     raise ValueError(f'Invalid scheduler action: {action!r} — expected one of {sorted(_VALID_ACTIONS)}')
 
   if action == 'quiet':
-    quiet.activate()
+    quiet.set_quiet(True)
   elif action == 'wake':
-    quiet.deactivate()
+    quiet.set_quiet(False)
   elif action == 'public':
     public.set_public(True)
   elif action == 'private':

--- a/integrations/unraid.py
+++ b/integrations/unraid.py
@@ -88,15 +88,15 @@ def get_variables() -> dict[str, list[list[str]]]:
   """
   global _cache
 
-  import config as _cfg
+  import config as _config_mod
 
   if _cache is not None and _cache.is_valid(_CACHE_TTL):
     logger.debug('Unraid: cache hit')
     return _cache.value
 
-  base_url = _cfg.get('unraid', 'url').rstrip('/')
-  api_key = _cfg.get('unraid', 'api_key')
-  verify = _cfg.get_optional_bool('unraid', 'verify_tls', default=True)
+  base_url = _config_mod.get('unraid', 'url').rstrip('/')
+  api_key = _config_mod.get('unraid', 'api_key')
+  verify = _config_mod.get_optional_bool('unraid', 'verify_tls', default=True)
 
   try:
     with warnings.catch_warnings():

--- a/integrations/uptimerobot.py
+++ b/integrations/uptimerobot.py
@@ -20,7 +20,6 @@ from typing import Any
 
 import requests
 
-import config as _cfg
 import integrations.vestaboard as _vb
 from exceptions import IntegrationDataUnavailableError
 from integrations.http import CacheEntry, fetch_with_retry
@@ -67,7 +66,9 @@ def _fetch_monitors() -> list[dict[str, Any]]:
   Returns the list of monitor dicts from the response. Raises
   IntegrationDataUnavailableError on API errors.
   """
-  api_key = _cfg.get('uptimerobot', 'api_key')
+  import config as _config_mod
+
+  api_key = _config_mod.get('uptimerobot', 'api_key')
 
   try:
     r = fetch_with_retry(

--- a/integrations/ynab.py
+++ b/integrations/ynab.py
@@ -112,9 +112,9 @@ def _resolve_budget_id(api_key: str) -> str:
   """Return the budget ID from config, or auto-detect if only one budget exists."""
   global _resolved_budget_id
 
-  import config as _cfg
+  import config as _config_mod
 
-  explicit = _cfg.get_optional('ynab', 'budget_id')
+  explicit = _config_mod.get_optional('ynab', 'budget_id')
   if explicit:
     return explicit
 
@@ -153,13 +153,13 @@ def get_variables() -> dict[str, list[list[str]]]:
   """
   global _cache
 
-  import config as _cfg
+  import config as _config_mod
 
   if _cache is not None and _cache.is_valid(_CACHE_TTL):
     logger.debug('YNAB: cache hit')
     return _cache.value
 
-  api_key = _cfg.get('ynab', 'api_key')
+  api_key = _config_mod.get('ynab', 'api_key')
   budget_id = _resolve_budget_id(api_key)
   hdrs = _headers(api_key)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.13.1"
+version = "1.13.2"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/quiet.py
+++ b/quiet.py
@@ -5,7 +5,7 @@
 # instead of sending it to the board. On wake, the virtual state is sent
 # immediately so the board shows contextually relevant content.
 #
-# State is persisted to [scheduler.quiet] in config.toml so quiet mode
+# State is persisted to [scheduler].quiet in config.toml so quiet mode
 # survives restarts (including Docker container recreates).
 #
 # Thread-safe: all state is behind a single lock.
@@ -21,9 +21,8 @@ _lock = threading.Lock()
 _active: bool = False
 _virtual_state: list[list[int]] | None = None
 
-# Set by activate() and deactivate() so the worker can detect transitions
-# without polling. The worker should wait on this event (with a timeout) in
-# its main loop.
+# Set by set_quiet() so the worker can detect transitions without polling.
+# The worker should wait on this event (with a timeout) in its main loop.
 _changed = threading.Event()
 
 
@@ -34,42 +33,29 @@ def init() -> None:
   """
   global _active
   with _lock:
-    _active = _config_mod.get_optional_bool('scheduler.quiet', 'active', default=False)
+    _active = _config_mod.get_optional_bool('scheduler', 'quiet', default=False)
     if _active:
       logger.info('Quiet mode restored from config (board is quiet)')
 
 
-def activate() -> None:
-  """Enable quiet mode and persist to config.toml."""
-  global _active
-  with _lock:
-    if _active:
-      logger.debug('Quiet mode already active')
-      return
-    _active = True
-    _config_mod.write_config_section('scheduler.quiet', {'active': True})
-    logger.info('Quiet mode activated')
-    _changed.set()
+def set_quiet(value: bool) -> None:
+  """Set quiet mode and persist to config.toml.
 
-
-def deactivate() -> None:
-  """Disable quiet mode and persist to config.toml.
-
-  Virtual state is preserved for the worker to retrieve via
-  pop_virtual_state() and send to the board.
+  When transitioning to inactive, virtual state is preserved for the worker
+  to retrieve via pop_virtual_state() and send to the board.
   """
   global _active
   with _lock:
-    if not _active:
-      logger.debug('Quiet mode already inactive')
+    if _active == value:
+      logger.debug('Quiet mode already %s', 'active' if value else 'inactive')
       return
-    _active = False
-    _config_mod.write_config_section('scheduler.quiet', {'active': False})
-    logger.info('Quiet mode deactivated')
+    _active = value
+    _config_mod.write_config_section('scheduler', {'quiet': value})
+    logger.info('Quiet mode %s', 'activated' if value else 'deactivated')
     _changed.set()
 
 
-def is_active() -> bool:
+def is_quiet() -> bool:
   """Return whether quiet mode is currently active."""
   with _lock:
     return _active

--- a/scheduler.py
+++ b/scheduler.py
@@ -386,7 +386,7 @@ def worker() -> None:
     # Handle quiet→wake transition: send the last virtual state to the board
     # so it wakes to contextually relevant content. Detected within ≤1s of
     # the wake webhook firing (the pop_valid_message timeout).
-    if not _quiet_mod.is_active():
+    if not _quiet_mod.is_quiet():
       virtual = _quiet_mod.pop_virtual_state()
       if virtual is not None:
         logger.info('Quiet mode ended — sending virtual state to board')
@@ -427,7 +427,7 @@ def worker() -> None:
 
     scheduled = datetime.fromtimestamp(time.time() - (time.monotonic() - message.scheduled_at))
     hold_desc = f'{message.hold}s (indefinite)' if message.indefinite else f'{message.hold}s'
-    quiet_tag = ' [quiet]' if _quiet_mod.is_active() else ''
+    quiet_tag = ' [quiet]' if _quiet_mod.is_quiet() else ''
     logger.info(
       'Sending %s%s | scheduled: %s | priority: %d | hold: %s',
       message.name,
@@ -452,7 +452,7 @@ def worker() -> None:
         variables = getattr(_get_integration(message.data['integration']), fn_name)()
       templates = message.data['templates']
       truncation = message.data.get('truncation', 'hard')
-      if _quiet_mod.is_active():
+      if _quiet_mod.is_quiet():
         grid = vestaboard.render(templates, variables, truncation)
         _quiet_mod.set_virtual_state(grid)
       else:
@@ -487,7 +487,7 @@ def worker() -> None:
     # During quiet mode, skip hold — no physical display to keep showing.
     # Transfer refresh capability to idle state so virtual state stays current,
     # then immediately process the next message.
-    if _quiet_mod.is_active():
+    if _quiet_mod.is_quiet():
       with _current_hold_lock:
         _current_hold_supersede_tag = ''
         _current_hold_priority = None
@@ -505,7 +505,7 @@ def worker() -> None:
           _tr: Any = _truncation,
         ) -> None:
           new_vars = getattr(_i, _f)()
-          if _quiet_mod.is_active():
+          if _quiet_mod.is_quiet():
             _grid = vestaboard.render(_t, new_vars, _tr)
             _quiet_mod.set_virtual_state(_grid)
           else:
@@ -539,7 +539,7 @@ def worker() -> None:
         _tr: Any = _truncation,
       ) -> None:
         new_vars = getattr(_i, _f)()
-        if _quiet_mod.is_active():
+        if _quiet_mod.is_quiet():
           _grid = vestaboard.render(_t, new_vars, _tr)
           _quiet_mod.set_virtual_state(_grid)
         else:
@@ -1190,6 +1190,7 @@ def main() -> None:
   logging.basicConfig(level=logging.INFO, handlers=[_handler])
   _validate_startup(args.config)
   _config_mod.load_config(args.config)
+  _config_mod.migrate_quiet_config()
   _quiet_mod.init()
   _public_mod.init()
 
@@ -1218,7 +1219,7 @@ def main() -> None:
     extras.append('no content loaded')
   if _public_mod.is_public():
     extras.append('public mode')
-  if _quiet_mod.is_active():
+  if _quiet_mod.is_quiet():
     extras.append('quiet mode')
   version = importlib.metadata.version('e-note-ion')
   logger.info('Starting e-note-ion v%s — %s, %s', version, board_desc, ', '.join(extras))

--- a/tests/core/test_bart.py
+++ b/tests/core/test_bart.py
@@ -22,10 +22,10 @@ def reset_caches() -> Generator[None, None, None]:
 @pytest.fixture()
 def bart_config(monkeypatch: pytest.MonkeyPatch) -> None:
   """Patch config to provide BART settings without a real config file."""
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'bart': {'api_key': 'test-bart-key', 'station': 'MLPT', 'line1_dest': 'DALY'}},
   )
@@ -82,27 +82,27 @@ def test_format_minutes_non_numeric_passthrough() -> None:
 
 
 def test_get_variables_missing_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   def _raise(section: str, key: str) -> str:
     if section == 'bart' and key == 'api_key':
       raise ValueError('Missing required config key [bart].api_key in config.toml')
     return 'value'
 
-  monkeypatch.setattr(_cfg, 'get', _raise)
+  monkeypatch.setattr(_config_mod, 'get', _raise)
   with pytest.raises(ValueError, match='api_key'):
     bart.get_variables()
 
 
 def test_get_variables_missing_station(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   def _raise(section: str, key: str) -> str:
     if section == 'bart' and key == 'station':
       raise ValueError('Missing required config key [bart].station in config.toml')
     return 'value'
 
-  monkeypatch.setattr(_cfg, 'get', _raise)
+  monkeypatch.setattr(_config_mod, 'get', _raise)
   with pytest.raises(ValueError, match='station'):
     bart.get_variables()
 

--- a/tests/core/test_calendar.py
+++ b/tests/core/test_calendar.py
@@ -25,10 +25,10 @@ def reset_caches() -> Generator[None, None, None]:
 @pytest.fixture()
 def ical_config_ics(monkeypatch: pytest.MonkeyPatch) -> None:
   """Patch config with a minimal ICS-mode ical section."""
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'calendar': {'urls': ['https://example.com/cal.ics']}, 'scheduler': {}},
   )
@@ -37,10 +37,10 @@ def ical_config_ics(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture()
 def ical_config_ics_two_urls(monkeypatch: pytest.MonkeyPatch) -> None:
   """Patch config with two ICS URLs, each with a color."""
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'calendar': {
@@ -176,9 +176,9 @@ def test_get_variables_all_day_no_time_prefix(ical_config_ics: None) -> None:
 
 
 def test_get_variables_apple_color_auto_detected(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'calendar': {'urls': ['https://example.com/cal.ics']}, 'scheduler': {}})
+  monkeypatch.setattr(_config_mod, '_config', {'calendar': {'urls': ['https://example.com/cal.ics']}, 'scheduler': {}})
   ics = _make_ics_with_cal_color([_future_event('WORK MEETING')], '#007AFFFF')  # blue
   with patch('integrations.calendar._fetch_ics_bytes', return_value=ics):
     with patch('integrations.calendar._display_tz', return_value=_UTC):
@@ -189,10 +189,10 @@ def test_get_variables_apple_color_auto_detected(monkeypatch: pytest.MonkeyPatch
 
 
 def test_get_variables_configured_color_used(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'calendar': {'urls': ['https://example.com/cal.ics'], 'colors': ['V']}, 'scheduler': {}},
   )
@@ -207,10 +207,10 @@ def test_get_variables_configured_color_used(monkeypatch: pytest.MonkeyPatch) ->
 
 def test_get_variables_configured_color_overrides_apple(monkeypatch: pytest.MonkeyPatch) -> None:
   """User-configured color takes precedence over auto-detected X-APPLE-CALENDAR-COLOR."""
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'calendar': {'urls': ['https://example.com/cal.ics'], 'colors': ['G']}, 'scheduler': {}},
   )
@@ -290,10 +290,10 @@ def test_get_variables_timed_before_allday(ical_config_ics: None) -> None:
 
 def test_get_variables_url_order_tiebreaker(monkeypatch: pytest.MonkeyPatch) -> None:
   """When two events have the same start time, the event from URL 0 comes first."""
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'calendar': {'urls': ['https://example.com/a.ics', 'https://example.com/b.ics']}, 'scheduler': {}},
   )
@@ -316,10 +316,10 @@ def test_get_variables_url_order_tiebreaker(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 def test_get_variables_multiple_urls_merged(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'calendar': {'urls': ['https://example.com/a.ics', 'https://example.com/b.ics']}, 'scheduler': {}},
   )
@@ -343,10 +343,10 @@ def test_get_variables_multiple_urls_merged(monkeypatch: pytest.MonkeyPatch) -> 
 
 def test_get_variables_one_url_fails_gracefully(monkeypatch: pytest.MonkeyPatch) -> None:
   """If one URL fails with no cache, it is skipped; events from the other URL still show."""
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'calendar': {'urls': ['https://example.com/fail.ics', 'https://example.com/ok.ics']}, 'scheduler': {}},
   )
@@ -403,10 +403,10 @@ def test_get_variables_both_modes_merged(monkeypatch: pytest.MonkeyPatch) -> Non
   """Events from ICS and CalDAV are merged into a single sorted list."""
   from unittest.mock import MagicMock
 
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'calendar': {
@@ -445,10 +445,10 @@ def test_get_variables_both_modes_merged(monkeypatch: pytest.MonkeyPatch) -> Non
 
 def test_get_variables_caldav_absent_does_not_block_ics(monkeypatch: pytest.MonkeyPatch) -> None:
   """If CalDAV returns no calendars, ICS events still appear."""
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'calendar': {
@@ -507,9 +507,9 @@ def _patch_birthdays(
   config: dict | None = None,
 ) -> None:
   """Patch config, birthday cache, and now for birthday unit tests."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', config or _BDAY_CONFIG)
+  monkeypatch.setattr(_config_mod, '_config', config or _BDAY_CONFIG)
   monkeypatch.setattr(calendar, '_birthday_cache', (contacts, time.monotonic()))
   monkeypatch.setattr(calendar, '_carddav_addressbook_url', 'https://fake/ab/')
   monkeypatch.setattr(calendar, '_display_tz', lambda: _UTC)
@@ -573,9 +573,9 @@ def test_birthday_no_results_raises(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_birthday_no_carddav_url_raises(monkeypatch: pytest.MonkeyPatch) -> None:
   """Missing carddav_url raises IntegrationDataUnavailableError immediately."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'calendar': {}, 'scheduler': {}})
+  monkeypatch.setattr(_config_mod, '_config', {'calendar': {}, 'scheduler': {}})
   with pytest.raises(IntegrationDataUnavailableError, match='carddav_url'):
     calendar.get_variables_birthdays()
 
@@ -584,9 +584,9 @@ def test_birthday_cache_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
   """Stale cache (> 24h) triggers a real HTTP fetch; fresh cache does not."""
   from unittest.mock import MagicMock
 
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _BDAY_CONFIG)
+  monkeypatch.setattr(_config_mod, '_config', _BDAY_CONFIG)
   monkeypatch.setattr(calendar, '_carddav_addressbook_url', 'https://fake/ab/')
   monkeypatch.setattr(calendar, '_display_tz', lambda: _UTC)
   monkeypatch.setattr(calendar, '_get_now', lambda tz: _FIXED_NOW)
@@ -665,9 +665,9 @@ def _patch_self_birthday(
   """
   from unittest.mock import MagicMock
 
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', config or _BDAY_CONFIG)
+  monkeypatch.setattr(_config_mod, '_config', config or _BDAY_CONFIG)
   monkeypatch.setattr(calendar, '_carddav_addressbook_url', 'https://fake/ab/')
   monkeypatch.setattr(calendar, '_carddav_home_url', 'https://fake/home/')
   monkeypatch.setattr(calendar, '_display_tz', lambda: _UTC)
@@ -712,9 +712,9 @@ def test_self_birthday_not_today(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_self_birthday_no_carddav_raises(monkeypatch: pytest.MonkeyPatch) -> None:
   """Missing carddav_url → raises immediately."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'calendar': {}, 'scheduler': {}})
+  monkeypatch.setattr(_config_mod, '_config', {'calendar': {}, 'scheduler': {}})
   with pytest.raises(IntegrationDataUnavailableError, match='carddav_url'):
     calendar.get_variables_self_birthday()
 
@@ -729,9 +729,9 @@ def test_self_birthday_no_bday_raises(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_self_birthday_cache_hit(monkeypatch: pytest.MonkeyPatch) -> None:
   """Cached self contact is returned without any HTTP request."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _BDAY_CONFIG)
+  monkeypatch.setattr(_config_mod, '_config', _BDAY_CONFIG)
   monkeypatch.setattr(calendar, '_display_tz', lambda: _UTC)
   monkeypatch.setattr(calendar, '_get_now', lambda tz: _FIXED_NOW)
   monkeypatch.setattr(

--- a/tests/core/test_discogs.py
+++ b/tests/core/test_discogs.py
@@ -28,9 +28,9 @@ def mock_fetch_cover_color() -> Generator[None, None, None]:
 @pytest.fixture()
 def discogs_config(monkeypatch: pytest.MonkeyPatch) -> None:
   """Patch config with Discogs settings."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'discogs': {'token': 'test-token'}})
+  monkeypatch.setattr(_config_mod, '_config', {'discogs': {'token': 'test-token'}})
 
 
 def _mock_identity(username: str = 'testuser') -> MagicMock:

--- a/tests/core/test_plex.py
+++ b/tests/core/test_plex.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-import config as _cfg
+import config as _config_mod
 import integrations.plex as _plex
 import integrations.tmdb as _tmdb
 import integrations.vestaboard as _vb
@@ -45,7 +45,7 @@ def _movie_payload(event: str = 'media.play', title: str = 'A Quiet Place') -> d
 @pytest.fixture(autouse=True)
 def _empty_config(monkeypatch: pytest.MonkeyPatch) -> None:
   """Ensure config has no plex schedule overrides for most tests."""
-  monkeypatch.setattr(_cfg, '_config', {})
+  monkeypatch.setattr(_config_mod, '_config', {})
 
 
 @pytest.fixture(autouse=True)
@@ -796,7 +796,7 @@ def test_handle_webhook_long_show_name_truncated_to_one_row() -> None:
 
 def test_handle_webhook_applies_config_override(monkeypatch: pytest.MonkeyPatch) -> None:
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'plex': {'schedules': {'now_playing': {'hold': 7200, 'priority': 9}}}},
   )
@@ -910,7 +910,7 @@ def _movie_payload_with_guid(tmdb_id: int, title: str = 'Inception') -> dict[str
 
 def test_handle_webhook_episode_uses_tmdb_canonical_show_name(monkeypatch: pytest.MonkeyPatch) -> None:
   """TVDb episode ID → find_episode_by_tvdb_id → show_id → get_show_title."""
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   # find returns (season, episode, title, show_id=40290, tmdb_episode_id=99001)
   monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: (1, 3, 'The Dish', 40290, 99001))
   show_calls: list[int] = []
@@ -930,7 +930,7 @@ def test_handle_webhook_episode_uses_tmdb_canonical_show_name(monkeypatch: pytes
 
 def test_handle_webhook_episode_falls_back_when_no_guid(monkeypatch: pytest.MonkeyPatch) -> None:
   """When the payload has no Guid array and title search fails, falls back to grandparentTitle."""
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   find_calls: list[int] = []
   monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: find_calls.append(tvdb_id) or None)
   monkeypatch.setattr(_tmdb, 'search_show_by_title', lambda title: None)
@@ -945,7 +945,7 @@ def test_handle_webhook_episode_falls_back_when_no_guid(monkeypatch: pytest.Monk
 
 def test_handle_webhook_episode_falls_back_when_find_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
   """When find_episode_by_tvdb_id returns None, falls back to grandparentTitle."""
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: None)
 
   with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
@@ -957,7 +957,7 @@ def test_handle_webhook_episode_falls_back_when_find_returns_none(monkeypatch: p
 
 def test_handle_webhook_episode_falls_back_when_tmdb_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
   """When TMDb is not configured, no lookup is attempted even with Guid."""
-  monkeypatch.setattr(_cfg, '_config', {})
+  monkeypatch.setattr(_config_mod, '_config', {})
   find_calls: list[int] = []
   monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: find_calls.append(tvdb_id) or None)
 
@@ -971,7 +971,7 @@ def test_handle_webhook_episode_falls_back_when_tmdb_unconfigured(monkeypatch: p
 
 def test_handle_webhook_movie_uses_tmdb_canonical_title(monkeypatch: pytest.MonkeyPatch) -> None:
   """When TMDb is configured, movie title uses the canonical TMDb title."""
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   calls: list[int] = []
 
   def _mock_get_movie_title(tmdb_id: int) -> str:
@@ -989,7 +989,7 @@ def test_handle_webhook_movie_uses_tmdb_canonical_title(monkeypatch: pytest.Monk
 
 def test_handle_webhook_movie_falls_back_when_tmdb_lookup_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
   """When the TMDb lookup returns None, falls back to Plex's native title."""
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   monkeypatch.setattr(_tmdb, 'get_movie_title', lambda tmdb_id: None)
 
   with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
@@ -1019,7 +1019,7 @@ def _episode_payload_with_imdb_guid(imdb_id: str, show: str = 'Jujutsu Kaisen') 
 
 def test_handle_webhook_episode_uses_tmdb_episode_title(monkeypatch: pytest.MonkeyPatch) -> None:
   """TMDb episode title is used instead of Plex's native episode title."""
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: (1, 51, 'Perfect Preparation', 95479, 6827061))
   monkeypatch.setattr(_tmdb, 'get_show_title', lambda show_id: 'Jujutsu Kaisen')
 
@@ -1036,7 +1036,7 @@ def test_handle_webhook_episode_falls_back_to_plex_title_when_no_tmdb_ep_title(
   monkeypatch: pytest.MonkeyPatch,
 ) -> None:
   """When TMDb returns an empty episode title, Plex's native title is used."""
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   # empty string title from TMDb (episode exists but title not yet filled in)
   monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: (1, 3, '', 40290, 99001))
   monkeypatch.setattr(_tmdb, 'get_show_title', lambda show_id: 'MasterChef')
@@ -1051,7 +1051,7 @@ def test_handle_webhook_episode_falls_back_to_plex_title_when_no_tmdb_ep_title(
 
 def test_handle_webhook_episode_uses_imdb_fallback_when_no_tvdb_guid(monkeypatch: pytest.MonkeyPatch) -> None:
   """When no tvdb:// guid is present, imdb:// is tried and the TMDb title is used."""
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   imdb_calls: list[str] = []
 
   def _mock_find_imdb(imdb_id: str) -> tuple[int, int, str, int, int]:
@@ -1073,7 +1073,7 @@ def test_handle_webhook_episode_uses_imdb_fallback_when_no_tvdb_guid(monkeypatch
 
 def test_handle_webhook_episode_falls_back_when_no_tvdb_and_no_imdb_guid(monkeypatch: pytest.MonkeyPatch) -> None:
   """When no tvdb://, imdb://, and title search all fail, falls back to Plex's raw title."""
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   imdb_calls: list[str] = []
   monkeypatch.setattr(_tmdb, 'find_episode_by_imdb_id', lambda imdb_id: imdb_calls.append(imdb_id) or None)
   monkeypatch.setattr(_tmdb, 'search_show_by_title', lambda title: None)
@@ -1100,7 +1100,7 @@ def test_handle_webhook_episode_falls_back_when_no_tvdb_and_no_imdb_guid(monkeyp
 
 def test_handle_webhook_episode_uses_title_search_when_no_guid(monkeypatch: pytest.MonkeyPatch) -> None:
   """When no external guid is present, title search + S/E lookup returns TMDb episode title."""
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   monkeypatch.setattr(_tmdb, 'search_show_by_title', lambda title: 95479)
   monkeypatch.setattr(_tmdb, 'get_episode_by_number', lambda show_id, s, e: ('Perfect Preparation', 6827061))
   monkeypatch.setattr(_tmdb, 'get_episode_group_position', lambda show_id, ep_id: None)
@@ -1133,7 +1133,7 @@ def test_handle_webhook_episode_uses_episode_group_fallback_when_base_lookup_fai
   Covers anime like Frieren and JJK where TMDb base data uses a flat Season 1
   but Plex uses broadcast-season numbering matching the type-6 episode group.
   """
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   monkeypatch.setattr(_tmdb, 'search_show_by_title', lambda title: 209867)
   monkeypatch.setattr(_tmdb, 'get_episode_by_number', lambda show_id, s, e: None)  # base lookup fails (404)
   monkeypatch.setattr(

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -261,10 +261,10 @@ def test_load_file_log_widths_from_effective_values(
 ) -> None:
   # When a cron override is shorter than the JSON value, column widths must be
   # computed from the effective (post-override) value, not the original (bug #150).
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'test': {'schedules': {'tmpl': {'cron': '* * * * *'}}}},
   )
@@ -463,11 +463,11 @@ def test_load_content_user_loaded_when_star(
 def test_load_file_applies_schedule_override(
   sched: BackgroundScheduler, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   # Override hold and timeout for the template in this file.
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'test': {'schedules': {'tmpl': {'hold': 120, 'timeout': 30}}}},
   )
@@ -484,10 +484,10 @@ def test_load_file_applies_schedule_override(
 def test_load_file_applies_priority_override(
   sched: BackgroundScheduler, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'test': {'schedules': {'tmpl': {'priority': 9}}}},
   )
@@ -504,10 +504,10 @@ def test_load_file_ignores_invalid_type_priority_override(
   monkeypatch: pytest.MonkeyPatch,
   caplog: pytest.LogCaptureFixture,
 ) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'test': {'schedules': {'tmpl': {'priority': 'high'}}}},
   )
@@ -524,10 +524,10 @@ def test_load_file_ignores_out_of_range_priority_override(
   monkeypatch: pytest.MonkeyPatch,
   caplog: pytest.LogCaptureFixture,
 ) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'test': {'schedules': {'tmpl': {'priority': 11}}}},
   )
@@ -541,10 +541,10 @@ def test_load_file_ignores_out_of_range_priority_override(
 def test_load_file_ignores_unknown_override_keys(
   sched: BackgroundScheduler, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'test': {'schedules': {'tmpl': {'hold': 90, 'unknown_field': 'ignored'}}}},
   )
@@ -557,9 +557,9 @@ def test_load_file_ignores_unknown_override_keys(
 def test_load_file_skips_disabled_template(
   sched: BackgroundScheduler, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'test': {'schedules': {'tmpl': {'disabled': True}}}})
+  monkeypatch.setattr(_config_mod, '_config', {'test': {'schedules': {'tmpl': {'disabled': True}}}})
   f = tmp_path / 'test.json'
   f.write_text(json.dumps(_make_content()))
   _mod._load_file(sched, f)
@@ -569,9 +569,9 @@ def test_load_file_skips_disabled_template(
 def test_load_file_disabled_false_does_not_skip(
   sched: BackgroundScheduler, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'test': {'schedules': {'tmpl': {'disabled': False}}}})
+  monkeypatch.setattr(_config_mod, '_config', {'test': {'schedules': {'tmpl': {'disabled': False}}}})
   f = tmp_path / 'test.json'
   f.write_text(json.dumps(_make_content()))
   _mod._load_file(sched, f)
@@ -584,9 +584,9 @@ def test_load_file_disabled_string_true_coerces(
   monkeypatch: pytest.MonkeyPatch,
   caplog: pytest.LogCaptureFixture,
 ) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'test': {'schedules': {'tmpl': {'disabled': 'true'}}}})
+  monkeypatch.setattr(_config_mod, '_config', {'test': {'schedules': {'tmpl': {'disabled': 'true'}}}})
   f = tmp_path / 'test.json'
   f.write_text(json.dumps(_make_content()))
   _mod._load_file(sched, f)
@@ -600,9 +600,9 @@ def test_load_file_disabled_invalid_type_ignored(
   monkeypatch: pytest.MonkeyPatch,
   caplog: pytest.LogCaptureFixture,
 ) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'test': {'schedules': {'tmpl': {'disabled': 1}}}})
+  monkeypatch.setattr(_config_mod, '_config', {'test': {'schedules': {'tmpl': {'disabled': 1}}}})
   f = tmp_path / 'test.json'
   f.write_text(json.dumps(_make_content()))
   _mod._load_file(sched, f)
@@ -614,7 +614,7 @@ def test_load_file_skips_disabled_webhook_only_template(
   sched: BackgroundScheduler, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
   # Cron template enabled, webhook-only template disabled — only cron job scheduled.
-  import config as _cfg
+  import config as _config_mod
 
   content: dict[str, Any] = {
     'templates': {
@@ -631,7 +631,7 @@ def test_load_file_skips_disabled_webhook_only_template(
       },
     }
   }
-  monkeypatch.setattr(_cfg, '_config', {'test': {'schedules': {'webhook_tmpl': {'disabled': True}}}})
+  monkeypatch.setattr(_config_mod, '_config', {'test': {'schedules': {'webhook_tmpl': {'disabled': True}}}})
   f = tmp_path / 'test.json'
   f.write_text(json.dumps(content))
   _mod._load_file(sched, f)
@@ -642,9 +642,9 @@ def test_load_file_skips_disabled_webhook_only_template(
 def test_load_file_private_override_sets_data_flag(
   sched: BackgroundScheduler, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'test': {'schedules': {'tmpl': {'private': True}}}})
+  monkeypatch.setattr(_config_mod, '_config', {'test': {'schedules': {'tmpl': {'private': True}}}})
   f = tmp_path / 'test.json'
   f.write_text(json.dumps(_make_content()))  # template has no 'private' field in JSON
   _mod._load_file(sched, f)
@@ -656,9 +656,9 @@ def test_load_file_private_override_sets_data_flag(
 def test_load_file_private_override_false_clears_json_flag(
   sched: BackgroundScheduler, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'test': {'schedules': {'tmpl': {'private': False}}}})
+  monkeypatch.setattr(_config_mod, '_config', {'test': {'schedules': {'tmpl': {'private': False}}}})
   f = tmp_path / 'test.json'
   f.write_text(json.dumps(_make_content(private=True)))
   _mod._load_file(sched, f)
@@ -712,10 +712,10 @@ def test_load_file_webhook_non_private_not_in_dict(
 def test_load_file_webhook_private_override_false(
   sched: BackgroundScheduler, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(_mod, '_webhook_private', {})
-  monkeypatch.setattr(_cfg, '_config', {'test': {'schedules': {'now_playing': {'private': False}}}})
+  monkeypatch.setattr(_config_mod, '_config', {'test': {'schedules': {'now_playing': {'private': False}}}})
   f = tmp_path / 'test.json'
   f.write_text(json.dumps(_make_webhook_private_content(private=True)))
   _mod._load_file(sched, f)
@@ -1249,10 +1249,10 @@ def test_main_empty_board_on_startup(monkeypatch: pytest.MonkeyPatch, caplog: py
 def test_main_passes_timezone_to_scheduler(monkeypatch: pytest.MonkeyPatch) -> None:
   from zoneinfo import ZoneInfo
 
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr('sys.argv', ['e-note-ion'])
-  monkeypatch.setattr(_cfg, '_config', {'scheduler': {'timezone': 'America/New_York'}})
+  monkeypatch.setattr(_config_mod, '_config', {'scheduler': {'timezone': 'America/New_York'}})
   mock_sched = _mock_sched()
   with (
     patch.object(_mod, '_validate_startup'),
@@ -1701,10 +1701,10 @@ def test_load_file_refresh_interval_absent_not_in_data(sched: BackgroundSchedule
 def test_load_file_applies_refresh_interval_override(
   sched: BackgroundScheduler, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'test': {'schedules': {'tmpl': {'refresh_interval': 90}}}},
   )
@@ -1720,10 +1720,10 @@ def test_load_file_ignores_invalid_refresh_interval_override(
   monkeypatch: pytest.MonkeyPatch,
   caplog: pytest.LogCaptureFixture,
 ) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'test': {'schedules': {'tmpl': {'refresh_interval': 10}}}},
   )

--- a/tests/core/test_tmdb.py
+++ b/tests/core/test_tmdb.py
@@ -24,23 +24,23 @@ def _clear_lru_caches() -> None:
 
 
 def test_is_configured_true(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   assert tmdb.is_configured() is True
 
 
 def test_is_configured_false_missing_section(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {})
+  monkeypatch.setattr(_config_mod, '_config', {})
   assert tmdb.is_configured() is False
 
 
 def test_is_configured_false_empty_token(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': ''}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': ''}})
   assert tmdb.is_configured() is False
 
 
@@ -48,9 +48,9 @@ def test_is_configured_false_empty_token(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 def test_get_show_title_returns_name(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   mock_r = MagicMock()
   mock_r.status_code = 200
   mock_r.json.return_value = {'name': 'Attack on Titan', 'id': 1429}
@@ -62,9 +62,9 @@ def test_get_show_title_returns_name(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_get_show_title_returns_none_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   with patch('integrations.tmdb.fetch_with_retry', side_effect=Exception('timeout')):
     result = tmdb.get_show_title(9999)
@@ -73,9 +73,9 @@ def test_get_show_title_returns_none_on_http_error(monkeypatch: pytest.MonkeyPat
 
 
 def test_get_show_title_returns_none_on_missing_name(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   mock_r = MagicMock()
   mock_r.status_code = 200
   mock_r.json.return_value = {}
@@ -90,9 +90,9 @@ def test_get_show_title_returns_none_on_missing_name(monkeypatch: pytest.MonkeyP
 
 
 def test_get_movie_title_returns_title(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   mock_r = MagicMock()
   mock_r.status_code = 200
   mock_r.json.return_value = {'title': 'Inception', 'id': 27205}
@@ -104,9 +104,9 @@ def test_get_movie_title_returns_title(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_get_movie_title_returns_none_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   with patch('integrations.tmdb.fetch_with_retry', side_effect=Exception('timeout')):
     result = tmdb.get_movie_title(27205)
@@ -118,9 +118,9 @@ def test_get_movie_title_returns_none_on_error(monkeypatch: pytest.MonkeyPatch) 
 
 
 def test_find_episode_by_tvdb_id_returns_season_episode_title(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   mock_r = MagicMock()
   mock_r.status_code = 200
   mock_r.json.return_value = {
@@ -136,9 +136,9 @@ def test_find_episode_by_tvdb_id_returns_season_episode_title(monkeypatch: pytes
 
 
 def test_find_episode_by_tvdb_id_returns_none_on_empty_results(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   mock_r = MagicMock()
   mock_r.status_code = 200
   mock_r.json.return_value = {'tv_episode_results': []}
@@ -150,9 +150,9 @@ def test_find_episode_by_tvdb_id_returns_none_on_empty_results(monkeypatch: pyte
 
 
 def test_find_episode_by_tvdb_id_returns_none_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   with patch('integrations.tmdb.fetch_with_retry', side_effect=Exception('timeout')):
     result = tmdb.find_episode_by_tvdb_id(8765432)
@@ -161,9 +161,9 @@ def test_find_episode_by_tvdb_id_returns_none_on_error(monkeypatch: pytest.Monke
 
 
 def test_find_episode_by_tvdb_id_empty_title_returns_empty_string(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   mock_r = MagicMock()
   mock_r.status_code = 200
   mock_r.json.return_value = {
@@ -180,9 +180,9 @@ def test_find_episode_by_tvdb_id_empty_title_returns_empty_string(monkeypatch: p
 
 
 def test_find_episode_by_imdb_id_returns_tuple(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   mock_r = MagicMock()
   mock_r.status_code = 200
   mock_r.json.return_value = {
@@ -201,9 +201,9 @@ def test_find_episode_by_imdb_id_returns_tuple(monkeypatch: pytest.MonkeyPatch) 
 
 
 def test_find_episode_by_imdb_id_returns_none_on_empty_results(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   mock_r = MagicMock()
   mock_r.status_code = 200
   mock_r.json.return_value = {'tv_episode_results': []}
@@ -215,9 +215,9 @@ def test_find_episode_by_imdb_id_returns_none_on_empty_results(monkeypatch: pyte
 
 
 def test_find_episode_by_imdb_id_returns_none_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   with patch('integrations.tmdb.fetch_with_retry', side_effect=Exception('timeout')):
     result = tmdb.find_episode_by_imdb_id('tt99999999')
@@ -229,9 +229,9 @@ def test_find_episode_by_imdb_id_returns_none_on_error(monkeypatch: pytest.Monke
 
 
 def test_search_show_by_title_returns_show_id(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   mock_r = MagicMock()
   mock_r.status_code = 200
   mock_r.json.return_value = {'results': [{'id': 95479, 'name': 'Jujutsu Kaisen'}]}
@@ -244,9 +244,9 @@ def test_search_show_by_title_returns_show_id(monkeypatch: pytest.MonkeyPatch) -
 
 
 def test_search_show_by_title_returns_none_on_empty_results(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   mock_r = MagicMock()
   mock_r.status_code = 200
   mock_r.json.return_value = {'results': []}
@@ -258,9 +258,9 @@ def test_search_show_by_title_returns_none_on_empty_results(monkeypatch: pytest.
 
 
 def test_search_show_by_title_returns_none_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   with patch('integrations.tmdb.fetch_with_retry', side_effect=Exception('timeout')):
     result = tmdb.search_show_by_title('Frieren')
@@ -272,9 +272,9 @@ def test_search_show_by_title_returns_none_on_error(monkeypatch: pytest.MonkeyPa
 
 
 def test_get_episode_by_number_returns_title_and_id(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   mock_r = MagicMock()
   mock_r.status_code = 200
   mock_r.json.return_value = {'id': 6827061, 'name': 'Perfect Preparation'}
@@ -287,9 +287,9 @@ def test_get_episode_by_number_returns_title_and_id(monkeypatch: pytest.MonkeyPa
 
 
 def test_get_episode_by_number_returns_none_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   with patch('integrations.tmdb.fetch_with_retry', side_effect=Exception('404')):
     result = tmdb.get_episode_by_number(95479, 99, 1)
@@ -301,9 +301,9 @@ def test_get_episode_by_number_returns_none_on_error(monkeypatch: pytest.MonkeyP
 
 
 def test_get_episode_group_position_returns_correct_season_episode(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   groups_r = MagicMock()
   groups_r.status_code = 200
@@ -326,9 +326,9 @@ def test_get_episode_group_position_returns_correct_season_episode(monkeypatch: 
 
 
 def test_get_episode_group_position_skips_specials_group(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   groups_r = MagicMock()
   groups_r.status_code = 200
@@ -349,9 +349,9 @@ def test_get_episode_group_position_skips_specials_group(monkeypatch: pytest.Mon
 
 
 def test_get_episode_group_position_no_type6_group(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   groups_r = MagicMock()
   groups_r.status_code = 200
@@ -364,9 +364,9 @@ def test_get_episode_group_position_no_type6_group(monkeypatch: pytest.MonkeyPat
 
 
 def test_get_episode_group_position_returns_none_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   with patch('integrations.tmdb.fetch_with_retry', side_effect=Exception('timeout')):
     result = tmdb.get_episode_group_position(209867, 9005)
@@ -403,9 +403,9 @@ def _group_fixture() -> tuple[MagicMock, MagicMock]:
 
 
 def test_find_episode_in_group_returns_title_and_id(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   groups_r, group_r = _group_fixture()
 
   with patch('integrations.tmdb.fetch_with_retry', side_effect=[groups_r, group_r]):
@@ -416,9 +416,9 @@ def test_find_episode_in_group_returns_title_and_id(monkeypatch: pytest.MonkeyPa
 
 
 def test_find_episode_in_group_season_1(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   groups_r, group_r = _group_fixture()
 
   with patch('integrations.tmdb.fetch_with_retry', side_effect=[groups_r, group_r]):
@@ -428,9 +428,9 @@ def test_find_episode_in_group_season_1(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 def test_find_episode_in_group_returns_none_when_season_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   groups_r, group_r = _group_fixture()
 
   with patch('integrations.tmdb.fetch_with_retry', side_effect=[groups_r, group_r]):
@@ -440,9 +440,9 @@ def test_find_episode_in_group_returns_none_when_season_not_found(monkeypatch: p
 
 
 def test_find_episode_in_group_returns_none_when_episode_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   groups_r, group_r = _group_fixture()
 
   with patch('integrations.tmdb.fetch_with_retry', side_effect=[groups_r, group_r]):
@@ -452,9 +452,9 @@ def test_find_episode_in_group_returns_none_when_episode_not_found(monkeypatch: 
 
 
 def test_find_episode_in_group_returns_none_when_no_type6_group(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   groups_r = MagicMock()
   groups_r.status_code = 200
   groups_r.json.return_value = {'results': [{'id': 'grp-xyz', 'type': 5}]}

--- a/tests/core/test_trakt.py
+++ b/tests/core/test_trakt.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-import config as _cfg
+import config as _config_mod
 import integrations.trakt as trakt
 import integrations.vestaboard as vb
 from exceptions import IntegrationDataUnavailableError
@@ -37,7 +37,7 @@ def config_with_tokens(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     f'expires_at = {int(time.time()) + 200000}\n'  # well above 24h threshold
   )
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'trakt': {
@@ -58,7 +58,7 @@ def config_without_tokens(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Pa
   """Return a tmp config.toml without trakt tokens."""
   cfg_file = tmp_path / 'config.toml'
   cfg_file.write_text('[trakt]\nclient_id = "test-id"\nclient_secret = "test-secret"\n')
-  monkeypatch.setattr(_cfg, '_config', {'trakt': {'client_id': 'test-id', 'client_secret': 'test-secret'}})
+  monkeypatch.setattr(_config_mod, '_config', {'trakt': {'client_id': 'test-id', 'client_secret': 'test-secret'}})
   monkeypatch.chdir(tmp_path)
   return cfg_file
 
@@ -91,7 +91,7 @@ def test_preflight_refreshes_near_expiry_token_at_startup(tmp_path: Path, monkey
     f'expires_at = {int(time.time()) + 3600}\n'  # 1 hour — inside 24h window
   )
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'trakt': {
@@ -123,7 +123,7 @@ def test_preflight_no_refresh_when_token_far_from_expiry(tmp_path: Path, monkeyp
     f'expires_at = {int(time.time()) + 200000}\n'  # well outside 24h
   )
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'trakt': {
@@ -157,7 +157,7 @@ def test_preflight_refresh_failure_clears_tokens_and_triggers_reauth(
     f'expires_at = {int(time.time()) + 3600}\n'
   )
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'trakt': {
@@ -180,8 +180,8 @@ def test_preflight_refresh_failure_clears_tokens_and_triggers_reauth(
       trakt.preflight()
 
   mock_auth.assert_called_once()
-  assert _cfg._config['trakt']['access_token'] == ''
-  assert _cfg._config['trakt']['refresh_token'] == ''
+  assert _config_mod._config['trakt']['access_token'] == ''
+  assert _config_mod._config['trakt']['refresh_token'] == ''
 
 
 def test_get_token_returns_access_token(config_with_tokens: Path) -> None:
@@ -212,7 +212,7 @@ def test_token_refresh_called_when_near_expiry(tmp_path: Path, monkeypatch: pyte
     f'expires_at = {int(time.time()) + 100}\n'  # within 24-hour threshold
   )
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'trakt': {
@@ -227,7 +227,7 @@ def test_token_refresh_called_when_near_expiry(tmp_path: Path, monkeypatch: pyte
   monkeypatch.chdir(tmp_path)
 
   def fake_refresh() -> None:
-    _cfg._config['trakt']['access_token'] = 'new-access'
+    _config_mod._config['trakt']['access_token'] = 'new-access'
 
   with patch.object(trakt, '_refresh_token', side_effect=fake_refresh) as mock_refresh:
     token = trakt._get_token()
@@ -249,7 +249,7 @@ def test_get_token_refresh_called_within_24h_window(tmp_path: Path, monkeypatch:
     f'expires_at = {expires}\n'
   )
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'trakt': {
@@ -283,7 +283,7 @@ def test_get_token_refresh_failure_clears_tokens_and_triggers_reauth(
     f'expires_at = {int(time.time()) + 100}\n'
   )
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'trakt': {
@@ -307,8 +307,8 @@ def test_get_token_refresh_failure_clears_tokens_and_triggers_reauth(
         trakt._get_token()
 
   mock_auth.assert_called_once()
-  assert _cfg._config['trakt']['access_token'] == ''
-  assert _cfg._config['trakt']['refresh_token'] == ''
+  assert _config_mod._config['trakt']['access_token'] == ''
+  assert _config_mod._config['trakt']['refresh_token'] == ''
 
 
 def test_get_token_refresh_failure_raises_unavailable_not_http_error(
@@ -325,7 +325,7 @@ def test_get_token_refresh_failure_raises_unavailable_not_http_error(
     f'expires_at = {int(time.time()) + 100}\n'
   )
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'trakt': {
@@ -374,10 +374,10 @@ def test_handle_api_401_refreshes_when_token_near_expiry(
   config_with_tokens: Path,
 ) -> None:
   """_handle_api_401 refreshes when expires_at is within the grace window."""
-  _cfg._config['trakt']['expires_at'] = int(time.time()) + 600  # 10 min — within 1h grace
+  _config_mod._config['trakt']['expires_at'] = int(time.time()) + 600  # 10 min — within 1h grace
 
   def fake_refresh() -> None:
-    _cfg._config['trakt']['access_token'] = 'refreshed-token'
+    _config_mod._config['trakt']['access_token'] = 'refreshed-token'
 
   with patch.object(trakt, '_refresh_token', side_effect=fake_refresh):
     token = trakt._handle_api_401()
@@ -389,7 +389,7 @@ def test_handle_api_401_refresh_failure_clears_tokens_and_triggers_reauth(
   config_with_tokens: Path,
 ) -> None:
   """_handle_api_401 clears tokens and starts re-auth when refresh fails."""
-  _cfg._config['trakt']['expires_at'] = int(time.time()) + 600  # near-expiry to trigger refresh path
+  _config_mod._config['trakt']['expires_at'] = int(time.time()) + 600  # near-expiry to trigger refresh path
   mock_resp = MagicMock()
   mock_resp.status_code = 400
   mock_resp.reason = 'Bad Request'
@@ -400,12 +400,12 @@ def test_handle_api_401_refresh_failure_clears_tokens_and_triggers_reauth(
         trakt._handle_api_401()
 
   mock_auth.assert_called_once()
-  assert _cfg._config['trakt']['access_token'] == ''
+  assert _config_mod._config['trakt']['access_token'] == ''
 
 
 def test_get_variables_calendar_401_retries_with_refreshed_token(config_with_tokens: Path) -> None:
   """A 401 from the calendar endpoint triggers a token refresh and retries when near expiry."""
-  _cfg._config['trakt']['expires_at'] = int(time.time()) + 600  # near-expiry
+  _config_mod._config['trakt']['expires_at'] = int(time.time()) + 600  # near-expiry
 
   unauth = MagicMock()
   unauth.status_code = 401
@@ -416,7 +416,7 @@ def test_get_variables_calendar_401_retries_with_refreshed_token(config_with_tok
   ok.json.return_value = _CALENDAR_RESPONSE
 
   def fake_refresh() -> None:
-    _cfg._config['trakt']['access_token'] = 'new-token'
+    _config_mod._config['trakt']['access_token'] = 'new-token'
 
   with patch.object(trakt, '_refresh_token', side_effect=fake_refresh):
     with patch('integrations.trakt.fetch_with_retry', side_effect=[unauth, ok]):
@@ -427,7 +427,7 @@ def test_get_variables_calendar_401_retries_with_refreshed_token(config_with_tok
 
 def test_get_variables_watching_401_retries_with_refreshed_token(config_with_tokens: Path) -> None:
   """A 401 from the watching endpoint triggers a token refresh and retries when near expiry."""
-  _cfg._config['trakt']['expires_at'] = int(time.time()) + 600  # near-expiry
+  _config_mod._config['trakt']['expires_at'] = int(time.time()) + 600  # near-expiry
 
   unauth = MagicMock()
   unauth.status_code = 401
@@ -442,7 +442,7 @@ def test_get_variables_watching_401_retries_with_refreshed_token(config_with_tok
   }
 
   def fake_refresh() -> None:
-    _cfg._config['trakt']['access_token'] = 'new-token'
+    _config_mod._config['trakt']['access_token'] = 'new-token'
 
   with patch.object(trakt, '_refresh_token', side_effect=fake_refresh):
     with patch('integrations.trakt.fetch_with_retry', side_effect=[unauth, ok]):
@@ -453,7 +453,7 @@ def test_get_variables_watching_401_retries_with_refreshed_token(config_with_tok
 
 def test_get_variables_next_up_401_retries_with_refreshed_token(config_with_tokens: Path) -> None:
   """A 401 from the watched/shows endpoint triggers a token refresh and retries when near expiry."""
-  _cfg._config['trakt']['expires_at'] = int(time.time()) + 600  # near-expiry
+  _config_mod._config['trakt']['expires_at'] = int(time.time()) + 600  # near-expiry
 
   unauth = MagicMock()
   unauth.status_code = 401
@@ -462,7 +462,7 @@ def test_get_variables_next_up_401_retries_with_refreshed_token(config_with_toke
   progress = _mock_progress_ok(_PROGRESS_WITH_NEXT)
 
   def fake_refresh() -> None:
-    _cfg._config['trakt']['access_token'] = 'new-token'
+    _config_mod._config['trakt']['access_token'] = 'new-token'
 
   with patch.object(trakt, '_refresh_token', side_effect=fake_refresh):
     with patch('integrations.trakt.fetch_with_retry', side_effect=[unauth, watched, progress]):
@@ -487,9 +487,9 @@ def test_store_tokens_writes_to_config(config_without_tokens: Path, monkeypatch:
 def test_write_tokens_errors_on_missing_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
   monkeypatch.chdir(tmp_path)
   # No config.toml in tmp_path
-  monkeypatch.setattr(_cfg, '_config', {'trakt': {}})
+  monkeypatch.setattr(_config_mod, '_config', {'trakt': {}})
   with pytest.raises(FileNotFoundError):
-    _cfg.write_section_values('trakt', {'access_token': 'x'})
+    _config_mod.write_section_values('trakt', {'access_token': 'x'})
 
 
 # --- token refresh HTTP ---
@@ -507,8 +507,8 @@ def test_token_refresh_updates_config(config_with_tokens: Path, monkeypatch: pyt
   with patch('requests.post', return_value=mock_response):
     trakt._refresh_token()
 
-  assert _cfg._config['trakt']['access_token'] == 'refreshed-access'
-  assert _cfg._config['trakt']['refresh_token'] == 'refreshed-refresh'
+  assert _config_mod._config['trakt']['access_token'] == 'refreshed-access'
+  assert _config_mod._config['trakt']['refresh_token'] == 'refreshed-refresh'
 
 
 def test_token_refresh_http_error_raised(config_with_tokens: Path) -> None:
@@ -615,9 +615,9 @@ def test_auth_thread_logs_error_on_denied(config_without_tokens: Path, caplog: p
 
 def test_canonicalize_episode_no_tmdb_uses_trakt_data(monkeypatch: pytest.MonkeyPatch) -> None:
   """Without TMDb configured, returns Trakt native title and episode numbers."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {})  # no [tmdb] section
+  monkeypatch.setattr(_config_mod, '_config', {})  # no [tmdb] section
 
   show_data = {'title': 'Attack on Titan', 'ids': {'tmdb': 1429}}
   ep_data = {'season': 1, 'number': 45, 'title': 'Above and Below', 'ids': {'tvdb': 8765432}}
@@ -632,9 +632,9 @@ def test_canonicalize_episode_no_tmdb_uses_trakt_data(monkeypatch: pytest.Monkey
 
 def test_canonicalize_episode_with_tmdb_uses_canonical_data(monkeypatch: pytest.MonkeyPatch) -> None:
   """With TMDb configured, returns canonical title and re-numbered episode."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   show_data = {'title': 'Attack on Titan', 'ids': {'tmdb': 1429}}
   ep_data = {'season': 1, 'number': 45, 'title': 'Wrong Title', 'ids': {'tvdb': 8765432}}
@@ -656,9 +656,9 @@ def test_canonicalize_episode_with_tmdb_uses_canonical_data(monkeypatch: pytest.
 
 def test_canonicalize_episode_tmdb_show_lookup_fails_uses_trakt_title(monkeypatch: pytest.MonkeyPatch) -> None:
   """When TMDb show lookup returns None, falls back to Trakt title."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   show_data = {'title': 'My Show', 'ids': {'tmdb': 9999}}
   ep_data = {'season': 2, 'number': 5, 'title': 'Pilot', 'ids': {}}
@@ -673,9 +673,9 @@ def test_canonicalize_episode_tmdb_show_lookup_fails_uses_trakt_title(monkeypatc
 
 def test_canonicalize_episode_missing_ids_skips_tmdb(monkeypatch: pytest.MonkeyPatch) -> None:
   """When show/episode have no ids dict, TMDb lookups are skipped gracefully."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   show_data = {'title': 'Great Show'}
   ep_data = {'season': 2, 'number': 5, 'title': 'The One With The Test'}
@@ -695,9 +695,9 @@ def test_canonicalize_episode_missing_ids_skips_tmdb(monkeypatch: pytest.MonkeyP
 
 def test_canonicalize_episode_show_id_mismatch_uses_trakt_se(monkeypatch: pytest.MonkeyPatch) -> None:
   """When resolved show_id doesn't match, falls back to Trakt S/E."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   show_data = {'title': 'My Anime', 'ids': {'tmdb': 1111}}
   ep_data = {'season': 1, 'number': 5, 'title': 'Episode Five', 'ids': {'tvdb': 5555555}}
@@ -717,9 +717,9 @@ def test_canonicalize_episode_show_id_mismatch_uses_trakt_se(monkeypatch: pytest
 
 def test_canonicalize_episode_missing_tmdb_show_id_skips_episode_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
   """When show has no tmdb ID, episode resolution via TVDb is skipped."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   show_data = {'title': 'No TMDb Show', 'ids': {'trakt': 42}}
   ep_data = {'season': 2, 'number': 3, 'title': 'An Episode', 'ids': {'tvdb': 7777777}}
@@ -734,9 +734,9 @@ def test_canonicalize_episode_missing_tmdb_show_id_skips_episode_resolution(monk
 
 def test_canonicalize_episode_uses_episode_group_position(monkeypatch: pytest.MonkeyPatch) -> None:
   """Episode group position overrides base TMDb S/E when available."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   show_data = {'title': 'Frieren', 'ids': {'tmdb': 209867}}
   ep_data = {'season': 1, 'number': 36, 'title': 'A Magnificent End', 'ids': {'tvdb': 11447771}}
@@ -756,9 +756,9 @@ def test_canonicalize_episode_uses_episode_group_position(monkeypatch: pytest.Mo
 
 def test_canonicalize_episode_falls_back_to_tmdb_base_when_group_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
   """When episode group returns None, uses base TMDb S/E."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   show_data = {'title': 'Some Show', 'ids': {'tmdb': 5555}}
   ep_data = {'season': 1, 'number': 10, 'title': 'Ep Ten', 'ids': {'tvdb': 1234567}}
@@ -776,9 +776,9 @@ def test_canonicalize_episode_falls_back_to_tmdb_base_when_group_unavailable(mon
 
 def test_canonicalize_episode_tmdb_empty_ep_title_keeps_trakt_title(monkeypatch: pytest.MonkeyPatch) -> None:
   """When TMDb returns an empty episode title, the Trakt title is kept."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   show_data = {'title': 'Frieren', 'ids': {'tmdb': 209867}}
   ep_data = {'season': 2, 'number': 9, 'title': 'Episode 9', 'ids': {'tvdb': 11447772}}
@@ -797,9 +797,9 @@ def test_canonicalize_episode_tmdb_empty_ep_title_keeps_trakt_title(monkeypatch:
 
 def test_canonicalize_episode_uses_imdb_fallback_when_no_tvdb_id(monkeypatch: pytest.MonkeyPatch) -> None:
   """When tvdb_ep_id is absent, imdb is tried as a fallback for S/E and title."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   show_data = {'title': 'Jujutsu Kaisen', 'ids': {'tmdb': 95479}}
   ep_data = {'season': 3, 'number': 4, 'title': 'Episode 4', 'ids': {'imdb': 'tt39370459'}}
@@ -826,9 +826,9 @@ def test_canonicalize_episode_imdb_fallback_show_id_mismatch_keeps_trakt_se(
   monkeypatch: pytest.MonkeyPatch,
 ) -> None:
   """When imdb fallback resolves a different show, Trakt S/E and title are kept."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   show_data = {'title': 'My Anime', 'ids': {'tmdb': 1111}}
   ep_data = {'season': 2, 'number': 3, 'title': 'Real Title', 'ids': {'imdb': 'tt99999999'}}
@@ -852,9 +852,9 @@ def test_canonicalize_episode_imdb_fallback_show_id_mismatch_keeps_trakt_se(
 
 
 def test_canonicalize_movie_no_tmdb_uses_trakt_title(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {})
+  monkeypatch.setattr(_config_mod, '_config', {})
 
   result = trakt._canonicalize_movie({'title': 'Inception', 'ids': {'tmdb': 27205}})  # noqa: SLF001
 
@@ -862,9 +862,9 @@ def test_canonicalize_movie_no_tmdb_uses_trakt_title(monkeypatch: pytest.MonkeyP
 
 
 def test_canonicalize_movie_with_tmdb_uses_canonical_title(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
 
   with patch('integrations.tmdb.get_movie_title', return_value='Inception') as mock_movie:
     result = trakt._canonicalize_movie({'title': 'inception', 'ids': {'tmdb': 27205}})  # noqa: SLF001

--- a/tests/core/test_vestaboard.py
+++ b/tests/core/test_vestaboard.py
@@ -470,18 +470,18 @@ def test_expand_format_escaped_brace_whole_line_not_expanded() -> None:
 
 
 def test_get_headers_uses_config_key(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'my-test-key'}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': 'my-test-key'}})
   headers = vb._get_headers()  # noqa: SLF001
   assert headers['X-Vestaboard-Read-Write-Key'] == 'my-test-key'
   assert headers['Content-Type'] == 'application/json'
 
 
 def test_get_headers_missing_key_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {})
+  monkeypatch.setattr(_config_mod, '_config', {})
   with pytest.raises(ValueError, match='vestaboard'):
     vb._get_headers()  # noqa: SLF001
 
@@ -490,9 +490,9 @@ def test_get_headers_missing_key_propagates(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 def test_get_state_returns_state(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': 'test-key'}})
   layout = [[0] * vb.model.cols for _ in range(vb.model.rows)]
   mock_resp = MagicMock()
   mock_resp.json.return_value = {
@@ -511,9 +511,9 @@ def test_get_state_returns_state(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_get_state_passes_auth_header(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'sentinel-key'}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': 'sentinel-key'}})
   layout = [[0] * vb.model.cols for _ in range(vb.model.rows)]
   mock_resp = MagicMock()
   mock_resp.json.return_value = {'currentMessage': {'id': 'x', 'appeared': 'y', 'layout': json.dumps(layout)}}
@@ -528,9 +528,9 @@ def test_get_state_passes_auth_header(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_set_state_posts_grid_to_api(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': 'test-key'}})
   mock_resp = MagicMock()
   mock_resp.status_code = 200
   mock_resp.raise_for_status.return_value = None
@@ -544,9 +544,9 @@ def test_set_state_posts_grid_to_api(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_set_state_raises_board_locked_on_423(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': 'test-key'}})
   mock_resp = MagicMock()
   mock_resp.status_code = 423
   with patch('integrations.vestaboard.requests.post', return_value=mock_resp):
@@ -555,9 +555,9 @@ def test_set_state_raises_board_locked_on_423(monkeypatch: pytest.MonkeyPatch) -
 
 
 def test_set_state_propagates_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'sentinel-key'}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': 'sentinel-key'}})
   mock_resp = MagicMock()
   mock_resp.status_code = 500
   mock_resp.reason = 'Internal Server Error'
@@ -568,9 +568,9 @@ def test_set_state_propagates_http_error(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 def test_set_state_http_error_does_not_leak_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'sentinel-key'}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': 'sentinel-key'}})
   mock_resp = MagicMock()
   mock_resp.status_code = 500
   mock_resp.reason = 'Internal Server Error'
@@ -582,9 +582,9 @@ def test_set_state_http_error_does_not_leak_api_key(monkeypatch: pytest.MonkeyPa
 
 
 def test_set_state_raises_duplicate_on_409(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': 'test-key'}})
   mock_resp = MagicMock()
   mock_resp.status_code = 409
   with patch('integrations.vestaboard.requests.post', return_value=mock_resp):
@@ -593,9 +593,9 @@ def test_set_state_raises_duplicate_on_409(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_get_state_raises_empty_board_on_404(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': 'test-key'}})
   mock_resp = MagicMock()
   mock_resp.status_code = 404
   with patch('integrations.vestaboard.requests.get', return_value=mock_resp):
@@ -604,9 +604,9 @@ def test_get_state_raises_empty_board_on_404(monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_get_state_http_error_does_not_leak_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'sentinel-key'}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': 'sentinel-key'}})
   mock_resp = MagicMock()
   mock_resp.status_code = 401
   mock_resp.reason = 'Unauthorized'
@@ -618,9 +618,9 @@ def test_get_state_http_error_does_not_leak_api_key(monkeypatch: pytest.MonkeyPa
 
 
 def test_set_state_passes_auth_header(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'sentinel-key'}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': 'sentinel-key'}})
   mock_resp = MagicMock()
   mock_resp.status_code = 200
   mock_resp.raise_for_status.return_value = None
@@ -631,9 +631,9 @@ def test_set_state_passes_auth_header(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_set_state_retries_on_429_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': 'test-key'}})
   rate_limited = MagicMock()
   rate_limited.status_code = 429
   ok = MagicMock()
@@ -649,9 +649,9 @@ def test_set_state_retries_on_429_then_succeeds(monkeypatch: pytest.MonkeyPatch)
 
 
 def test_set_state_raises_after_exhausted_429_retries(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': 'test-key'}})
   rate_limited = MagicMock()
   rate_limited.status_code = 429
   with (
@@ -664,9 +664,9 @@ def test_set_state_raises_after_exhausted_429_retries(monkeypatch: pytest.Monkey
 
 
 def test_set_state_logs_warning_on_429_retry(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': 'test-key'}})
   rate_limited = MagicMock()
   rate_limited.status_code = 429
   ok = MagicMock()
@@ -733,9 +733,9 @@ def test_render_does_not_call_api() -> None:
 
 
 def test_set_state_raw_posts_grid(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': 'test-key'}})
   grid = [[0] * vb.model.cols for _ in range(vb.model.rows)]
   mock_resp = MagicMock()
   mock_resp.status_code = 200
@@ -748,9 +748,9 @@ def test_set_state_raw_posts_grid(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_set_state_raw_raises_board_locked(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': 'test-key'}})
   mock_resp = MagicMock()
   mock_resp.status_code = 423
   with patch('integrations.vestaboard.requests.post', return_value=mock_resp):
@@ -760,9 +760,9 @@ def test_set_state_raw_raises_board_locked(monkeypatch: pytest.MonkeyPatch) -> N
 
 def test_set_state_calls_render_then_raw(monkeypatch: pytest.MonkeyPatch) -> None:
   """set_state() convenience wrapper calls render() then set_state_raw()."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': 'test-key'}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': 'test-key'}})
   mock_resp = MagicMock()
   mock_resp.status_code = 200
   mock_resp.raise_for_status.return_value = None

--- a/tests/core/test_weather.py
+++ b/tests/core/test_weather.py
@@ -22,10 +22,10 @@ def reset_caches() -> Generator[None, None, None]:
 @pytest.fixture()
 def weather_config_imperial(monkeypatch: pytest.MonkeyPatch) -> None:
   """Patch config with imperial weather settings."""
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'weather': {'city': 'san francisco', 'units': 'imperial'}},
   )
@@ -34,10 +34,10 @@ def weather_config_imperial(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture()
 def weather_config_metric(monkeypatch: pytest.MonkeyPatch) -> None:
   """Patch config with metric weather settings."""
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'weather': {'city': 'London', 'units': 'metric'}},
   )
@@ -46,10 +46,10 @@ def weather_config_metric(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture()
 def weather_config_no_units(monkeypatch: pytest.MonkeyPatch) -> None:
   """Patch config with no units key (should default to imperial)."""
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'weather': {'city': 'Chicago'}},
   )
@@ -196,9 +196,9 @@ def test_geocoding_cached_after_first_call(weather_config_imperial: None) -> Non
 
 def test_geocoding_uses_count2_with_country_code(monkeypatch: pytest.MonkeyPatch) -> None:
   """count=2 must be sent when a country code is present (Open-Meteo count=1+countryCode bug)."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'weather': {'city': 'Santa Clara, CA'}})
+  monkeypatch.setattr(_config_mod, '_config', {'weather': {'city': 'Santa Clara, CA'}})
   with patch('integrations.weather.fetch_with_retry', side_effect=[_mock_geocode(), _mock_forecast()]) as mock_fetch:
     weather.get_variables()
   geocode_call = mock_fetch.call_args_list[0]
@@ -216,9 +216,9 @@ def test_geocoding_uses_count1_without_country_code(weather_config_imperial: Non
 
 
 def test_geocoding_not_found_raises_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'weather': {'city': 'Notaplace12345'}})
+  monkeypatch.setattr(_config_mod, '_config', {'weather': {'city': 'Notaplace12345'}})
   mock = MagicMock()
   mock.raise_for_status.return_value = None
   mock.json.return_value = {'results': []}
@@ -228,9 +228,9 @@ def test_geocoding_not_found_raises_unavailable(monkeypatch: pytest.MonkeyPatch)
 
 
 def test_geocoding_http_error_raises_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'weather': {'city': 'San Francisco'}})
+  monkeypatch.setattr(_config_mod, '_config', {'weather': {'city': 'San Francisco'}})
   err_resp = MagicMock()
   err_resp.status_code = 500
   err_resp.reason = 'Internal Server Error'
@@ -260,9 +260,9 @@ def test_forecast_http_error_raises_unavailable(weather_config_imperial: None) -
 
 
 def test_geocoding_timeout_raises_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'weather': {'city': 'San Francisco'}})
+  monkeypatch.setattr(_config_mod, '_config', {'weather': {'city': 'San Francisco'}})
   with patch('integrations.weather.fetch_with_retry', side_effect=requests.Timeout()):
     with pytest.raises(IntegrationDataUnavailableError):
       weather.get_variables()

--- a/tests/core/test_webhook.py
+++ b/tests/core/test_webhook.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-import config as _cfg  # noqa: E402
+import config as _config_mod  # noqa: E402
 import scheduler as _mod  # noqa: E402
 
 # ---------------------------------------------------------------------------
@@ -121,7 +121,7 @@ def reset_hold_interrupt() -> Generator[None, None, None]:
 def test_webhook_server_not_started_when_no_section(
   monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-  monkeypatch.setattr(_cfg, '_config', {})
+  monkeypatch.setattr(_config_mod, '_config', {})
   mock_sched = MagicMock()
   mock_sched.get_jobs.return_value = []
   with patch.object(_mod, '_start_webhook_server') as mock_start:
@@ -142,7 +142,7 @@ def test_webhook_server_not_started_when_no_section(
 def test_webhook_server_started_when_section_present(
   monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-  monkeypatch.setattr(_cfg, '_config', {'webhook': {'port': '8080'}})
+  monkeypatch.setattr(_config_mod, '_config', {'webhook': {'port': '8080'}})
   mock_sched = MagicMock()
   mock_sched.get_jobs.return_value = []
   with patch.object(_mod, '_start_webhook_server') as mock_start:
@@ -169,7 +169,7 @@ def test_valid_secret_returns_200() -> None:
   mock_mod = MagicMock()
   mock_mod.handle_webhook.return_value = None  # discard — just testing auth
 
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       server, port = _start_test_server()
       try:
@@ -214,7 +214,7 @@ def test_query_param_secret_accepted() -> None:
   mock_mod = MagicMock()
   mock_mod.handle_webhook.return_value = None
 
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       server, port = _start_test_server()
       try:
@@ -255,7 +255,7 @@ def test_header_takes_precedence_over_query_param() -> None:
   mock_mod = MagicMock()
   mock_mod.handle_webhook.return_value = None
 
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       server, port = _start_test_server()
       try:
@@ -284,7 +284,7 @@ def test_header_takes_precedence_over_query_param() -> None:
 
 
 def test_unknown_integration_returns_404() -> None:
-  with patch.dict(_cfg._config, _cred_config('notareal')):
+  with patch.dict(_config_mod._config, _cred_config('notareal')):
     server, port = _start_test_server()
     try:
       status, _ = _post(port, '/webhook/notareal')
@@ -318,7 +318,7 @@ def test_non_post_method_returns_501() -> None:
 def test_integration_without_handle_webhook_returns_404() -> None:
   mock_mod = MagicMock(spec=[])  # no handle_webhook attribute
 
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       server, port = _start_test_server()
       try:
@@ -338,7 +338,7 @@ def test_handle_webhook_none_returns_200_no_enqueue() -> None:
   mock_mod = MagicMock()
   mock_mod.handle_webhook.return_value = None
 
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       with patch.object(_mod, 'enqueue') as mock_enqueue:
         server, port = _start_test_server()
@@ -362,7 +362,7 @@ def test_handle_webhook_result_enqueues_message() -> None:
   mock_mod = MagicMock()
   mock_mod.handle_webhook.return_value = wm
 
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       with patch.object(_mod, 'enqueue') as mock_enqueue:
         server, port = _start_test_server()
@@ -394,7 +394,7 @@ def test_enqueue_uses_default_name_when_blank() -> None:
   mock_mod = MagicMock()
   mock_mod.handle_webhook.return_value = wm
 
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       with patch.object(_mod, 'enqueue') as mock_enqueue:
         server, port = _start_test_server()
@@ -423,7 +423,7 @@ def test_interrupt_false_does_not_set_event() -> None:
   mock_mod = MagicMock()
   mock_mod.handle_webhook.return_value = wm
 
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       with patch.object(_mod, 'enqueue'):
         server, port = _start_test_server()
@@ -446,7 +446,7 @@ def test_interrupt_true_sets_hold_interrupt_event() -> None:
   mock_mod = MagicMock()
   mock_mod.handle_webhook.return_value = wm
 
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       with patch.object(_mod, 'enqueue'):
         server, port = _start_test_server()
@@ -469,7 +469,7 @@ def test_interrupt_only_sets_hold_interrupt_without_enqueue() -> None:
   mock_mod = MagicMock()
   mock_mod.handle_webhook.return_value = wm
 
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       with patch.object(_mod, 'enqueue') as mock_enqueue:
         server, port = _start_test_server()
@@ -501,7 +501,7 @@ def test_interrupt_blocked_when_current_hold_is_high_priority() -> None:
     _mod._current_hold_priority = 8  # active high-priority hold
     _mod._current_hold_supersede_tag = 'plex'  # different source
 
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       with patch.object(_mod, 'enqueue'):
         server, port = _start_test_server()
@@ -534,7 +534,7 @@ def test_interrupt_bypasses_threshold_when_same_supersede_tag() -> None:
     _mod._current_hold_priority = 8  # active high-priority hold — same source
     _mod._current_hold_supersede_tag = 'plex'
 
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       with patch.object(_mod, 'enqueue'):
         server, port = _start_test_server()
@@ -563,7 +563,7 @@ def test_interrupt_blocked_for_different_tag_high_priority_hold() -> None:
     _mod._current_hold_priority = 8  # active high-priority hold — different source
     _mod._current_hold_supersede_tag = 'plex'
 
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       with patch.object(_mod, 'enqueue'):
         server, port = _start_test_server()
@@ -590,7 +590,7 @@ def test_interrupt_allowed_when_current_hold_is_low_priority() -> None:
   with _mod._current_hold_lock:
     _mod._current_hold_priority = 7  # active low-priority hold
 
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       with patch.object(_mod, 'enqueue'):
         server, port = _start_test_server()
@@ -617,7 +617,7 @@ def test_interrupt_only_blocked_when_current_hold_is_high_priority() -> None:
   with _mod._current_hold_lock:
     _mod._current_hold_priority = 8  # active high-priority hold
 
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       with patch.object(_mod, 'enqueue') as mock_enqueue:
         server, port = _start_test_server()
@@ -647,7 +647,7 @@ def test_interrupt_only_allowed_when_current_hold_is_low_priority() -> None:
   with _mod._current_hold_lock:
     _mod._current_hold_priority = 7  # active low-priority hold
 
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       with patch.object(_mod, 'enqueue') as mock_enqueue:
         server, port = _start_test_server()
@@ -674,7 +674,7 @@ def test_webhook_normal_indefinite_enqueues_with_indefinite_flag() -> None:
   mock_mod = MagicMock()
   mock_mod.handle_webhook.return_value = wm
 
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       with patch.object(_mod, 'enqueue') as mock_enqueue:
         server, port = _start_test_server()
@@ -696,7 +696,7 @@ def test_webhook_normal_indefinite_enqueues_with_indefinite_flag() -> None:
 
 
 def test_malformed_json_returns_400() -> None:
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     server, port = _start_test_server()
     try:
       conn = http.client.HTTPConnection('127.0.0.1', port, timeout=5)
@@ -721,7 +721,7 @@ def test_handle_webhook_exception_returns_500_server_survives() -> None:
   mock_mod = MagicMock()
   mock_mod.handle_webhook.side_effect = RuntimeError('boom')
 
-  with patch.dict(_cfg._config, _cred_config('bart')):
+  with patch.dict(_config_mod._config, _cred_config('bart')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       server, port = _start_test_server()
       try:
@@ -745,7 +745,7 @@ def test_credential_autogenerated_when_absent(
   config_file = tmp_path / 'config.toml'
   config_file.write_text('[webhook]\nport = 8080\n')
   monkeypatch.chdir(tmp_path)
-  monkeypatch.setattr(_cfg, '_config', {'webhook': {'port': '8080'}})
+  monkeypatch.setattr(_config_mod, '_config', {'webhook': {'port': '8080'}})
 
   with patch('scheduler.HTTPServer') as mock_http:
     mock_http.return_value = MagicMock()
@@ -753,7 +753,7 @@ def test_credential_autogenerated_when_absent(
       _mod._start_webhook_server()
 
   assert 'auto-generated' in caplog.text.lower()
-  creds = _cfg._config.get('webhook', {}).get('credentials', {})
+  creds = _config_mod._config.get('webhook', {}).get('credentials', {})
   assert creds  # at least one credential was created
 
 
@@ -767,7 +767,7 @@ def test_existing_credential_not_regenerated(
   )
   monkeypatch.chdir(tmp_path)
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'webhook': {
@@ -784,7 +784,7 @@ def test_existing_credential_not_regenerated(
 
   # plex should not be regenerated.
   assert "auto-generated for 'plex'" not in caplog.text
-  assert _cfg._config['webhook']['credentials']['plex']['secret_hash'] == existing_hash
+  assert _config_mod._config['webhook']['credentials']['plex']['secret_hash'] == existing_hash
 
 
 def test_message_admin_autogenerated_even_when_friends_present(
@@ -795,7 +795,7 @@ def test_message_admin_autogenerated_even_when_friends_present(
   config_file.write_text('[webhook]\nport = 8080\n')
   monkeypatch.chdir(tmp_path)
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'webhook': {
@@ -817,7 +817,7 @@ def test_message_admin_autogenerated_even_when_friends_present(
       _mod._start_webhook_server()
 
   assert "auto-generated for 'message'" in caplog.text
-  assert 'admin' in _cfg.get_credentials('message')
+  assert 'admin' in _config_mod.get_credentials('message')
 
 
 def test_old_flat_message_credentials_auto_migrated_on_startup(
@@ -832,7 +832,7 @@ def test_old_flat_message_credentials_auto_migrated_on_startup(
   )
   monkeypatch.chdir(tmp_path)
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'webhook': {
@@ -869,7 +869,7 @@ def test_multipart_payload_field_is_parsed_as_json() -> None:
   mock_mod = MagicMock()
   mock_mod.handle_webhook.return_value = None
 
-  with patch.dict(_cfg._config, _cred_config('plex')):
+  with patch.dict(_config_mod._config, _cred_config('plex')):
     with patch.object(_mod, '_get_integration', return_value=mock_mod):
       server, port = _start_test_server()
       try:
@@ -885,7 +885,7 @@ def test_multipart_payload_field_is_parsed_as_json() -> None:
 def test_multipart_missing_payload_field_returns_400() -> None:
   body = f'--{_BOUNDARY}\r\nContent-Disposition: form-data; name="other"\r\n\r\nvalue\r\n--{_BOUNDARY}--\r\n'.encode()
 
-  with patch.dict(_cfg._config, _cred_config('plex')):
+  with patch.dict(_config_mod._config, _cred_config('plex')):
     server, port = _start_test_server()
     try:
       conn = http.client.HTTPConnection('127.0.0.1', port, timeout=5)
@@ -906,7 +906,7 @@ def test_multipart_missing_payload_field_returns_400() -> None:
 
 
 def test_multipart_invalid_json_in_payload_returns_400() -> None:
-  with patch.dict(_cfg._config, _cred_config('plex')):
+  with patch.dict(_config_mod._config, _cred_config('plex')):
     server, port = _start_test_server()
     try:
       status, _ = _post_multipart(port, '/webhook/plex', 'not json{')

--- a/tests/integrations/test_bart.py
+++ b/tests/integrations/test_bart.py
@@ -249,10 +249,10 @@ def test_fetch_dest_colors_raises_on_http_error() -> None:
 
 @pytest.fixture()
 def bart_env(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'bart': {'api_key': 'testkey', 'station': 'MLPT', 'line1_dest': 'DALY'}},
   )
@@ -282,17 +282,17 @@ def test_get_variables_no_service_when_dest_absent(bart_env: None) -> None:
 
 
 def test_get_variables_missing_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {})
+  monkeypatch.setattr(_config_mod, '_config', {})
   with pytest.raises(ValueError, match='api_key'):
     bart.get_variables()
 
 
 def test_get_variables_missing_station(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'bart': {'api_key': 'testkey'}})
+  monkeypatch.setattr(_config_mod, '_config', {'bart': {'api_key': 'testkey'}})
   with pytest.raises(ValueError, match='station'):
     bart.get_variables()
 
@@ -309,9 +309,9 @@ def test_get_variables_matches_by_abbreviation_code(bart_env: None) -> None:
 
 
 def test_get_variables_code_matching_is_case_insensitive(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'bart': {'api_key': 'testkey', 'station': 'MLPT', 'line1_dest': 'daly'}})
+  monkeypatch.setattr(_config_mod, '_config', {'bart': {'api_key': 'testkey', 'station': 'MLPT', 'line1_dest': 'daly'}})
   mock_resp = MagicMock()
   mock_resp.json.return_value = _FAKE_ETD
   mock_resp.raise_for_status.return_value = None
@@ -321,9 +321,9 @@ def test_get_variables_code_matching_is_case_insensitive(monkeypatch: pytest.Mon
 
 
 def test_get_variables_unknown_code_shows_no_service(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'bart': {'api_key': 'testkey', 'station': 'MLPT', 'line1_dest': 'ZZZZ'}})
+  monkeypatch.setattr(_config_mod, '_config', {'bart': {'api_key': 'testkey', 'station': 'MLPT', 'line1_dest': 'ZZZZ'}})
   mock_resp = MagicMock()
   mock_resp.json.return_value = _FAKE_ETD
   mock_resp.raise_for_status.return_value = None
@@ -394,10 +394,10 @@ _FAKE_ETD_TWO_DESTS: dict[str, Any] = {
 
 
 def test_get_variables_two_lines(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'bart': {'api_key': 'testkey', 'station': 'MLPT', 'line1_dest': 'DALY', 'line2_dest': 'BERY'}},
   )
@@ -413,10 +413,10 @@ def test_get_variables_two_lines(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_get_variables_http_error_does_not_leak_key(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   api_key = 'supersecretkey99'
-  monkeypatch.setattr(_cfg, '_config', {'bart': {'api_key': api_key, 'station': 'MLPT', 'line1_dest': 'DALY'}})
+  monkeypatch.setattr(_config_mod, '_config', {'bart': {'api_key': api_key, 'station': 'MLPT', 'line1_dest': 'DALY'}})
   mock_resp = MagicMock()
   mock_resp.status_code = 401
   mock_resp.reason = 'Unauthorized'

--- a/tests/integrations/test_bart_integration.py
+++ b/tests/integrations/test_bart_integration.py
@@ -10,7 +10,7 @@ import os
 
 import pytest
 
-import config as _cfg
+import config as _config_mod
 import integrations.bart as bart
 import integrations.vestaboard as vb
 
@@ -20,7 +20,7 @@ import integrations.vestaboard as vb
 def test_get_variables_real_api(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
   """get_variables() returns a valid variables dict from the live BART API."""
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'bart': {

--- a/tests/integrations/test_calendar_integration.py
+++ b/tests/integrations/test_calendar_integration.py
@@ -15,7 +15,7 @@ from typing import Generator
 
 import pytest
 
-import config as _cfg
+import config as _config_mod
 import integrations.calendar as calendar
 from exceptions import IntegrationDataUnavailableError
 
@@ -37,7 +37,7 @@ def reset_caches() -> Generator[None, None, None]:
 @pytest.mark.require_env('CALENDAR_URL')
 def test_ics_mode_real_feed(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
   """get_variables() returns valid events or raises cleanly from a real .ics feed."""
-  monkeypatch.setattr(_cfg, '_config', {'calendar': {'urls': [os.environ['CALENDAR_URL']]}, 'scheduler': {}})
+  monkeypatch.setattr(_config_mod, '_config', {'calendar': {'urls': [os.environ['CALENDAR_URL']]}, 'scheduler': {}})
 
   try:
     result = calendar.get_variables()
@@ -56,7 +56,7 @@ def test_ics_mode_real_feed(require_env: None, monkeypatch: pytest.MonkeyPatch) 
 def test_caldav_mode_real_icloud(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
   """get_variables() connects to a real CalDAV server and returns valid events or raises cleanly."""
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'calendar': {
@@ -84,7 +84,7 @@ def test_caldav_mode_real_icloud(require_env: None, monkeypatch: pytest.MonkeyPa
 def test_birthdays_mode_real_icloud(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
   """get_variables_birthdays() connects to real iCloud Contacts and returns valid results."""
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'calendar': {

--- a/tests/integrations/test_discogs_integration.py
+++ b/tests/integrations/test_discogs_integration.py
@@ -11,7 +11,7 @@ from typing import Generator
 
 import pytest
 
-import config as _cfg
+import config as _config_mod
 import integrations.discogs as discogs
 
 
@@ -28,7 +28,7 @@ def reset_caches() -> Generator[None, None, None]:
 @pytest.mark.require_env('DISCOGS_TOKEN')
 def test_get_variables_returns_artist_and_album(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
   """get_variables() returns a valid variables dict from the live Discogs API."""
-  monkeypatch.setattr(_cfg, '_config', {'discogs': {'token': os.environ['DISCOGS_TOKEN']}})
+  monkeypatch.setattr(_config_mod, '_config', {'discogs': {'token': os.environ['DISCOGS_TOKEN']}})
 
   result = discogs.get_variables()
 

--- a/tests/integrations/test_diving_integration.py
+++ b/tests/integrations/test_diving_integration.py
@@ -14,7 +14,7 @@ import os
 
 import pytest
 
-import config as _cfg
+import config as _config_mod
 import integrations.diving as dc
 
 
@@ -23,7 +23,7 @@ import integrations.diving as dc
 def test_ndbc_get_variables(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
   """get_variables() returns valid variables from the live NDBC API."""
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'diving': {
@@ -63,7 +63,7 @@ def test_ndbc_get_variables(require_env: None, monkeypatch: pytest.MonkeyPatch) 
 def test_openmeteo_fallback_get_variables(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
   """get_variables() returns valid variables from the live Open-Meteo APIs."""
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'diving': {

--- a/tests/integrations/test_morning_integration.py
+++ b/tests/integrations/test_morning_integration.py
@@ -9,7 +9,7 @@ The morning integration has no env vars of its own; it reuses [weather] config.
 
 import pytest
 
-import config as _cfg
+import config as _config_mod
 import integrations.morning as morning
 import integrations.weather as weather
 
@@ -32,7 +32,7 @@ def _count_visual_width(row: str) -> int:
 @pytest.mark.integration
 def test_get_variables_live(monkeypatch: pytest.MonkeyPatch) -> None:
   """get_variables() returns a valid 7-wide visual using live Open-Meteo data."""
-  monkeypatch.setattr(_cfg, '_config', {'weather': {'city': 'San Francisco', 'units': 'imperial'}})
+  monkeypatch.setattr(_config_mod, '_config', {'weather': {'city': 'San Francisco', 'units': 'imperial'}})
   weather._geocode_cache = None
   weather._forecast_cache = None
 

--- a/tests/integrations/test_parcel_integration.py
+++ b/tests/integrations/test_parcel_integration.py
@@ -12,7 +12,7 @@ import os
 
 import pytest
 
-import config as _cfg
+import config as _config_mod
 import integrations.parcel as pc
 from exceptions import IntegrationDataUnavailableError
 
@@ -26,7 +26,7 @@ def test_get_variables_or_no_deliveries(require_env: None, monkeypatch: pytest.M
   The test verifies the API call succeeds either way.
   """
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'parcel': {'api_key': os.environ['PARCEL_API_KEY']}},
   )

--- a/tests/integrations/test_tmdb_integration.py
+++ b/tests/integrations/test_tmdb_integration.py
@@ -10,14 +10,14 @@ import os
 
 import pytest
 
-import config as _cfg
+import config as _config_mod
 import integrations.tmdb as tmdb
 
 
 def _patch_config(monkeypatch: pytest.MonkeyPatch) -> None:
   """Inject real API credentials from env into the in-memory config."""
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'tmdb': {'api_read_access_token': os.environ['TMDB_API_READ_ACCESS_TOKEN']}},
   )

--- a/tests/integrations/test_trakt_integration.py
+++ b/tests/integrations/test_trakt_integration.py
@@ -13,7 +13,7 @@ import time
 
 import pytest
 
-import config as _cfg
+import config as _config_mod
 import integrations.trakt as trakt
 from exceptions import IntegrationDataUnavailableError
 
@@ -21,7 +21,7 @@ from exceptions import IntegrationDataUnavailableError
 def _patch_config(monkeypatch: pytest.MonkeyPatch) -> None:
   """Inject real API credentials from env into the in-memory config."""
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'trakt': {
@@ -37,7 +37,7 @@ def _patch_config(monkeypatch: pytest.MonkeyPatch) -> None:
   )
   # Prevent any config writes (e.g. _clear_tokens after a failed refresh) from
   # touching the filesystem — config.toml does not exist in CI.
-  monkeypatch.setattr(_cfg, 'write_section_values', lambda section, values: None)
+  monkeypatch.setattr(_config_mod, 'write_section_values', lambda section, values: None)
 
 
 @pytest.mark.integration

--- a/tests/integrations/test_uptimerobot_integration.py
+++ b/tests/integrations/test_uptimerobot_integration.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-import config as _cfg
+import config as _config_mod
 import integrations.uptimerobot as uptimerobot
 
 
@@ -17,7 +17,7 @@ def test_get_variables(require_env: None, monkeypatch: pytest.MonkeyPatch) -> No
   """
   from exceptions import IntegrationDataUnavailableError
 
-  monkeypatch.setattr(_cfg, '_config', {'uptimerobot': {'api_key': os.environ['UPTIMEROBOT_API_KEY']}})
+  monkeypatch.setattr(_config_mod, '_config', {'uptimerobot': {'api_key': os.environ['UPTIMEROBOT_API_KEY']}})
   uptimerobot._cache = None
   uptimerobot._first_seen_down.clear()
 

--- a/tests/integrations/test_vestaboard_integration.py
+++ b/tests/integrations/test_vestaboard_integration.py
@@ -12,7 +12,7 @@ import time
 
 import pytest
 
-import config as _cfg
+import config as _config_mod
 import integrations.vestaboard as vb
 
 
@@ -20,7 +20,7 @@ import integrations.vestaboard as vb
 @pytest.mark.require_env('VESTABOARD_VIRTUAL_API_KEY')
 def test_set_state_real_api(require_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
   """set_state() successfully writes a message to the live virtual board."""
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': os.environ['VESTABOARD_VIRTUAL_API_KEY']}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': os.environ['VESTABOARD_VIRTUAL_API_KEY']}})
 
   # Use the last 4 digits of the epoch to make each run unique — the virtual
   # board returns 409 if you POST the same content as the current message.
@@ -35,7 +35,7 @@ def test_get_state_real_api(require_env: None, monkeypatch: pytest.MonkeyPatch) 
 
   Relies on test_set_state_real_api having run first so the board has state.
   """
-  monkeypatch.setattr(_cfg, '_config', {'vestaboard': {'api_key': os.environ['VESTABOARD_VIRTUAL_API_KEY']}})
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': os.environ['VESTABOARD_VIRTUAL_API_KEY']}})
 
   state = vb.get_state()
 

--- a/tests/integrations/test_weather_integration.py
+++ b/tests/integrations/test_weather_integration.py
@@ -7,7 +7,7 @@ No API key required. Open-Meteo is free for non-commercial use.
 
 import pytest
 
-import config as _cfg
+import config as _config_mod
 import integrations.vestaboard as vb
 import integrations.weather as weather
 
@@ -16,7 +16,7 @@ import integrations.weather as weather
 def test_get_variables_returns_expected_keys(monkeypatch: pytest.MonkeyPatch) -> None:
   """get_variables() returns a valid variables dict from the live Open-Meteo API."""
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'weather': {'city': 'San Francisco', 'units': 'imperial'}},
   )

--- a/tests/integrations/test_ynab_integration.py
+++ b/tests/integrations/test_ynab_integration.py
@@ -15,7 +15,7 @@ import os
 
 import pytest
 
-import config as _cfg
+import config as _config_mod
 import integrations.ynab as ynab
 
 
@@ -28,7 +28,7 @@ def test_get_variables(require_env: None, monkeypatch: pytest.MonkeyPatch) -> No
   if budget_id:
     cfg['ynab']['budget_id'] = budget_id
 
-  monkeypatch.setattr(_cfg, '_config', cfg)
+  monkeypatch.setattr(_config_mod, '_config', cfg)
   ynab._cache = None
   ynab._resolved_budget_id = None
 

--- a/tests/integrations/test_youtube_integration.py
+++ b/tests/integrations/test_youtube_integration.py
@@ -20,7 +20,7 @@ import time
 import pytest
 import requests
 
-import config as _cfg
+import config as _config_mod
 import integrations.google as google
 import integrations.youtube as youtube
 from exceptions import IntegrationDataUnavailableError
@@ -48,7 +48,7 @@ def _patch_config(monkeypatch: pytest.MonkeyPatch) -> None:
   """Inject real API credentials from env into the in-memory config."""
   access_token = _obtain_access_token()
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'google': {
@@ -60,7 +60,7 @@ def _patch_config(monkeypatch: pytest.MonkeyPatch) -> None:
       }
     },
   )
-  monkeypatch.setattr(_cfg, 'write_section_values', lambda section, values: None)
+  monkeypatch.setattr(_config_mod, 'write_section_values', lambda section, values: None)
 
 
 @pytest.mark.integration

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-import config as _cfg
+import config as _config_mod
 from integrations.calendar import _resolve_display_name
 
 # ── _resolve_display_name ──────────────────────────────────────────────────────
@@ -133,7 +133,7 @@ def test_get_variables_birthdays_today_format(
 ) -> None:
   import integrations.calendar as cal
 
-  monkeypatch.setattr(_cfg, '_config', {'calendar': {'carddav_url': 'x', 'username': 'u', 'password': 'p'}})
+  monkeypatch.setattr(_config_mod, '_config', {'calendar': {'carddav_url': 'x', 'username': 'u', 'password': 'p'}})
   today = date.today()
   mock_fetch.return_value = [('JAY', today.month, today.day)]
 
@@ -155,7 +155,7 @@ def test_get_variables_birthdays_future_format(
 ) -> None:
   import integrations.calendar as cal
 
-  monkeypatch.setattr(_cfg, '_config', {'calendar': {'carddav_url': 'x', 'username': 'u', 'password': 'p'}})
+  monkeypatch.setattr(_config_mod, '_config', {'calendar': {'carddav_url': 'x', 'username': 'u', 'password': 'p'}})
   # Use a fixed "today" of 2026-03-14 (Saturday) and a birthday 2 days later (Monday).
   fixed_today = date(2026, 3, 14)
   mock_fetch.return_value = [('JANE S', 3, 16)]  # March 16 = Monday
@@ -178,7 +178,7 @@ def test_get_variables_birthdays_sorted_by_days_ahead(
 ) -> None:
   import integrations.calendar as cal
 
-  monkeypatch.setattr(_cfg, '_config', {'calendar': {'carddav_url': 'x', 'username': 'u', 'password': 'p'}})
+  monkeypatch.setattr(_config_mod, '_config', {'calendar': {'carddav_url': 'x', 'username': 'u', 'password': 'p'}})
   fixed_today = date(2026, 3, 14)
   # Two contacts: one in 3 days, one in 1 day.
   mock_fetch.return_value = [('FAR A', 3, 17), ('NEAR B', 3, 15)]
@@ -203,7 +203,7 @@ def test_get_variables_self_birthday_uses_display_name(
   import integrations.calendar as cal
 
   today = date.today()
-  monkeypatch.setattr(_cfg, '_config', {'calendar': {'carddav_url': 'x', 'username': 'u', 'password': 'p'}})
+  monkeypatch.setattr(_config_mod, '_config', {'calendar': {'carddav_url': 'x', 'username': 'u', 'password': 'p'}})
   mock_self.return_value = ('JAY', today.month, today.day)
 
   with patch.object(cal, '_get_now', return_value=MagicMock(date=lambda: today)):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -530,6 +530,76 @@ def test_delete_config_section_missing_file_raises(
 # --- migrate_message_credentials ---
 
 
+# --- migrate_quiet_config ---
+
+
+def test_migrate_quiet_config_rewrites_active_true(
+  tmp_path: Path,
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  content = '[scheduler]\nmodel = "note"\n\n[scheduler.quiet]\nactive = true\n'
+  cfg = _setup_wcs(tmp_path, monkeypatch, content)
+  monkeypatch.setattr(_mod, '_config', {'scheduler': {'model': 'note', 'quiet': {'active': True}}})
+  _mod.migrate_quiet_config()
+  text = cfg.read_text()
+  assert '[scheduler.quiet]' not in text
+  assert 'quiet = true' in text
+  assert _mod._config['scheduler'].get('quiet') is True  # noqa: SLF001
+
+
+def test_migrate_quiet_config_rewrites_active_false(
+  tmp_path: Path,
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  content = '[scheduler]\nmodel = "note"\n\n[scheduler.quiet]\nactive = false\n'
+  cfg = _setup_wcs(tmp_path, monkeypatch, content)
+  monkeypatch.setattr(_mod, '_config', {'scheduler': {'model': 'note', 'quiet': {'active': False}}})
+  _mod.migrate_quiet_config()
+  text = cfg.read_text()
+  assert '[scheduler.quiet]' not in text
+  assert 'quiet = false' in text
+
+
+def test_migrate_quiet_config_noop_when_already_flat(
+  tmp_path: Path,
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  content = '[scheduler]\nquiet = true\n'
+  cfg = _setup_wcs(tmp_path, monkeypatch, content)
+  monkeypatch.setattr(_mod, '_config', {'scheduler': {'quiet': True}})
+  _mod.migrate_quiet_config()
+  assert cfg.read_text() == content
+
+
+def test_migrate_quiet_config_noop_when_absent(
+  tmp_path: Path,
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  content = '[scheduler]\nmodel = "note"\n'
+  cfg = _setup_wcs(tmp_path, monkeypatch, content)
+  monkeypatch.setattr(_mod, '_config', {'scheduler': {'model': 'note'}})
+  _mod.migrate_quiet_config()
+  assert cfg.read_text() == content
+
+
+def test_migrate_quiet_config_logs_deprecation_warning(
+  tmp_path: Path,
+  monkeypatch: pytest.MonkeyPatch,
+  caplog: pytest.LogCaptureFixture,
+) -> None:
+  content = '[scheduler]\nmodel = "note"\n\n[scheduler.quiet]\nactive = true\n'
+  _setup_wcs(tmp_path, monkeypatch, content)
+  monkeypatch.setattr(_mod, '_config', {'scheduler': {'model': 'note', 'quiet': {'active': True}}})
+  import logging
+
+  with caplog.at_level(logging.WARNING, logger='config'):
+    _mod.migrate_quiet_config()
+  assert 'deprecated' in caplog.text.lower()
+
+
+# --- migrate_message_credentials ---
+
+
 def test_migrate_message_credentials_rewrites_friend_to_nested_path(
   tmp_path: Path,
   monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_diving.py
+++ b/tests/test_diving.py
@@ -301,9 +301,9 @@ def _patched_config(station_id: str = '46042', units: str = 'imperial') -> dict:
 
 def test_cache_hit_avoids_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
 
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
 
   cached_value: dict = {'header': [['[G] WATER 55F']], 'swell': [['SWELL 1.5FT 14S']], 'wind': [['WIND 10KT W']]}
   dc._cache = dc.CacheEntry(cached_value)  # type: ignore[attr-defined]
@@ -317,9 +317,9 @@ def test_cache_hit_avoids_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_cache_miss_fetches(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   dc._cache = None
 
   mock_resp = MagicMock()
@@ -338,9 +338,9 @@ def test_cache_miss_fetches(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_expired_cache_fetches_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
   import time
 
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
 
   stale_value: dict = {'header': [['[G] WATER 55F']], 'swell': [['SWELL 1.5FT 14S']], 'wind': [['WIND 10KT W']]}
   dc._cache = dc.CacheEntry(stale_value)  # type: ignore[attr-defined]
@@ -363,9 +363,9 @@ def test_stale_cache_served_on_fetch_failure(monkeypatch: pytest.MonkeyPatch) ->
 
   import requests as _requests
 
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
 
   stale_value: dict = {'header': [['[Y] WATER 55F']], 'swell': [['SWELL 1.5FT 14S']], 'wind': [['WIND 10KT W']]}
   dc._cache = dc.CacheEntry(stale_value)  # type: ignore[attr-defined]
@@ -384,9 +384,9 @@ def test_stale_cache_served_on_fetch_failure(monkeypatch: pytest.MonkeyPatch) ->
 def test_no_cache_on_fetch_failure_raises(monkeypatch: pytest.MonkeyPatch) -> None:
   import requests as _requests
 
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   dc._cache = None
 
   with patch(
@@ -403,10 +403,10 @@ def test_no_cache_on_fetch_failure_raises(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 def test_get_variables_uses_openmeteo_when_no_station(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'diving': {'latitude': '36.6', 'longitude': '-121.9', 'units': 'imperial'}},
   )
@@ -423,9 +423,9 @@ def test_get_variables_uses_openmeteo_when_no_station(monkeypatch: pytest.Monkey
 
 
 def test_get_variables_imperial_units(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config(units='imperial'))
+  monkeypatch.setattr(_config_mod, '_config', _patched_config(units='imperial'))
   dc._cache = None
 
   mock_resp = MagicMock()
@@ -444,9 +444,9 @@ def test_get_variables_imperial_units(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_get_variables_metric_units(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config(units='metric'))
+  monkeypatch.setattr(_config_mod, '_config', _patched_config(units='metric'))
   dc._cache = None
 
   mock_resp = MagicMock()
@@ -463,9 +463,9 @@ def test_get_variables_metric_units(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_get_variables_missing_data_shows_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   dc._cache = None
 
   mock_resp = MagicMock()
@@ -482,10 +482,10 @@ def test_get_variables_missing_data_shows_placeholder(monkeypatch: pytest.Monkey
 
 
 def test_get_variables_wind_always_in_knots(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   for units in ('imperial', 'metric'):
-    monkeypatch.setattr(_cfg, '_config', _patched_config(units=units))
+    monkeypatch.setattr(_config_mod, '_config', _patched_config(units=units))
     dc._cache = None
 
     mock_resp = MagicMock()
@@ -500,9 +500,9 @@ def test_get_variables_wind_always_in_knots(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 def test_get_variables_missing_lat_lon_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'diving': {}})
+  monkeypatch.setattr(_config_mod, '_config', {'diving': {}})
   dc._cache = None
 
   with pytest.raises(IntegrationDataUnavailableError, match='ndbc_station_id or latitude/longitude'):
@@ -522,17 +522,17 @@ def _last_dive_config(last_dived_on: str | None) -> dict:
 
 
 def test_get_variables_last_dive_no_key(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _last_dive_config(None))
+  monkeypatch.setattr(_config_mod, '_config', _last_dive_config(None))
   with pytest.raises(IntegrationDataUnavailableError, match='last_dived_on not set'):
     dc.get_variables_last_dive()
 
 
 def test_get_variables_last_dive_bad_format(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _last_dive_config('not-a-date'))
+  monkeypatch.setattr(_config_mod, '_config', _last_dive_config('not-a-date'))
   with pytest.raises(IntegrationDataUnavailableError, match='not a valid YYYY-MM-DD date'):
     dc.get_variables_last_dive()
 
@@ -541,9 +541,9 @@ def test_get_variables_last_dive_today(monkeypatch: pytest.MonkeyPatch) -> None:
   from datetime import date
   from unittest.mock import patch
 
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _last_dive_config('2026-03-12'))
+  monkeypatch.setattr(_config_mod, '_config', _last_dive_config('2026-03-12'))
   with patch('integrations.diving.datetime') as mock_dt:
     mock_dt.now.return_value.date.return_value = date(2026, 3, 12)
     result = dc.get_variables_last_dive()
@@ -554,9 +554,9 @@ def test_get_variables_last_dive_1_day(monkeypatch: pytest.MonkeyPatch) -> None:
   from datetime import date
   from unittest.mock import patch
 
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _last_dive_config('2026-03-11'))
+  monkeypatch.setattr(_config_mod, '_config', _last_dive_config('2026-03-11'))
   with patch('integrations.diving.datetime') as mock_dt:
     mock_dt.now.return_value.date.return_value = date(2026, 3, 12)
     result = dc.get_variables_last_dive()
@@ -567,9 +567,9 @@ def test_get_variables_last_dive_n_days(monkeypatch: pytest.MonkeyPatch) -> None
   from datetime import date
   from unittest.mock import patch
 
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _last_dive_config('2026-02-26'))
+  monkeypatch.setattr(_config_mod, '_config', _last_dive_config('2026-02-26'))
   with patch('integrations.diving.datetime') as mock_dt:
     mock_dt.now.return_value.date.return_value = date(2026, 3, 12)
     result = dc.get_variables_last_dive()
@@ -580,9 +580,9 @@ def test_get_variables_last_dive_future_clamped(monkeypatch: pytest.MonkeyPatch)
   from datetime import date
   from unittest.mock import patch
 
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _last_dive_config('2026-03-13'))
+  monkeypatch.setattr(_config_mod, '_config', _last_dive_config('2026-03-13'))
   with patch('integrations.diving.datetime') as mock_dt:
     mock_dt.now.return_value.date.return_value = date(2026, 3, 12)
     result = dc.get_variables_last_dive()

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -11,10 +11,10 @@ from exceptions import IntegrationDataUnavailableError
 
 @pytest.fixture(autouse=True)
 def _mock_config(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'google': {
@@ -52,10 +52,10 @@ def test_get_token_returns_valid_token() -> None:
 
 
 def test_get_token_no_token_raises_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {'google': {'client_id': 'id', 'client_secret': 'secret'}},
   )
@@ -70,10 +70,10 @@ def test_get_token_no_token_raises_unavailable(monkeypatch: pytest.MonkeyPatch) 
 
 
 def test_get_token_refreshes_near_expiry(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'google': {
@@ -107,10 +107,10 @@ def test_get_token_refreshes_near_expiry(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 def test_get_token_refresh_failure_clears_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'google': {

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -12,10 +12,10 @@ def _run_main_with_log_level(
   config: dict[str, Any],
 ) -> None:
   """Run main() with the given config, patching away all side effects."""
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr('sys.argv', ['e-note-ion'])
-  monkeypatch.setattr(_cfg, '_config', config)
+  monkeypatch.setattr(_config_mod, '_config', config)
   mock_sched = MagicMock()
   mock_sched.get_jobs.return_value = []
   with (

--- a/tests/test_parcel.py
+++ b/tests/test_parcel.py
@@ -199,9 +199,9 @@ def test_sort_key_null_dates_last() -> None:
 
 
 def test_get_variables_out_for_delivery(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   pc._cache = None
 
   resp = _api_response(
@@ -224,9 +224,9 @@ def test_get_variables_out_for_delivery(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 def test_get_variables_no_active_deliveries(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   pc._cache = None
 
   resp = _api_response([_delivery(status_code=0)])  # completed
@@ -238,9 +238,9 @@ def test_get_variables_no_active_deliveries(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 def test_get_variables_empty_response(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   pc._cache = None
 
   resp = _api_response([])
@@ -252,9 +252,9 @@ def test_get_variables_empty_response(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_get_variables_selects_soonest(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   pc._cache = None
 
   resp = _api_response(
@@ -272,9 +272,9 @@ def test_get_variables_selects_soonest(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_get_variables_no_description_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   pc._cache = None
 
   resp = _api_response([_delivery(description='')])
@@ -291,9 +291,9 @@ def test_get_variables_no_description_fallback(monkeypatch: pytest.MonkeyPatch) 
 
 
 def test_cache_hit_avoids_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
 
   cached_value: dict = {
     'status_line': [['[B] ON THE WAY']],
@@ -313,9 +313,9 @@ def test_cache_hit_avoids_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_stale_cache_served_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
   import requests as _requests
 
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
 
   stale_value: dict = {
     'status_line': [['[O] ON THE WAY']],
@@ -341,9 +341,9 @@ def test_stale_cache_served_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_no_cache_on_error_raises(monkeypatch: pytest.MonkeyPatch) -> None:
   import requests as _requests
 
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   pc._cache = None
 
   with patch(

--- a/tests/test_qbittorrent.py
+++ b/tests/test_qbittorrent.py
@@ -99,9 +99,9 @@ def test_login_bad_credentials() -> None:
 
 
 def test_get_variables_normal(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   qbt._cache = None
 
   session_mock = MagicMock()
@@ -122,9 +122,9 @@ def test_get_variables_normal(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_get_variables_no_seeders(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   qbt._cache = None
 
   session_mock = MagicMock()
@@ -142,9 +142,9 @@ def test_get_variables_no_seeders(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_get_variables_login_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   qbt._cache = None
 
   session_mock = MagicMock()
@@ -163,9 +163,9 @@ def test_get_variables_login_failure(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_cache_hit_avoids_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
 
   cached_value: dict = {
     'header': [['[B] TORRENTS']],
@@ -183,9 +183,9 @@ def test_cache_hit_avoids_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_stale_cache_served_on_login_error(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
 
   stale_value: dict = {
     'header': [['[B] TORRENTS']],
@@ -211,11 +211,11 @@ def test_stale_cache_served_on_login_error(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_verify_tls_false_passes_verify(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   cfg = _patched_config()
   cfg['qbittorrent']['verify_tls'] = False
-  monkeypatch.setattr(_cfg, '_config', cfg)
+  monkeypatch.setattr(_config_mod, '_config', cfg)
   qbt._cache = None
 
   session_mock = MagicMock()
@@ -235,9 +235,9 @@ def test_verify_tls_false_passes_verify(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 def test_verify_tls_default_true(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   qbt._cache = None
 
   session_mock = MagicMock()

--- a/tests/test_quiet.py
+++ b/tests/test_quiet.py
@@ -21,93 +21,85 @@ def _reset_state() -> None:
 def test_init_defaults_to_inactive(tmp_path: Path) -> None:
   with patch('quiet._config_mod.get_optional_bool', return_value=False) as mock:
     _mod.init()
-  mock.assert_called_once_with('scheduler.quiet', 'active', default=False)
-  assert not _mod.is_active()
+  mock.assert_called_once_with('scheduler', 'quiet', default=False)
+  assert not _mod.is_quiet()
 
 
 def test_init_restores_active_state(tmp_path: Path) -> None:
   with patch('quiet._config_mod.get_optional_bool', return_value=True) as mock:
     _mod.init()
-  mock.assert_called_once_with('scheduler.quiet', 'active', default=False)
-  assert _mod.is_active()
+  mock.assert_called_once_with('scheduler', 'quiet', default=False)
+  assert _mod.is_quiet()
 
 
-def test_init_active_false_stays_inactive() -> None:
-  """Regression: [scheduler.quiet] active = false must not activate quiet mode.
-
-  Previously init() read _config['scheduler']['quiet'] which returned the dict
-  {'active': False} — bool of a non-empty dict is True, so quiet mode was
-  always restored as active.  See #456.
-  """
-  with patch.dict('config._config', {'scheduler': {'quiet': {'active': False}}}):
+def test_init_quiet_false_stays_inactive() -> None:
+  """Regression: [scheduler] quiet = false must not activate quiet mode."""
+  with patch.dict('config._config', {'scheduler': {'quiet': False}}):
     _mod.init()
-  assert not _mod.is_active()
+  assert not _mod.is_quiet()
 
 
-# --- activate ---
+# --- set_quiet ---
 
 
-def test_activate_sets_active() -> None:
+def test_set_quiet_true_activates() -> None:
   with patch('quiet._config_mod.write_config_section'):
-    _mod.activate()
-  assert _mod.is_active()
+    _mod.set_quiet(True)
+  assert _mod.is_quiet()
 
 
-def test_activate_persists_to_config() -> None:
+def test_set_quiet_true_persists_to_config() -> None:
   with patch('quiet._config_mod.write_config_section') as mock_write:
-    _mod.activate()
-  mock_write.assert_called_once_with('scheduler.quiet', {'active': True})
+    _mod.set_quiet(True)
+  mock_write.assert_called_once_with('scheduler', {'quiet': True})
 
 
-def test_activate_sets_changed_event() -> None:
+def test_set_quiet_true_sets_changed_event() -> None:
   with patch('quiet._config_mod.write_config_section'):
-    _mod.activate()
+    _mod.set_quiet(True)
   assert _mod.changed_event().is_set()
 
 
-def test_activate_idempotent() -> None:
+def test_set_quiet_true_idempotent() -> None:
   with patch('quiet._config_mod.write_config_section') as mock_write:
-    _mod.activate()
-    _mod.activate()  # second call should be a no-op
+    _mod.set_quiet(True)
+    _mod.set_quiet(True)  # second call should be a no-op
   mock_write.assert_called_once()
 
 
-# --- deactivate ---
-
-
-def test_deactivate_clears_active() -> None:
+def test_set_quiet_false_deactivates() -> None:
   _mod._active = True
   with patch('quiet._config_mod.write_config_section'):
-    _mod.deactivate()
-  assert not _mod.is_active()
+    _mod.set_quiet(False)
+  assert not _mod.is_quiet()
 
 
-def test_deactivate_persists_to_config() -> None:
+def test_set_quiet_false_persists_to_config() -> None:
   _mod._active = True
   with patch('quiet._config_mod.write_config_section') as mock_write:
-    _mod.deactivate()
-  mock_write.assert_called_once_with('scheduler.quiet', {'active': False})
+    _mod.set_quiet(False)
+  mock_write.assert_called_once_with('scheduler', {'quiet': False})
 
 
-def test_deactivate_sets_changed_event() -> None:
+def test_set_quiet_false_sets_changed_event() -> None:
   _mod._active = True
   with patch('quiet._config_mod.write_config_section'):
-    _mod.deactivate()
+    _mod.set_quiet(False)
   assert _mod.changed_event().is_set()
 
 
-def test_deactivate_when_already_inactive_is_noop() -> None:
+def test_set_quiet_false_when_already_inactive_is_noop() -> None:
   with patch('quiet._config_mod.write_config_section') as mock_write:
-    _mod.deactivate()
+    _mod.set_quiet(False)
   mock_write.assert_not_called()
 
 
-def test_deactivate_preserves_virtual_state() -> None:
+def test_set_quiet_false_preserves_virtual_state() -> None:
   """Virtual state is preserved for the worker to retrieve via pop_virtual_state."""
   _mod._active = True
   _mod._virtual_state = [[1, 2, 3]]
   with patch('quiet._config_mod.write_config_section'):
-    _mod.deactivate()
+    _mod.set_quiet(False)
   assert _mod.get_virtual_state() == [[1, 2, 3]]
 
 
@@ -139,15 +131,15 @@ def test_pop_virtual_state_none_when_empty() -> None:
 # --- thread safety ---
 
 
-def test_concurrent_activate_deactivate() -> None:
-  """Rapid concurrent activate/deactivate should not corrupt state."""
+def test_concurrent_set_quiet() -> None:
+  """Rapid concurrent set_quiet should not corrupt state."""
   errors: list[Exception] = []
 
   def _toggle(n: int) -> None:
     try:
       for _ in range(n):
-        _mod.activate()
-        _mod.deactivate()
+        _mod.set_quiet(True)
+        _mod.set_quiet(False)
     except Exception as e:  # noqa: BLE001
       errors.append(e)
 
@@ -159,4 +151,4 @@ def test_concurrent_activate_deactivate() -> None:
       t.join()
   assert not errors
   # Final state should be inactive (all threads did activate+deactivate pairs)
-  assert not _mod.is_active()
+  assert not _mod.is_quiet()

--- a/tests/test_scheduler_webhook.py
+++ b/tests/test_scheduler_webhook.py
@@ -6,16 +6,16 @@ import integrations.scheduler as _mod
 
 
 def test_handle_webhook_quiet() -> None:
-  with patch('quiet.activate') as mock:
+  with patch('quiet.set_quiet') as mock:
     result = _mod.handle_webhook({'action': 'quiet'})
-  mock.assert_called_once()
+  mock.assert_called_once_with(True)
   assert result is None
 
 
 def test_handle_webhook_wake() -> None:
-  with patch('quiet.deactivate') as mock:
+  with patch('quiet.set_quiet') as mock:
     result = _mod.handle_webhook({'action': 'wake'})
-  mock.assert_called_once()
+  mock.assert_called_once_with(False)
   assert result is None
 
 
@@ -45,6 +45,6 @@ def test_handle_webhook_missing_action() -> None:
 
 def test_handle_webhook_accepts_credential_name() -> None:
   """credential_name kwarg is accepted (even though unused)."""
-  with patch('quiet.activate'):
+  with patch('quiet.set_quiet'):
     result = _mod.handle_webhook({'action': 'quiet'}, credential_name='scheduler')
   assert result is None

--- a/tests/test_unraid.py
+++ b/tests/test_unraid.py
@@ -112,9 +112,9 @@ def test_fmt_uptime(seconds: int, expected: str) -> None:
 
 
 def test_get_variables_normal(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   unraid._cache = None
 
   data = _normal_data(uptime_secs=3 * 30 * 24 * 3600 + 2 * 24 * 3600 + 8 * 3600)
@@ -130,9 +130,9 @@ def test_get_variables_normal(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_get_variables_array_stopped(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   unraid._cache = None
 
   data = _normal_data(state='STOPPED')
@@ -144,9 +144,9 @@ def test_get_variables_array_stopped(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_get_variables_array_degraded(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   unraid._cache = None
 
   data = _normal_data(state='DEGRADED')
@@ -158,9 +158,9 @@ def test_get_variables_array_degraded(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_get_variables_graphql_error(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   unraid._cache = None
 
   resp = _graphql_response(errors=[{'message': 'not authorized'}])
@@ -172,9 +172,9 @@ def test_get_variables_graphql_error(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_get_variables_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   unraid._cache = None
 
   with patch(
@@ -193,9 +193,9 @@ def test_get_variables_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_cache_hit_avoids_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
 
   cached_value: dict = {
     'header': [['[O] UNRAID']],
@@ -213,9 +213,9 @@ def test_cache_hit_avoids_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_stale_cache_served_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
 
   stale_value: dict = {
     'header': [['[O] UNRAID']],
@@ -241,11 +241,11 @@ def test_stale_cache_served_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_verify_tls_false_passes_verify(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   cfg = _patched_config()
   cfg['unraid']['verify_tls'] = False
-  monkeypatch.setattr(_cfg, '_config', cfg)
+  monkeypatch.setattr(_config_mod, '_config', cfg)
   unraid._cache = None
 
   data = _normal_data()
@@ -257,9 +257,9 @@ def test_verify_tls_false_passes_verify(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 def test_verify_tls_default_true(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   unraid._cache = None
 
   data = _normal_data()
@@ -277,9 +277,9 @@ def test_verify_tls_default_true(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_uptime_iso_timestamp(monkeypatch: pytest.MonkeyPatch) -> None:
   """The API returns a boot timestamp, not seconds — verify parsing works."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   unraid._cache = None
 
   data = _normal_data(uptime_secs=3600)
@@ -294,9 +294,9 @@ def test_uptime_iso_timestamp(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_uptime_unparseable_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
   """Unparseable uptime value should produce an empty line, not crash."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   unraid._cache = None
 
   data = {

--- a/tests/test_uptimerobot.py
+++ b/tests/test_uptimerobot.py
@@ -39,9 +39,9 @@ def _monitor(
 
 @pytest.fixture(autouse=True)
 def _mock_config(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', {'uptimerobot': {'api_key': 'test-key'}})
+  monkeypatch.setattr(_config_mod, '_config', {'uptimerobot': {'api_key': 'test-key'}})
   yield
 
 

--- a/tests/test_ynab.py
+++ b/tests/test_ynab.py
@@ -125,9 +125,9 @@ def test_fmt_pct(delta: int, start: int, expected: str) -> None:
 
 
 def test_get_variables_positive_delta(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   ynab._cache = None
   ynab._resolved_budget_id = None
 
@@ -146,9 +146,9 @@ def test_get_variables_positive_delta(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_get_variables_negative_delta(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   ynab._cache = None
   ynab._resolved_budget_id = None
 
@@ -165,9 +165,9 @@ def test_get_variables_negative_delta(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_get_variables_zero_start_of_month(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   ynab._cache = None
   ynab._resolved_budget_id = None
 
@@ -185,9 +185,9 @@ def test_get_variables_zero_start_of_month(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_get_variables_negative_net_worth(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   ynab._cache = None
   ynab._resolved_budget_id = None
 
@@ -204,9 +204,9 @@ def test_get_variables_negative_net_worth(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 def test_get_variables_filters_closed_deleted(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   ynab._cache = None
   ynab._resolved_budget_id = None
 
@@ -227,9 +227,9 @@ def test_get_variables_filters_closed_deleted(monkeypatch: pytest.MonkeyPatch) -
 
 
 def test_get_variables_large_numbers(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   ynab._cache = None
   ynab._resolved_budget_id = None
 
@@ -250,9 +250,9 @@ def test_get_variables_large_numbers(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_api_error_no_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
   ynab._cache = None
   ynab._resolved_budget_id = None
 
@@ -268,9 +268,9 @@ def test_api_error_no_cache(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_api_error_serves_stale_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
 
   stale_value: dict = {
     'header': [['[G] NET WORTH']],
@@ -293,9 +293,9 @@ def test_api_error_serves_stale_cache(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_txn_error_serves_stale_cache(monkeypatch: pytest.MonkeyPatch) -> None:
   """Transaction fetch fails after accounts succeed — stale cache returned."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
 
   stale_value: dict = {
     'header': [['[G] NET WORTH']],
@@ -330,9 +330,9 @@ def test_txn_error_serves_stale_cache(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_cache_hit_avoids_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config())
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
 
   cached_value: dict = {
     'header': [['[G] NET WORTH']],
@@ -356,9 +356,9 @@ def test_cache_hit_avoids_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_auto_detect_single_budget(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config(include_budget_id=False))
+  monkeypatch.setattr(_config_mod, '_config', _patched_config(include_budget_id=False))
   ynab._cache = None
   ynab._resolved_budget_id = None
 
@@ -377,9 +377,9 @@ def test_auto_detect_single_budget(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_auto_detect_multiple_budgets_errors(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config(include_budget_id=False))
+  monkeypatch.setattr(_config_mod, '_config', _patched_config(include_budget_id=False))
   ynab._cache = None
   ynab._resolved_budget_id = None
 
@@ -399,9 +399,9 @@ def test_auto_detect_multiple_budgets_errors(monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_auto_detect_no_budgets_errors(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config(include_budget_id=False))
+  monkeypatch.setattr(_config_mod, '_config', _patched_config(include_budget_id=False))
   ynab._cache = None
   ynab._resolved_budget_id = None
 
@@ -417,9 +417,9 @@ def test_auto_detect_no_budgets_errors(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_auto_detect_cached_on_second_call(monkeypatch: pytest.MonkeyPatch) -> None:
   """Second call should reuse the resolved budget ID, not hit /budgets again."""
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config(include_budget_id=False))
+  monkeypatch.setattr(_config_mod, '_config', _patched_config(include_budget_id=False))
   ynab._cache = None
   ynab._resolved_budget_id = None
 
@@ -447,9 +447,9 @@ def test_auto_detect_cached_on_second_call(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_auto_detect_skips_deleted_budgets(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
-  monkeypatch.setattr(_cfg, '_config', _patched_config(include_budget_id=False))
+  monkeypatch.setattr(_config_mod, '_config', _patched_config(include_budget_id=False))
   ynab._cache = None
   ynab._resolved_budget_id = None
 

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -19,10 +19,10 @@ def _mock_response(data: Any, status_code: int = 200) -> MagicMock:
 
 @pytest.fixture(autouse=True)
 def _mock_config(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'google': {
@@ -345,10 +345,10 @@ def test_get_variables_no_live_streams_raises() -> None:
 
 
 def test_get_variables_no_subscriptions_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-  import config as _cfg
+  import config as _config_mod
 
   monkeypatch.setattr(
-    _cfg,
+    _config_mod,
     '_config',
     {
       'google': {

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.13.1"
+version = "1.13.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- **#484**: Migrate quiet mode config from `[scheduler.quiet].active` subsection to flat `[scheduler].quiet` key with backward-compatible migration shim (removed in 2.0 per #483). Rename `quiet.py` API to `set_quiet()`/`is_quiet()` matching `public.py`'s pattern
- **#487**: Standardize config import alias from `_cfg` to `_config_mod` across all 6 integration files and all test files
- **#488**: Move `uptimerobot.py` module-level config import to function scope matching all other integrations

Patch bump 1.13.1 → 1.13.2.

## Test plan

- [x] All 1291 tests pass
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `pyright` 0 errors
- [x] `bandit` clean
- [x] `pretty-format-json` clean
- [ ] CI passes

Closes #484, closes #487, closes #488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
