### PR TITLE
chore(docs): document config import and state module conventions (#493)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -570,3 +570,11 @@ template output, consult and follow both content docs:
 - All `requests` calls must include `timeout=`
 - Suppress bandit findings with `# nosec BXXX` (include rule ID); never
   suppress blindly
+- Integration modules must import `config` inside functions (not at module
+  level) using the alias `import config as _config_mod` — consistent with
+  `_public_mod` / `_quiet_mod` in `scheduler.py`. This keeps integrations
+  importable in tests without a loaded config file.
+- Runtime state modules (`public.py`, `quiet.py`) follow a symmetric API:
+  `set_<name>(bool)` / `is_<name>()` with state persisted as a flat key under
+  `[scheduler]` in `config.toml`. New runtime state modules should follow the
+  same pattern.


### PR DESCRIPTION
— *Claude Code*

## Summary

- Add two bullets to **Code Conventions** in `AGENTS.md` documenting conventions established in #484/#487/#488:
  - Integration modules must import `config` inside functions (not at module level) using the alias `_config_mod`
  - Runtime state modules (`public.py`, `quiet.py`) follow a symmetric `set_<name>(bool)` / `is_<name>()` API with flat-key persistence under `[scheduler]`

Closes #493
