### PR TITLE
feat(public): clear board when enabling public mode with private content displayed

### DIFF
--- a/public.py
+++ b/public.py
@@ -17,6 +17,10 @@ logger = logging.getLogger(__name__)
 _lock = threading.Lock()
 _public: bool = False
 
+# Set by set_public(True) so the worker can detect activation without polling.
+# The worker should check this event (with is_set/clear) in its hold loop.
+_changed = threading.Event()
+
 
 def init() -> None:
   """Load persisted public mode state from config.toml.
@@ -40,9 +44,16 @@ def set_public(value: bool) -> None:
     _public = value
     _config_mod.write_config_section('scheduler', {'public': value})
     logger.info('Public mode %s', 'activated' if value else 'deactivated')
+    if value:
+      _changed.set()
 
 
 def is_public() -> bool:
   """Return whether public mode is currently active."""
   with _lock:
     return _public
+
+
+def changed_event() -> threading.Event:
+  """Return the event that signals public mode activation."""
+  return _changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.13.3"
+version = "1.14.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -271,6 +271,11 @@ _current_hold_lock = threading.Lock()
 _current_hold_supersede_tag: str = ''
 _current_hold_priority: int | None = None
 
+# Tracks whether the board is currently showing private content. Defaults to
+# True (safe assumption after restart — we don't know what was last displayed).
+# Set True when a private message is sent, False on non-private send or clear.
+_board_showing_private: bool = True
+
 
 def current_hold_tag() -> str:
   """Return the supersede_tag of the message currently being held, or ''."""
@@ -386,6 +391,14 @@ def _do_hold(
           logger.error('[hold] error sending virtual state on wake: %s', e)
     was_quiet = now_quiet
 
+    # Detect public mode activation while the board shows private content.
+    # Break immediately so the worker can drain the queue or clear the board.
+    if _public_mod.changed_event().is_set():
+      _public_mod.changed_event().clear()
+      if _board_showing_private:
+        logger.info('[hold] public mode activated while private content displayed (%s) — breaking', message.name)
+        break
+
     if refresh_fn and refresh_interval:
       now = time.monotonic()
       if now - last_refresh >= refresh_interval:
@@ -396,12 +409,47 @@ def _do_hold(
           logger.warning('Refresh error for %s: %s', message.name, e)
 
 
+def _clear_private_content() -> None:
+  """Drain the queue for the next public message, or clear the board.
+
+  Called when public mode is activated while the board shows private content.
+  Skips private messages in the queue until a public one is found (put back for
+  the main loop). If no public message is available, sends a blank grid to the
+  board. Privacy trumps quiet mode: the blank grid is sent to the real board
+  even when quiet is active.
+  """
+  global _board_showing_private
+  found_public = False
+  while True:
+    try:
+      m = _queue.get_nowait()
+    except Empty:
+      break
+    m_private = m.data.get('private')
+    if not m_private and m.name.startswith('webhook.'):
+      m_private = _webhook_private.get(m.name.removeprefix('webhook.'), False)
+    if m_private:
+      logger.debug('Draining %s — private content hidden in public mode', m.name)
+      continue
+    _queue.put(m)
+    found_public = True
+    break
+  if not found_public:
+    logger.info('Public mode active with private content displayed — clearing board')
+    try:
+      blank = [[0] * vestaboard.model.cols for _ in range(vestaboard.model.rows)]
+      vestaboard.set_state_raw(blank)
+      _board_showing_private = False
+    except Exception as e:  # noqa: BLE001
+      logger.error('Error clearing board for public mode: %s', e)
+
+
 def worker() -> None:
   # Single worker thread — ensures messages are sent to the Vestaboard
   # sequentially and never overlap. After sending a message, sleeps for
   # `hold` seconds before pulling the next one, giving the physical flaps
   # time to settle and the content time to be read.
-  global _current_hold_supersede_tag, _current_hold_priority
+  global _current_hold_supersede_tag, _current_hold_priority, _board_showing_private
   _idle_refresh_fn: Callable[[], None] | None = None
   _idle_refresh_interval: int | None = None
   _idle_last_refresh: float = 0.0
@@ -421,6 +469,15 @@ def worker() -> None:
           logger.warning('Board locked on wake — virtual state discarded')
         except Exception as e:  # noqa: BLE001
           logger.error('Error sending virtual state on wake: %s', e)
+
+    # Public mode activated while idle — if the board shows private content,
+    # drain the queue for the next public message or clear the board.
+    if _public_mod.changed_event().is_set():
+      _public_mod.changed_event().clear()
+      if _board_showing_private:
+        _idle_refresh_fn = None
+        _idle_refresh_interval = None
+        _clear_private_content()
 
     # Idle refresh: if the queue is empty and the previous integration message
     # is still on the board, keep refreshing at the same interval until a new
@@ -508,7 +565,10 @@ def worker() -> None:
       continue
 
     # New message successfully sent (or DuplicateContentError fell through) —
-    # clear idle refresh state before setting up the new hold.
+    # track whether the board is now showing private content.
+    _board_showing_private = bool(is_private)
+
+    # Clear idle refresh state before setting up the new hold.
     _idle_refresh_fn = None
     _idle_refresh_interval = None
 
@@ -554,6 +614,14 @@ def worker() -> None:
       _current_hold_supersede_tag = ''
       _current_hold_priority = None
     logger.debug('[hold] %s hold ended, tag cleared', message.name)
+
+    # Public mode activated while private content is on the board — drain the
+    # queue for the next public message or clear the board.
+    if _board_showing_private and _public_mod.is_public():
+      _idle_refresh_fn = None
+      _idle_refresh_interval = None
+      _clear_private_content()
+      continue
 
     # Hold expired — if this was a refresh-capable integration message, transfer
     # the refresh fn to idle state so the display keeps updating while the queue

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -2349,3 +2349,195 @@ def test_worker_wake_no_virtual_state_is_noop() -> None:
     with pytest.raises(KeyboardInterrupt):
       _mod.worker()
   mock_raw.assert_not_called()
+
+
+# --- public mode: clear private content on activation ---
+
+
+def test_do_hold_breaks_on_public_activation_with_private_content() -> None:
+  """Public mode activation while board shows private content exits the hold early."""
+  import public as public_mod
+
+  message = _make_message(priority=5, hold=10)
+  _mod._hold_interrupt.clear()
+  _mod._board_showing_private = True
+  public_mod._changed.clear()
+
+  t = threading.Timer(1.0, public_mod._changed.set)
+  t.start()
+  try:
+    start = time.monotonic()
+    _mod._do_hold(message, min_hold=0)
+    elapsed = time.monotonic() - start
+    assert elapsed < 5, f'Expected early exit, got {elapsed:.2f}s'
+  finally:
+    t.cancel()
+    _mod._board_showing_private = True
+    public_mod._changed.clear()
+
+
+def test_do_hold_ignores_public_activation_with_non_private_content() -> None:
+  """Public mode activation while board shows non-private content does not break the hold."""
+  import public as public_mod
+
+  message = _make_message(priority=5, hold=3)
+  _mod._hold_interrupt.clear()
+  _mod._board_showing_private = False
+  public_mod._changed.clear()
+
+  t = threading.Timer(1.0, public_mod._changed.set)
+  t.start()
+  try:
+    start = time.monotonic()
+    _mod._do_hold(message, min_hold=0)
+    elapsed = time.monotonic() - start
+    assert elapsed >= 2.5, f'Expected full hold, got {elapsed:.2f}s'
+  finally:
+    t.cancel()
+    _mod._board_showing_private = True
+    public_mod._changed.clear()
+
+
+def test_board_showing_private_defaults_true() -> None:
+  """_board_showing_private defaults to True (safe assumption after restart)."""
+  # Read the module-level default — it's True unless a test mutated it.
+  # We restore it in teardown regardless.
+  assert _mod._board_showing_private is True
+
+
+def test_clear_private_content_drains_to_first_public_message() -> None:
+  """_clear_private_content skips private messages and puts first public one back."""
+  _mod._queue.put(
+    _mod.QueuedMessage(
+      priority=5,
+      seq=1,
+      name='queued_private',
+      scheduled_at=time.monotonic(),
+      data={'private': True, 'templates': [{'format': ['X']}], 'variables': {}, 'truncation': 'hard'},
+      hold=60,
+      timeout=3600,
+    )
+  )
+  _mod._queue.put(
+    _mod.QueuedMessage(
+      priority=5,
+      seq=2,
+      name='queued_public',
+      scheduled_at=time.monotonic(),
+      data={'templates': [{'format': ['Y']}], 'variables': {}, 'truncation': 'hard'},
+      hold=60,
+      timeout=3600,
+    )
+  )
+  with patch('integrations.vestaboard.set_state_raw') as mock_raw:
+    _mod._clear_private_content()
+  mock_raw.assert_not_called()
+  # Public message should be back on the queue
+  m = _mod._queue.get_nowait()
+  assert m.name == 'queued_public'
+
+
+def test_clear_private_content_clears_board_when_queue_empty() -> None:
+  """_clear_private_content sends a blank grid when no public message is available."""
+  with patch('integrations.vestaboard.set_state_raw') as mock_raw:
+    _mod._clear_private_content()
+  mock_raw.assert_called_once()
+  grid = mock_raw.call_args[0][0]
+  assert all(all(c == 0 for c in row) for row in grid)
+  assert _mod._board_showing_private is False
+  _mod._board_showing_private = True  # restore default
+
+
+def test_clear_private_content_clears_board_when_all_private() -> None:
+  """_clear_private_content clears the board when only private messages are queued."""
+  _mod._queue.put(
+    _mod.QueuedMessage(
+      priority=5,
+      seq=1,
+      name='priv1',
+      scheduled_at=time.monotonic(),
+      data={'private': True, 'templates': [{'format': ['X']}], 'variables': {}, 'truncation': 'hard'},
+      hold=60,
+      timeout=3600,
+    )
+  )
+  with patch('integrations.vestaboard.set_state_raw') as mock_raw:
+    _mod._clear_private_content()
+  mock_raw.assert_called_once()
+  grid = mock_raw.call_args[0][0]
+  assert all(all(c == 0 for c in row) for row in grid)
+  _mod._board_showing_private = True  # restore default
+
+
+def test_worker_clears_board_on_public_activation_during_idle() -> None:
+  """Public mode activated while idle with board showing private content clears the board."""
+  import public as public_mod
+
+  public_mod._changed.set()
+  _mod._board_showing_private = True
+
+  with (
+    patch.object(_mod, 'pop_valid_message', side_effect=KeyboardInterrupt()),
+    patch('integrations.vestaboard.set_state_raw') as mock_raw,
+  ):
+    with pytest.raises(KeyboardInterrupt):
+      _mod.worker()
+  mock_raw.assert_called_once()
+  grid = mock_raw.call_args[0][0]
+  assert all(all(c == 0 for c in row) for row in grid)
+  _mod._board_showing_private = True  # restore default
+  public_mod._changed.clear()
+
+
+def test_worker_no_clear_during_idle_when_board_not_private() -> None:
+  """Public mode activated while idle with non-private content does not clear."""
+  import public as public_mod
+
+  public_mod._changed.set()
+  _mod._board_showing_private = False
+
+  with (
+    patch.object(_mod, 'pop_valid_message', side_effect=KeyboardInterrupt()),
+    patch('integrations.vestaboard.set_state_raw') as mock_raw,
+  ):
+    with pytest.raises(KeyboardInterrupt):
+      _mod.worker()
+  mock_raw.assert_not_called()
+  _mod._board_showing_private = True  # restore default
+  public_mod._changed.clear()
+
+
+def test_board_showing_private_set_false_on_non_private_send() -> None:
+  """Sending a non-private message sets _board_showing_private to False."""
+  msg = _make_worker_msg(scheduled_at=time.monotonic(), timeout=3600)
+  _mod._board_showing_private = True
+
+  with (
+    patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
+    patch('public.is_public', return_value=False),
+    patch('integrations.vestaboard.set_state'),
+    patch.object(_mod, '_do_hold', side_effect=lambda *a, **kw: None),
+    patch.object(_mod, '_hold_interrupt'),
+  ):
+    with pytest.raises(KeyboardInterrupt):
+      _mod.worker()
+  assert _mod._board_showing_private is False
+  _mod._board_showing_private = True  # restore default
+
+
+def test_board_showing_private_set_true_on_private_send() -> None:
+  """Sending a private message sets _board_showing_private to True."""
+  msg = _make_worker_msg(scheduled_at=time.monotonic(), timeout=3600)
+  msg.data['private'] = True
+  _mod._board_showing_private = False
+
+  with (
+    patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
+    patch('public.is_public', return_value=False),
+    patch('integrations.vestaboard.set_state'),
+    patch.object(_mod, '_do_hold', side_effect=lambda *a, **kw: None),
+    patch.object(_mod, '_hold_interrupt'),
+  ):
+    with pytest.raises(KeyboardInterrupt):
+      _mod.worker()
+  assert _mod._board_showing_private is True

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -45,3 +45,31 @@ def test_set_public_noop_when_unchanged() -> None:
 def test_is_public_default_false() -> None:
   _mod._public = False
   assert _mod.is_public() is False
+
+
+def test_set_public_true_fires_changed_event() -> None:
+  _mod._public = False
+  _mod._changed.clear()
+  with patch('config.write_config_section'):
+    _mod.set_public(True)
+  assert _mod._changed.is_set()
+  _mod._public = False
+  _mod._changed.clear()
+
+
+def test_set_public_false_does_not_fire_changed_event() -> None:
+  _mod._public = True
+  _mod._changed.clear()
+  with patch('config.write_config_section'):
+    _mod.set_public(False)
+  assert not _mod._changed.is_set()
+
+
+def test_changed_event_not_fired_on_noop() -> None:
+  _mod._public = True
+  _mod._changed.clear()
+  with patch('config.write_config_section') as mock_write:
+    _mod.set_public(True)
+  assert not _mod._changed.is_set()
+  mock_write.assert_not_called()
+  _mod._public = False

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.13.3"
+version = "1.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- When public mode is activated, private content currently displayed on the board is cleared immediately — the worker drains the queue for the next public message, or sends a blank grid if none is available
- Tracks board privacy state via `_board_showing_private` (defaults to `True` after restart as a safe assumption, so activating public mode before any messages are sent still clears the board)
- Detection in both `_do_hold()` (mid-hold) and the worker main loop (idle), using a `threading.Event` on `public.py` (same pattern as quiet mode)
- Privacy trumps quiet mode: the board is cleared with a real write even during quiet hours

Closes #496

## Test plan

- [x] `test_do_hold_breaks_on_public_activation_with_private_content` — hold exits early
- [x] `test_do_hold_ignores_public_activation_with_non_private_content` — hold continues
- [x] `test_board_showing_private_defaults_true` — safe restart default
- [x] `test_clear_private_content_drains_to_first_public_message` — skips private, finds public
- [x] `test_clear_private_content_clears_board_when_queue_empty` — blank grid sent
- [x] `test_clear_private_content_clears_board_when_all_private` — all private drained, blank grid
- [x] `test_worker_clears_board_on_public_activation_during_idle` — idle detection works
- [x] `test_worker_no_clear_during_idle_when_board_not_private` — no false positive
- [x] `test_board_showing_private_set_false_on_non_private_send` — tracking updated
- [x] `test_board_showing_private_set_true_on_private_send` — tracking updated
- [x] `test_set_public_true_fires_changed_event` — event fires on activation
- [x] `test_set_public_false_does_not_fire_changed_event` — no event on deactivation
- [x] `test_changed_event_not_fired_on_noop` — no event when already active
- [x] Full check suite passes (ruff, pyright, bandit, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
