### PR TITLE
fix(quiet): preserve hold/priority semantics in quiet mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.13.2"
+version = "1.13.3"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -333,9 +333,14 @@ def _do_hold(
   If refresh_fn and refresh_interval are provided, refresh_fn() is called
   every refresh_interval seconds during the hold. Errors from refresh_fn are
   logged and the hold continues; the display keeps showing the last good content.
+
+  Quiet→wake transitions are detected within ≤1s (the poll interval). When
+  detected, the virtual state is sent to the board immediately and the hold
+  continues normally.
   """
   hold_start = time.monotonic()
   last_refresh = hold_start
+  was_quiet = _quiet_mod.is_quiet()
   while True:
     elapsed = time.monotonic() - hold_start
     remaining = message.hold - elapsed
@@ -362,6 +367,24 @@ def _do_hold(
             time.monotonic() - hold_start,
           )
           break
+
+    # Detect quiet→wake transition and push the virtual state to the board
+    # immediately, without breaking the hold. Subsequent refreshes (if any)
+    # will write to the board directly via _do_refresh's is_quiet() check.
+    now_quiet = _quiet_mod.is_quiet()
+    if was_quiet and not now_quiet:
+      virtual = _quiet_mod.pop_virtual_state()
+      if virtual is not None:
+        logger.info('[hold] quiet→wake during %s — sending virtual state to board', message.name)
+        try:
+          vestaboard.set_state_raw(virtual)
+        except vestaboard.DuplicateContentError:
+          pass
+        except vestaboard.BoardLockedError:
+          logger.warning('[hold] board locked on wake — virtual state discarded')
+        except Exception as e:  # noqa: BLE001
+          logger.error('[hold] error sending virtual state on wake: %s', e)
+    was_quiet = now_quiet
 
     if refresh_fn and refresh_interval:
       now = time.monotonic()
@@ -482,41 +505,6 @@ def worker() -> None:
         _current_hold_supersede_tag = ''
         _current_hold_priority = None
       logger.error('Error sending to board: %s', e)
-      continue
-
-    # During quiet mode, skip hold — no physical display to keep showing.
-    # Transfer refresh capability to idle state so virtual state stays current,
-    # then immediately process the next message.
-    if _quiet_mod.is_quiet():
-      with _current_hold_lock:
-        _current_hold_supersede_tag = ''
-        _current_hold_priority = None
-      refresh_interval = message.data.get('refresh_interval')
-      if refresh_interval and 'integration' in message.data:
-        _integration = _get_integration(message.data['integration'])
-        _fn_name = message.data.get('integration_fn', 'get_variables')
-        _templates = message.data['templates']
-        _truncation = message.data.get('truncation', 'hard')
-
-        def _do_quiet_refresh(
-          _i: Any = _integration,
-          _f: Any = _fn_name,
-          _t: Any = _templates,
-          _tr: Any = _truncation,
-        ) -> None:
-          new_vars = getattr(_i, _f)()
-          if _quiet_mod.is_quiet():
-            _grid = vestaboard.render(_t, new_vars, _tr)
-            _quiet_mod.set_virtual_state(_grid)
-          else:
-            try:
-              vestaboard.set_state(_t, new_vars, _tr)
-            except vestaboard.DuplicateContentError, IntegrationDataUnavailableError:
-              pass
-
-        _idle_refresh_fn = _do_quiet_refresh
-        _idle_refresh_interval = refresh_interval
-        _idle_last_refresh = 0.0
       continue
 
     # New message successfully sent (or DuplicateContentError fell through) —

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -2028,6 +2028,37 @@ def test_do_hold_non_indefinite_unchanged() -> None:
   assert time.monotonic() - start >= 1.9
 
 
+def test_do_hold_quiet_to_wake_sends_virtual_state() -> None:
+  """When quiet mode deactivates during a hold, virtual state is sent to
+  the board immediately without breaking the hold."""
+  import quiet as quiet_mod
+
+  grid = [[8, 5, 12, 12, 15] + [0] * 10] * 3
+  quiet_mod._active = True
+  quiet_mod._virtual_state = grid
+  message = _make_message(priority=5, hold=3)
+  _mod._hold_interrupt.clear()
+
+  # Deactivate quiet after 1s so the hold detects the transition mid-hold
+  t = threading.Timer(1.0, lambda: setattr(quiet_mod, '_active', False))
+  t.start()
+  try:
+    with patch('integrations.vestaboard.set_state_raw') as mock_raw:
+      start = time.monotonic()
+      _mod._do_hold(message, min_hold=0)
+      elapsed = time.monotonic() - start
+    # Hold ran to completion (not broken by wake)
+    assert elapsed >= 2.5, f'Expected full hold, got {elapsed:.2f}s'
+    # Virtual state was sent to the board during the hold
+    mock_raw.assert_called_once_with(grid)
+    # Virtual state was consumed
+    assert quiet_mod.get_virtual_state() is None
+  finally:
+    t.cancel()
+    quiet_mod._active = False
+    quiet_mod._virtual_state = None
+
+
 # --- enqueue: indefinite ---
 
 
@@ -2243,6 +2274,7 @@ def test_worker_quiet_mode_stores_virtual_state() -> None:
     with (
       patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
       patch('integrations.vestaboard.set_state') as mock_set_state,
+      patch.object(_mod, '_do_hold'),
     ):
       with pytest.raises(KeyboardInterrupt):
         _mod.worker()
@@ -2255,23 +2287,27 @@ def test_worker_quiet_mode_stores_virtual_state() -> None:
     quiet_mod._virtual_state = None
 
 
-def test_worker_quiet_mode_skips_hold() -> None:
-  """During quiet mode, worker should not hold — it processes messages
-  immediately and moves to the next one."""
+def test_worker_quiet_mode_holds_like_wake() -> None:
+  """During quiet mode, worker still runs _do_hold so priority protection
+  prevents lower-priority messages from overwriting virtual state."""
   import quiet as quiet_mod
 
-  msg1 = _make_worker_msg(scheduled_at=time.monotonic(), timeout=3600)
-  msg1.name = 'first'
-  msg2 = _make_worker_msg(scheduled_at=time.monotonic(), timeout=3600)
-  msg2.name = 'second'
-  msg2.seq = 1
+  msg = _make_worker_msg(scheduled_at=time.monotonic(), timeout=3600)
+  hold_called: list[bool] = []
+
+  def _fake_do_hold(m: Any, min_hold: Any, **kw: Any) -> None:
+    hold_called.append(True)
+
   quiet_mod._active = True
   quiet_mod._virtual_state = None
   try:
-    with patch.object(_mod, 'pop_valid_message', side_effect=[msg1, msg2, KeyboardInterrupt()]):
+    with (
+      patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
+      patch.object(_mod, '_do_hold', side_effect=_fake_do_hold),
+    ):
       with pytest.raises(KeyboardInterrupt):
         _mod.worker()
-    # Both messages processed without hold — virtual state is from the second
+    assert hold_called, '_do_hold must be called in quiet mode'
     assert quiet_mod.get_virtual_state() is not None
   finally:
     quiet_mod._active = False

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.13.2"
+version = "1.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Remove the quiet-mode hold bypass that skipped `_do_hold()` entirely, causing lower-priority messages (e.g. Trakt watching at priority 7) to overwrite the virtual state set by higher-priority indefinite holds (e.g. Plex webhook at priority 8)
- The worker now runs `_do_hold()` in quiet mode identically to wake mode — same priority protection, interrupt semantics, and refresh behavior. The only difference remains at the render step (lines 455–459), which already dispatches to virtual state vs board based on `is_quiet()`
- Detect quiet→wake transitions inside `_do_hold()` within ≤1s and push the virtual state to the board immediately, without breaking the hold

Closes #490

## Test plan

- [x] Replaced `test_worker_quiet_mode_skips_hold` with `test_worker_quiet_mode_holds_like_wake` — asserts `_do_hold` is called in quiet mode
- [x] Updated `test_worker_quiet_mode_stores_virtual_state` to mock `_do_hold`
- [x] Added `test_do_hold_quiet_to_wake_sends_virtual_state` — verifies mid-hold wake transition sends virtual state without breaking the hold
- [x] All 1292 tests pass; ruff, pyright, bandit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
