### PR TITLE
feat(health): separate vestaboard send-path target from integrations (#512)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,14 +145,26 @@ the container logs for the plaintext secret. Pass it as
 `X-Webhook-Secret: <secret>` (preferred) or `?secret=<secret>`.
 
 **HTTP status codes:**
-- `200` — all integrations healthy (or unknown)
-- `503` — one or more integrations degraded or errored
+- `200` — everything healthy (or unknown)
+- `503` — one or more targets degraded or errored
 
 **Response format:**
 ```json
 {
   "status": "healthy",
   "uptime_seconds": 3600,
+  "vestaboard": {
+    "status": "healthy",
+    "last_success": "2026-01-01T12:00:00+00:00",
+    "last_expected_empty": null,
+    "last_error": null,
+    "last_error_message": null,
+    "last_locked": "2026-01-01T07:00:00+00:00",
+    "locked_events": 2,
+    "success_rate": 1.0,
+    "total_events": 10,
+    "registered_at": "2026-01-01T08:00:00+00:00"
+  },
   "integrations": {
     "weather": {
       "status": "healthy",
@@ -160,6 +172,8 @@ the container logs for the plaintext secret. Pass it as
       "last_expected_empty": null,
       "last_error": null,
       "last_error_message": null,
+      "last_locked": null,
+      "locked_events": 0,
       "success_rate": 1.0,
       "total_events": 10,
       "registered_at": "2026-01-01T08:00:00+00:00"
@@ -168,10 +182,15 @@ the container logs for the plaintext secret. Pass it as
 }
 ```
 
-Each integration tracks the last 20 events in a rolling buffer. Status levels:
-`healthy` (≥70% non-error rate), `degraded` (below threshold), `error` (all
-errors), `unknown` (no events yet). Expected empty data (e.g. nothing playing,
-no events today) counts as healthy — only API failures trigger degraded/error.
+The `vestaboard` key tracks the display send path itself (POST to the
+Read/Write API) separately from integrations, so a Vestaboard outage does
+not smear across every integration's status — and vice versa. Each target
+tracks the last 20 events in a rolling buffer. Status levels: `healthy`
+(≥70% non-error rate), `degraded` (below threshold), `error` (all errors),
+`unknown` (no events yet). Expected empty data (e.g. nothing playing, no
+events today) counts as healthy — only API failures trigger degraded/error.
+Vestaboard `locked` responses (HTTP 423 during quiet hours) are tracked
+separately via `last_locked` / `locked_events` and do not affect status.
 
 Health events are persisted to `data/health.jsonl` so that history survives
 container restarts. Events older than 7 days are automatically purged. In

--- a/health.py
+++ b/health.py
@@ -1,8 +1,15 @@
 # health.py
 #
-# Integration health tracking for the Vestaboard scheduler. Records
-# success/failure/expected-empty outcomes per integration and exposes a
-# summary for the /health endpoint and periodic console log.
+# Health tracking for the Vestaboard scheduler. Records outcomes for two
+# kinds of targets:
+#   1. Integrations — data sources (weather, bart, discogs, …) tracked via
+#      success / expected_empty / error events.
+#   2. The Vestaboard send path itself — tracked under the reserved target
+#      name 'vestaboard' via success / error / locked events. This lets the
+#      /health endpoint distinguish "fetch failed" from "display POST failed"
+#      so a Vestaboard outage doesn't smear across every integration.
+#
+# Exposes a summary for the /health endpoint and periodic console log.
 #
 # Thread-safe: all state is behind a single lock.
 #
@@ -52,6 +59,7 @@ class EventType(Enum):
   SUCCESS = 'success'
   EXPECTED_EMPTY = 'expected_empty'
   ERROR = 'error'
+  LOCKED = 'locked'
 
 
 class Status(Enum):
@@ -69,13 +77,18 @@ class HealthEvent:
 
 
 @dataclass
-class _IntegrationState:
+class _TargetState:
   registered_at: float
   events: deque[HealthEvent] = field(default_factory=lambda: deque(maxlen=_WINDOW_SIZE))
 
 
+# Reserved target name for the Vestaboard send path. Registered implicitly
+# alongside the user's integrations so the /health endpoint can attribute
+# display failures separately from integration data fetch failures.
+VESTABOARD_TARGET = 'vestaboard'
+
 _lock = threading.Lock()
-_integrations: dict[str, _IntegrationState] = {}
+_targets: dict[str, _TargetState] = {}
 _started_at: float = 0.0
 _log_timer: threading.Timer | None = None
 
@@ -127,9 +140,9 @@ def _load_log() -> None:
 
     error_msg = obj.get('error') if event_type == EventType.ERROR else None
 
-    if name not in _integrations:
-      _integrations[name] = _IntegrationState(registered_at=ts)
-    _integrations[name].events.append(HealthEvent(ts, event_type, error_msg))
+    if name not in _targets:
+      _targets[name] = _TargetState(registered_at=ts)
+    _targets[name].events.append(HealthEvent(ts, event_type, error_msg))
     kept_lines.append(line)
 
   # Rewrite the file without purged entries.
@@ -161,7 +174,7 @@ def _purge_stale_events() -> bool:
   """
   cutoff = time.time() - _PURGE_SECONDS
   purged = False
-  for state in _integrations.values():
+  for state in _targets.values():
     before = len(state.events)
     state.events = deque(
       (e for e in state.events if e.timestamp >= cutoff),
@@ -175,7 +188,7 @@ def _purge_stale_events() -> bool:
 def _rewrite_log() -> None:
   """Rewrite the log file from current in-memory state. Caller holds _lock."""
   lines: list[str] = []
-  for name, state in sorted(_integrations.items()):
+  for name, state in sorted(_targets.items()):
     for event in state.events:
       entry: dict[str, Any] = {
         'ts': event.timestamp,
@@ -198,29 +211,35 @@ def _rewrite_log() -> None:
 
 
 def init() -> None:
-  """Initialize the health system. Call once at scheduler startup."""
+  """Initialize the health system. Call once at scheduler startup.
+
+  Loads persisted events from disk and registers the reserved Vestaboard
+  send-path target so /health always reports it alongside integrations.
+  """
   global _started_at
   _started_at = time.time()
   with _lock:
     _load_log()
+    if VESTABOARD_TARGET not in _targets:
+      _targets[VESTABOARD_TARGET] = _TargetState(registered_at=time.time())
 
 
 def register(name: str) -> None:
-  """Register an integration for health tracking.
+  """Register a target for health tracking.
 
   Called at content load time for each integration template. Safe to call
   multiple times for the same name (e.g. when multiple templates use the
   same integration with different functions).
   """
   with _lock:
-    if name not in _integrations:
-      _integrations[name] = _IntegrationState(registered_at=time.time())
+    if name not in _targets:
+      _targets[name] = _TargetState(registered_at=time.time())
 
 
 def record_success(name: str) -> None:
-  """Record a successful integration call."""
+  """Record a successful call against the named target."""
   with _lock:
-    state = _integrations.get(name)
+    state = _targets.get(name)
     if state is None:
       return
     ts = time.time()
@@ -231,7 +250,7 @@ def record_success(name: str) -> None:
 def record_expected_empty(name: str) -> None:
   """Record an integration call that returned no data (expected)."""
   with _lock:
-    state = _integrations.get(name)
+    state = _targets.get(name)
     if state is None:
       return
     ts = time.time()
@@ -240,9 +259,9 @@ def record_expected_empty(name: str) -> None:
 
 
 def record_error(name: str, error: str) -> None:
-  """Record a failed integration call."""
+  """Record a failed call against the named target."""
   with _lock:
-    state = _integrations.get(name)
+    state = _targets.get(name)
     if state is None:
       return
     ts = time.time()
@@ -250,20 +269,39 @@ def record_error(name: str, error: str) -> None:
     _append_log(name, EventType.ERROR, ts, error)
 
 
-def _compute_status(state: _IntegrationState) -> Status:
-  """Compute health status for a single integration. Caller holds _lock.
+def record_locked(name: str) -> None:
+  """Record a Vestaboard 'locked' response (HTTP 423).
 
-  Uses a success-rate threshold instead of binary error detection:
-  - No events → unknown
+  423 is expected behavior during quiet hours or when the board is briefly
+  rate-limited, so it is tracked separately from errors and does NOT count
+  toward the success-rate denominator used to compute status.
+  """
+  with _lock:
+    state = _targets.get(name)
+    if state is None:
+      return
+    ts = time.time()
+    state.events.append(HealthEvent(ts, EventType.LOCKED))
+    _append_log(name, EventType.LOCKED, ts)
+
+
+def _compute_status(state: _TargetState) -> Status:
+  """Compute health status for a single target. Caller holds _lock.
+
+  Uses a success-rate threshold instead of binary error detection. LOCKED
+  events are excluded from the denominator so expected quiet-hours 423
+  responses do not tank status.
+  - No scored events → unknown
   - No errors → healthy
   - All errors → error
   - Non-error rate ≥ _SUCCESS_RATE_THRESHOLD → healthy
   - Below threshold → degraded
   """
-  if not state.events:
+  scored = [e for e in state.events if e.event_type != EventType.LOCKED]
+  if not scored:
     return Status.UNKNOWN
-  errors = sum(1 for e in state.events if e.event_type == EventType.ERROR)
-  total = len(state.events)
+  errors = sum(1 for e in scored if e.event_type == EventType.ERROR)
+  total = len(scored)
   if errors == 0:
     return Status.HEALTHY
   if errors == total:
@@ -280,17 +318,25 @@ def _format_timestamp(ts: float | None) -> str | None:
   return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
 
 
-def _integration_detail(name: str, state: _IntegrationState) -> dict[str, Any]:
-  """Build the per-integration health detail dict. Caller holds _lock."""
+def _target_detail(name: str, state: _TargetState) -> dict[str, Any]:
+  """Build the per-target health detail dict. Caller holds _lock.
+
+  `success_rate` and `total_events` exclude LOCKED events (they are not
+  failures and would skew the denominator). `locked_events` reports the
+  raw count of locked events in the window.
+  """
   status = _compute_status(state)
-  total = len(state.events)
-  errors = sum(1 for e in state.events if e.event_type == EventType.ERROR)
+  scored = [e for e in state.events if e.event_type != EventType.LOCKED]
+  total = len(scored)
+  errors = sum(1 for e in scored if e.event_type == EventType.ERROR)
   ok = total - errors
+  locked = sum(1 for e in state.events if e.event_type == EventType.LOCKED)
 
   last_success: float | None = None
   last_expected_empty: float | None = None
   last_error: float | None = None
   last_error_message: str | None = None
+  last_locked: float | None = None
 
   for event in reversed(state.events):
     if event.event_type == EventType.SUCCESS and last_success is None:
@@ -300,6 +346,8 @@ def _integration_detail(name: str, state: _IntegrationState) -> dict[str, Any]:
     elif event.event_type == EventType.ERROR and last_error is None:
       last_error = event.timestamp
       last_error_message = event.error_message
+    elif event.event_type == EventType.LOCKED and last_locked is None:
+      last_locked = event.timestamp
 
   detail: dict[str, Any] = {
     'status': status.value,
@@ -307,6 +355,8 @@ def _integration_detail(name: str, state: _IntegrationState) -> dict[str, Any]:
     'last_expected_empty': _format_timestamp(last_expected_empty),
     'last_error': _format_timestamp(last_error),
     'last_error_message': last_error_message,
+    'last_locked': _format_timestamp(last_locked),
+    'locked_events': locked,
     'success_rate': ok / total if total else None,
     'total_events': total,
     'registered_at': _format_timestamp(state.registered_at),
@@ -318,7 +368,7 @@ def overall_status() -> Status:
   """Return the worst status across all registered integrations."""
   with _lock:
     worst = Status.HEALTHY
-    for state in _integrations.values():
+    for state in _targets.values():
       s = _compute_status(state)
       if s == Status.ERROR:
         return Status.ERROR
@@ -328,13 +378,22 @@ def overall_status() -> Status:
 
 
 def get_summary() -> dict[str, Any]:
-  """Return the full health summary for the /health endpoint."""
+  """Return the full health summary for the /health endpoint.
+
+  The Vestaboard send-path target is returned under its own top-level
+  `vestaboard` key, separate from the `integrations` dict, so display
+  failures can be attributed distinctly from integration fetch failures.
+  """
   with _lock:
     integrations: dict[str, Any] = {}
+    vestaboard_detail: dict[str, Any] | None = None
     worst = Status.HEALTHY
-    for name, state in sorted(_integrations.items()):
-      detail = _integration_detail(name, state)
-      integrations[name] = detail
+    for name, state in sorted(_targets.items()):
+      detail = _target_detail(name, state)
+      if name == VESTABOARD_TARGET:
+        vestaboard_detail = detail
+      else:
+        integrations[name] = detail
       s = Status(detail['status'])
       if s == Status.ERROR:
         worst = Status.ERROR
@@ -344,12 +403,13 @@ def get_summary() -> dict[str, Any]:
     return {
       'status': worst.value,
       'uptime_seconds': round(time.time() - _started_at) if _started_at else 0,
+      'vestaboard': vestaboard_detail,
       'integrations': integrations,
     }
 
 
 def _log_summary() -> None:
-  """Log a one-line health summary plus details for non-healthy integrations.
+  """Log a one-line health summary plus details for non-healthy targets.
 
   Also purges stale events (older than _PURGE_DAYS) from memory and disk
   as a belt-and-suspenders check for long-running instances.
@@ -359,16 +419,17 @@ def _log_summary() -> None:
     if _purge_stale_events():
       _rewrite_log()
 
-    if not _integrations:
+    if not _targets:
       return
     counts: dict[str, int] = {}
     problems: list[str] = []
-    for name, state in sorted(_integrations.items()):
+    for name, state in sorted(_targets.items()):
       s = _compute_status(state)
       counts[s.value] = counts.get(s.value, 0) + 1
       if s in (Status.DEGRADED, Status.ERROR):
-        total = len(state.events)
-        errors = sum(1 for e in state.events if e.event_type == EventType.ERROR)
+        scored = [e for e in state.events if e.event_type != EventType.LOCKED]
+        total = len(scored)
+        errors = sum(1 for e in scored if e.event_type == EventType.ERROR)
         ok = total - errors
         last_err = None
         for event in reversed(state.events):
@@ -382,7 +443,7 @@ def _log_summary() -> None:
 
   total_count = sum(counts.values())
   parts = [f'{v} {k}' for k, v in counts.items()]
-  logger.info('Health: %d integrations — %s', total_count, ', '.join(parts))
+  logger.info('Health: %d targets — %s', total_count, ', '.join(parts))
   for line in problems:
     logger.info(line)
 
@@ -415,6 +476,6 @@ def reset() -> None:
   """Clear all state (for tests)."""
   global _started_at, _log_timer
   with _lock:
-    _integrations.clear()
+    _targets.clear()
     _started_at = 0.0
   stop_periodic_log()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.16.2"
+version = "1.17.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -442,7 +442,11 @@ def _clear_private_content() -> None:
       blank = [[0] * vestaboard.model.cols for _ in range(vestaboard.model.rows)]
       vestaboard.set_state_raw(blank)
       _board_showing_private = False
+      _health_mod.record_success(_health_mod.VESTABOARD_TARGET)
+    except vestaboard.BoardLockedError:
+      _health_mod.record_locked(_health_mod.VESTABOARD_TARGET)
     except Exception as e:  # noqa: BLE001
+      _health_mod.record_error(_health_mod.VESTABOARD_TARGET, str(e))
       logger.error('Error clearing board for public mode: %s', e)
 
 
@@ -528,6 +532,10 @@ def worker() -> None:
       _current_hold_priority = message.priority
 
     _health_name = message.data.get('integration', '')
+    # Phase 1: fetch + render — attributed to the integration target.
+    # Phase 2: POST to the board — attributed to the 'vestaboard' target.
+    # Splitting the phases keeps Vestaboard-side outages from smearing
+    # across every integration's health status and vice versa.
     try:
       variables = message.data['variables']
       if 'integration' in message.data:
@@ -535,13 +543,7 @@ def worker() -> None:
         variables = getattr(_get_integration(message.data['integration']), fn_name)()
       templates = message.data['templates']
       truncation = message.data.get('truncation', 'hard')
-      if _quiet_mod.is_quiet():
-        grid = vestaboard.render(templates, variables, truncation)
-        _quiet_mod.set_virtual_state(grid)
-      else:
-        vestaboard.set_state(templates, variables, truncation)
-      if _health_name:
-        _health_mod.record_success(_health_name)
+      grid = vestaboard.render(templates, variables, truncation)
     except IntegrationDataUnavailableError as e:
       if _health_name:
         if e.expected:
@@ -553,28 +555,51 @@ def worker() -> None:
         _current_hold_priority = None
       logger.warning('Skipping %s: %s', message.name, e)
       continue
-    except vestaboard.DuplicateContentError:
-      logger.warning('Duplicate content for %s — already on board, still holding.', message.name)
-      # Fall through to _do_hold(): content is already showing; we must still
-      # hold it so lower-priority queued messages cannot preempt it.
-    except vestaboard.BoardLockedError as e:
-      with _current_hold_lock:
-        _current_hold_supersede_tag = ''
-        _current_hold_priority = None
-      logger.warning('Board locked: %s. Retrying in %ds.', e, _LOCK_RETRY_DELAY)
-      time.sleep(_LOCK_RETRY_DELAY)
-      # Re-enqueue if the message hasn't exceeded its timeout.
-      if time.monotonic() - message.scheduled_at <= message.timeout:
-        _queue.put(message)
-      continue
     except Exception as e:
       if _health_name:
         _health_mod.record_error(_health_name, str(e))
       with _current_hold_lock:
         _current_hold_supersede_tag = ''
         _current_hold_priority = None
-      logger.error('Error sending to board: %s', e)
+      logger.error('Error fetching data for %s: %s', message.name, e)
       continue
+    if _health_name:
+      _health_mod.record_success(_health_name)
+
+    # Phase 2: send to the board. Quiet mode skips the POST entirely, so
+    # no vestaboard health event is recorded — recording a fake success
+    # there would mask real outages whenever quiet mode is active.
+    if _quiet_mod.is_quiet():
+      _quiet_mod.set_virtual_state(grid)
+    else:
+      try:
+        vestaboard.set_state_raw(grid)
+      except vestaboard.DuplicateContentError:
+        # Duplicate = board already shows this content. Count as vestaboard
+        # success (the user's goal is met) and fall through to _do_hold()
+        # so lower-priority queued messages cannot preempt it.
+        _health_mod.record_success(_health_mod.VESTABOARD_TARGET)
+        logger.warning('Duplicate content for %s — already on board, still holding.', message.name)
+      except vestaboard.BoardLockedError as e:
+        _health_mod.record_locked(_health_mod.VESTABOARD_TARGET)
+        with _current_hold_lock:
+          _current_hold_supersede_tag = ''
+          _current_hold_priority = None
+        logger.warning('Board locked: %s. Retrying in %ds.', e, _LOCK_RETRY_DELAY)
+        time.sleep(_LOCK_RETRY_DELAY)
+        # Re-enqueue if the message hasn't exceeded its timeout.
+        if time.monotonic() - message.scheduled_at <= message.timeout:
+          _queue.put(message)
+        continue
+      except Exception as e:
+        _health_mod.record_error(_health_mod.VESTABOARD_TARGET, str(e))
+        with _current_hold_lock:
+          _current_hold_supersede_tag = ''
+          _current_hold_priority = None
+        logger.error('Error sending to board: %s', e)
+        continue
+      else:
+        _health_mod.record_success(_health_mod.VESTABOARD_TARGET)
 
     # New message successfully sent (or DuplicateContentError fell through) —
     # track whether the board is now showing private content.
@@ -599,8 +624,10 @@ def worker() -> None:
         _tr: Any = _truncation,
         _hn: str = _health_name,
       ) -> None:
+        # Phase 1: fetch + render — attributed to the integration target.
         try:
           new_vars = getattr(_i, _f)()
+          _grid = vestaboard.render(_t, new_vars, _tr)
         except IntegrationDataUnavailableError as _e:
           if _hn:
             if _e.expected:
@@ -614,14 +641,22 @@ def worker() -> None:
           raise
         if _hn:
           _health_mod.record_success(_hn)
+
+        # Phase 2: send to the board — attributed to the vestaboard target.
         if _quiet_mod.is_quiet():
-          _grid = vestaboard.render(_t, new_vars, _tr)
           _quiet_mod.set_virtual_state(_grid)
+          return
+        try:
+          vestaboard.set_state_raw(_grid)
+        except vestaboard.DuplicateContentError:
+          _health_mod.record_success(_health_mod.VESTABOARD_TARGET)
+        except vestaboard.BoardLockedError:
+          _health_mod.record_locked(_health_mod.VESTABOARD_TARGET)
+        except Exception as _e:
+          _health_mod.record_error(_health_mod.VESTABOARD_TARGET, str(_e))
+          raise
         else:
-          try:
-            vestaboard.set_state(_t, new_vars, _tr)
-          except vestaboard.DuplicateContentError, IntegrationDataUnavailableError:
-            pass
+          _health_mod.record_success(_health_mod.VESTABOARD_TARGET)
 
       _refresh_fn = _do_refresh
 

--- a/tests/core/test_health.py
+++ b/tests/core/test_health.py
@@ -230,6 +230,7 @@ def test_summary_structure() -> None:
   assert 'status' in summary
   assert 'uptime_seconds' in summary
   assert isinstance(summary['uptime_seconds'], int)
+  assert 'vestaboard' in summary
   assert 'integrations' in summary
   detail = summary['integrations']['weather']
   assert 'status' in detail
@@ -237,6 +238,8 @@ def test_summary_structure() -> None:
   assert 'last_expected_empty' in detail
   assert 'last_error' in detail
   assert 'last_error_message' in detail
+  assert 'last_locked' in detail
+  assert 'locked_events' in detail
   assert 'success_rate' in detail
   assert 'total_events' in detail
   assert 'registered_at' in detail
@@ -261,6 +264,105 @@ def test_success_rate_computation() -> None:
 def test_success_rate_none_when_no_events() -> None:
   _mod.register('bart')
   assert _mod.get_summary()['integrations']['bart']['success_rate'] is None
+
+
+# ---------------------------------------------------------------------------
+# Locked events and vestaboard target split
+# ---------------------------------------------------------------------------
+
+
+def test_record_locked_event() -> None:
+  """record_locked() appends a LOCKED event exposed via last_locked/locked_events."""
+  _mod.register(_mod.VESTABOARD_TARGET)
+  _mod.record_locked(_mod.VESTABOARD_TARGET)
+  detail = _mod.get_summary()['vestaboard']
+  assert detail is not None
+  assert detail['locked_events'] == 1
+  assert detail['last_locked'] is not None
+  # A lone locked event leaves the target UNKNOWN — no scored events yet.
+  assert detail['status'] == 'unknown'
+
+
+def test_locked_excluded_from_success_rate() -> None:
+  """LOCKED events do not affect success_rate or status."""
+  _mod.register(_mod.VESTABOARD_TARGET)
+  for _ in range(5):
+    _mod.record_success(_mod.VESTABOARD_TARGET)
+  for _ in range(3):
+    _mod.record_locked(_mod.VESTABOARD_TARGET)
+  detail = _mod.get_summary()['vestaboard']
+  assert detail['status'] == 'healthy'
+  assert detail['success_rate'] == 1.0
+  assert detail['total_events'] == 5  # scored events only
+  assert detail['locked_events'] == 3
+
+
+def test_locked_does_not_mask_errors() -> None:
+  """LOCKED events don't dilute error rate — 2 success + 3 error + 10 locked = degraded."""
+  _mod.register(_mod.VESTABOARD_TARGET)
+  for _ in range(2):
+    _mod.record_success(_mod.VESTABOARD_TARGET)
+  for _ in range(3):
+    _mod.record_error(_mod.VESTABOARD_TARGET, 'boom')
+  for _ in range(10):
+    _mod.record_locked(_mod.VESTABOARD_TARGET)
+  detail = _mod.get_summary()['vestaboard']
+  # 2/5 = 40% scored success → below 70% threshold → degraded
+  assert detail['status'] == 'degraded'
+  assert detail['total_events'] == 5
+  assert detail['locked_events'] == 10
+
+
+def test_vestaboard_target_registered_on_init() -> None:
+  """init() auto-registers the reserved vestaboard target."""
+  # _reset_health autouse fixture already called init(); assert it is present.
+  summary = _mod.get_summary()
+  assert 'vestaboard' in summary
+  assert summary['vestaboard'] is not None
+  assert summary['vestaboard']['status'] == 'unknown'
+  # And it is NOT in the integrations dict.
+  assert 'vestaboard' not in summary['integrations']
+
+
+def test_vestaboard_errored_drives_rollup() -> None:
+  """A vestaboard error propagates to top-level status even when integrations are healthy."""
+  _mod.register('weather')
+  _mod.record_success('weather')
+  _mod.record_error(_mod.VESTABOARD_TARGET, 'HTTP 500')
+  summary = _mod.get_summary()
+  assert summary['status'] == 'error'
+  assert summary['vestaboard']['status'] == 'error'
+  assert summary['integrations']['weather']['status'] == 'healthy'
+
+
+def test_vestaboard_unknown_does_not_drive_rollup() -> None:
+  """vestaboard starts UNKNOWN on fresh deploy — top-level stays healthy."""
+  _mod.register('weather')
+  _mod.record_success('weather')
+  # vestaboard registered but no events yet
+  summary = _mod.get_summary()
+  assert summary['status'] == 'healthy'
+  assert summary['vestaboard']['status'] == 'unknown'
+
+
+def test_locked_persisted_and_reloaded(tmp_path: Path) -> None:
+  """LOCKED events survive a reset + init cycle."""
+  _mod.register(_mod.VESTABOARD_TARGET)
+  _mod.record_success(_mod.VESTABOARD_TARGET)
+  _mod.record_locked(_mod.VESTABOARD_TARGET)
+  _mod.record_locked(_mod.VESTABOARD_TARGET)
+
+  log_path = _mod._LOG_PATH
+  log_dir = _mod._LOG_DIR
+
+  _mod.reset()
+  _mod._LOG_PATH = log_path
+  _mod._LOG_DIR = log_dir
+  _mod.init()
+
+  detail = _mod.get_summary()['vestaboard']
+  assert detail['total_events'] == 1
+  assert detail['locked_events'] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -430,11 +532,11 @@ def test_periodic_purge_removes_stale_events(tmp_path: Path) -> None:
   # Inject an old event directly into the deque.
   old_ts = time.time() - (_mod._PURGE_SECONDS + 3600)
   with _mod._lock:
-    state = _mod._integrations['weather']
+    state = _mod._targets['weather']
     state.events.appendleft(_mod.HealthEvent(old_ts, _mod.EventType.ERROR, 'stale'))
 
   _mod._log_summary()
 
   # The old event should have been purged.
-  for event in _mod._integrations['weather'].events:
+  for event in _mod._targets['weather'].events:
     assert event.timestamp > old_ts

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -747,7 +747,7 @@ def test_worker_skips_private_message_in_public_mode() -> None:
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
     patch('public.is_public', return_value=True),
-    patch('integrations.vestaboard.set_state') as mock_set,
+    patch('integrations.vestaboard.set_state_raw') as mock_set,
   ):
     with pytest.raises(KeyboardInterrupt):
       _mod.worker()
@@ -760,7 +760,7 @@ def test_worker_shows_private_message_in_normal_mode() -> None:
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
     patch('public.is_public', return_value=False),
-    patch('integrations.vestaboard.set_state'),
+    patch('integrations.vestaboard.set_state_raw'),
     patch('time.sleep'),
     patch.object(_mod, '_hold_interrupt'),
   ):
@@ -776,7 +776,7 @@ def test_worker_skips_webhook_private_message_in_public_mode(monkeypatch: pytest
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
     patch('public.is_public', return_value=True),
-    patch('integrations.vestaboard.set_state') as mock_set,
+    patch('integrations.vestaboard.set_state_raw') as mock_set,
   ):
     with pytest.raises(KeyboardInterrupt):
       _mod.worker()
@@ -791,7 +791,7 @@ def test_worker_shows_webhook_private_message_in_normal_mode(monkeypatch: pytest
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
     patch('public.is_public', return_value=False),
-    patch('integrations.vestaboard.set_state'),
+    patch('integrations.vestaboard.set_state_raw'),
     patch('time.sleep'),
     patch.object(_mod, '_hold_interrupt'),
   ):
@@ -803,7 +803,7 @@ def test_worker_board_locked_requeues_within_timeout() -> None:
   msg = _make_worker_msg(scheduled_at=time.monotonic(), timeout=3600)
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
-    patch('integrations.vestaboard.set_state', side_effect=vb.BoardLockedError('locked')),
+    patch('integrations.vestaboard.set_state_raw', side_effect=vb.BoardLockedError('locked')),
     patch('time.sleep'),
   ):
     with pytest.raises(KeyboardInterrupt):
@@ -815,7 +815,7 @@ def test_worker_board_locked_discards_after_timeout() -> None:
   msg = _make_worker_msg(scheduled_at=time.monotonic() - 1000, timeout=10)
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
-    patch('integrations.vestaboard.set_state', side_effect=vb.BoardLockedError('locked')),
+    patch('integrations.vestaboard.set_state_raw', side_effect=vb.BoardLockedError('locked')),
     patch('time.sleep'),
   ):
     with pytest.raises(KeyboardInterrupt):
@@ -828,7 +828,7 @@ def test_worker_log_includes_template_name(caplog: pytest.LogCaptureFixture) -> 
   msg.name = 'user.test.my_template'
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
-    patch('integrations.vestaboard.set_state'),
+    patch('integrations.vestaboard.set_state_raw'),
     patch('time.sleep'),
     patch.object(_mod, '_hold_interrupt'),
   ):
@@ -853,7 +853,7 @@ def test_worker_clears_stale_hold_interrupt_before_hold() -> None:
 
   with (
     patch.object(_mod, 'pop_valid_message', return_value=msg),
-    patch('integrations.vestaboard.set_state'),
+    patch('integrations.vestaboard.set_state_raw'),
     patch.object(_mod, '_do_hold', side_effect=_fake_do_hold),
   ):
     with pytest.raises(KeyboardInterrupt):
@@ -887,7 +887,7 @@ def test_worker_sets_hold_tag_before_set_state() -> None:
 
   with (
     patch.object(_mod, 'pop_valid_message', return_value=msg),
-    patch('integrations.vestaboard.set_state', side_effect=_fake_set_state),
+    patch('integrations.vestaboard.set_state_raw', side_effect=_fake_set_state),
   ):
     with pytest.raises(KeyboardInterrupt):
       _mod.worker()
@@ -908,12 +908,14 @@ def test_worker_clears_hold_tag_on_integration_data_unavailable() -> None:
   )
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
-    patch('integrations.vestaboard.set_state', side_effect=IntegrationDataUnavailableError('no data')),
+    # Raise from render() which is in the fetch/render phase, since worker
+    # attribution now separates fetch-phase from send-phase errors.
+    patch('integrations.vestaboard.render', side_effect=IntegrationDataUnavailableError('no data')),
   ):
     with pytest.raises(KeyboardInterrupt):
       _mod.worker()
 
-  assert _mod.current_hold_tag() == '', 'tag must be cleared when set_state raises IntegrationDataUnavailableError'
+  assert _mod.current_hold_tag() == '', 'tag must be cleared when fetch phase raises IntegrationDataUnavailableError'
 
 
 def test_worker_clears_hold_tag_on_board_locked() -> None:
@@ -929,7 +931,7 @@ def test_worker_clears_hold_tag_on_board_locked() -> None:
   )
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
-    patch('integrations.vestaboard.set_state', side_effect=vb.BoardLockedError('locked')),
+    patch('integrations.vestaboard.set_state_raw', side_effect=vb.BoardLockedError('locked')),
     patch('time.sleep'),
   ):
     with pytest.raises(KeyboardInterrupt):
@@ -951,7 +953,7 @@ def test_worker_clears_hold_tag_on_generic_exception() -> None:
   )
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
-    patch('integrations.vestaboard.set_state', side_effect=RuntimeError('boom')),
+    patch('integrations.vestaboard.set_state_raw', side_effect=RuntimeError('boom')),
   ):
     with pytest.raises(KeyboardInterrupt):
       _mod.worker()
@@ -1000,7 +1002,7 @@ def test_worker_refires_interrupt_when_same_tag_message_queued_during_set_state(
 
   with (
     patch.object(_mod, 'pop_valid_message', return_value=now_playing),
-    patch('integrations.vestaboard.set_state', side_effect=_fake_set_state),
+    patch('integrations.vestaboard.set_state_raw', side_effect=_fake_set_state),
     patch.object(_mod, '_do_hold', side_effect=_fake_do_hold),
   ):
     with pytest.raises(KeyboardInterrupt):
@@ -1009,6 +1011,159 @@ def test_worker_refires_interrupt_when_same_tag_message_queued_during_set_state(
   assert interrupt_state_at_hold == [True], (
     '_hold_interrupt must be re-fired when a same-tag message is queued during set_state'
   )
+
+
+# --- Worker health attribution (phase split: fetch vs send) ---
+
+
+def _make_integration_worker_msg(*, integration: str, scheduled_at: float, timeout: int) -> Any:
+  """Build a worker message whose fetch phase calls a mocked integration."""
+  return _mod.QueuedMessage(
+    priority=5,
+    seq=0,
+    name=f'user.{integration}.tmpl',
+    scheduled_at=scheduled_at,
+    data={
+      'integration': integration,
+      'templates': [{'format': ['HELLO']}],
+      'variables': {},
+      'truncation': 'hard',
+    },
+    hold=60,
+    timeout=timeout,
+  )
+
+
+def test_worker_fetch_failure_records_integration_not_vestaboard() -> None:
+  """When the integration raises, only the integration target gets an error."""
+  msg = _make_integration_worker_msg(integration='weather', scheduled_at=time.monotonic(), timeout=3600)
+  mock_int = MagicMock()
+  mock_int.get_variables.side_effect = RuntimeError('fetch boom')
+  with (
+    patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
+    patch.object(_mod, '_get_integration', return_value=mock_int),
+    patch('integrations.vestaboard.set_state_raw') as mock_send,
+    patch.object(_mod._health_mod, 'record_error') as mock_err,
+    patch.object(_mod._health_mod, 'record_success') as mock_ok,
+    patch.object(_mod, '_do_hold'),
+    patch('time.sleep'),
+  ):
+    with pytest.raises(KeyboardInterrupt):
+      _mod.worker()
+  mock_send.assert_not_called()
+  # Exactly one error for 'weather'; no errors for vestaboard.
+  targets_with_errors = [c.args[0] for c in mock_err.call_args_list]
+  assert 'weather' in targets_with_errors
+  assert _mod._health_mod.VESTABOARD_TARGET not in targets_with_errors
+  # No successes recorded at all — fetch never completed.
+  targets_with_success = [c.args[0] for c in mock_ok.call_args_list]
+  assert 'weather' not in targets_with_success
+  assert _mod._health_mod.VESTABOARD_TARGET not in targets_with_success
+
+
+def test_worker_send_failure_records_integration_success_and_vestaboard_error() -> None:
+  """Integration success + vestaboard HTTPError → both recorded distinctly."""
+  import requests
+
+  msg = _make_integration_worker_msg(integration='weather', scheduled_at=time.monotonic(), timeout=3600)
+  mock_int = MagicMock()
+  mock_int.get_variables.return_value = {}
+  with (
+    patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
+    patch.object(_mod, '_get_integration', return_value=mock_int),
+    patch('integrations.vestaboard.set_state_raw', side_effect=requests.HTTPError('500')),
+    patch.object(_mod._health_mod, 'record_error') as mock_err,
+    patch.object(_mod._health_mod, 'record_success') as mock_ok,
+    patch.object(_mod, '_do_hold'),
+    patch('time.sleep'),
+  ):
+    with pytest.raises(KeyboardInterrupt):
+      _mod.worker()
+  # Integration recorded success (fetch succeeded).
+  assert ('weather',) in [c.args for c in mock_ok.call_args_list]
+  # Vestaboard recorded error.
+  err_targets = [c.args[0] for c in mock_err.call_args_list]
+  assert _mod._health_mod.VESTABOARD_TARGET in err_targets
+  # Integration did NOT get an error.
+  assert 'weather' not in err_targets
+
+
+def test_worker_duplicate_content_records_both_success() -> None:
+  """409 DuplicateContentError counts as vestaboard success (user's goal met)."""
+  msg = _make_integration_worker_msg(integration='weather', scheduled_at=time.monotonic(), timeout=3600)
+  mock_int = MagicMock()
+  mock_int.get_variables.return_value = {}
+  with (
+    patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
+    patch.object(_mod, '_get_integration', return_value=mock_int),
+    patch('integrations.vestaboard.set_state_raw', side_effect=vb.DuplicateContentError('dup')),
+    patch.object(_mod._health_mod, 'record_error') as mock_err,
+    patch.object(_mod._health_mod, 'record_success') as mock_ok,
+    patch.object(_mod._health_mod, 'record_locked') as mock_locked,
+    patch.object(_mod, '_do_hold'),
+    patch('time.sleep'),
+  ):
+    with pytest.raises(KeyboardInterrupt):
+      _mod.worker()
+  ok_targets = [c.args[0] for c in mock_ok.call_args_list]
+  assert 'weather' in ok_targets
+  assert _mod._health_mod.VESTABOARD_TARGET in ok_targets
+  mock_err.assert_not_called()
+  mock_locked.assert_not_called()
+
+
+def test_worker_board_locked_records_integration_success_and_vestaboard_locked() -> None:
+  """423 BoardLockedError → vestaboard.locked, integration.success."""
+  msg = _make_integration_worker_msg(integration='weather', scheduled_at=time.monotonic(), timeout=3600)
+  mock_int = MagicMock()
+  mock_int.get_variables.return_value = {}
+  with (
+    patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
+    patch.object(_mod, '_get_integration', return_value=mock_int),
+    patch('integrations.vestaboard.set_state_raw', side_effect=vb.BoardLockedError('locked')),
+    patch.object(_mod._health_mod, 'record_error') as mock_err,
+    patch.object(_mod._health_mod, 'record_success') as mock_ok,
+    patch.object(_mod._health_mod, 'record_locked') as mock_locked,
+    patch.object(_mod, '_do_hold'),
+    patch('time.sleep'),
+  ):
+    with pytest.raises(KeyboardInterrupt):
+      _mod.worker()
+  # Integration fetch recorded success.
+  assert ('weather',) in [c.args for c in mock_ok.call_args_list]
+  # Vestaboard locked, not errored.
+  mock_locked.assert_called_once_with(_mod._health_mod.VESTABOARD_TARGET)
+  err_targets = [c.args[0] for c in mock_err.call_args_list]
+  assert _mod._health_mod.VESTABOARD_TARGET not in err_targets
+
+
+def test_worker_quiet_mode_no_vestaboard_health_event() -> None:
+  """In quiet mode the board is not POSTed to — no vestaboard event recorded."""
+  msg = _make_integration_worker_msg(integration='weather', scheduled_at=time.monotonic(), timeout=3600)
+  mock_int = MagicMock()
+  mock_int.get_variables.return_value = {}
+  with (
+    patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
+    patch.object(_mod, '_get_integration', return_value=mock_int),
+    patch('quiet.is_quiet', return_value=True),
+    patch('quiet.set_virtual_state'),
+    patch('integrations.vestaboard.set_state_raw') as mock_send,
+    patch.object(_mod._health_mod, 'record_error') as mock_err,
+    patch.object(_mod._health_mod, 'record_success') as mock_ok,
+    patch.object(_mod._health_mod, 'record_locked') as mock_locked,
+    patch.object(_mod, '_do_hold'),
+    patch('time.sleep'),
+  ):
+    with pytest.raises(KeyboardInterrupt):
+      _mod.worker()
+  mock_send.assert_not_called()
+  # Integration still gets credit for the fetch.
+  assert ('weather',) in [c.args for c in mock_ok.call_args_list]
+  # Vestaboard gets no events in quiet mode — recording a fake success would
+  # mask real outages when quiet mode is active.
+  assert _mod._health_mod.VESTABOARD_TARGET not in [c.args[0] for c in mock_ok.call_args_list]
+  assert _mod._health_mod.VESTABOARD_TARGET not in [c.args[0] for c in mock_err.call_args_list]
+  mock_locked.assert_not_called()
 
 
 # --- _load_file (private key missing) ---
@@ -1307,7 +1462,7 @@ def test_worker_calls_integration_get_variables() -> None:
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
     patch.object(_mod, '_get_integration', return_value=mock_integration),
-    patch('integrations.vestaboard.set_state'),
+    patch('integrations.vestaboard.set_state_raw'),
     patch('time.sleep'),
   ):
     with pytest.raises(KeyboardInterrupt):
@@ -1333,7 +1488,7 @@ def test_worker_logs_and_skips_on_missing_integration_deps() -> None:
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
     patch.object(_mod, '_get_integration', side_effect=RuntimeError('missing dependencies')),
-    patch('integrations.vestaboard.set_state') as mock_set_state,
+    patch('integrations.vestaboard.set_state_raw') as mock_set_state,
     patch('time.sleep'),
   ):
     with pytest.raises(KeyboardInterrupt):
@@ -1352,7 +1507,7 @@ def test_worker_still_holds_on_duplicate_content() -> None:
   hold_called = []
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
-    patch('integrations.vestaboard.set_state', side_effect=vb.DuplicateContentError('already shown')),
+    patch('integrations.vestaboard.set_state_raw', side_effect=vb.DuplicateContentError('already shown')),
     patch.object(_mod, '_do_hold', side_effect=lambda *a, **kw: hold_called.append(True)),
   ):
     with pytest.raises(KeyboardInterrupt):
@@ -1424,7 +1579,7 @@ def test_worker_silently_skips_on_data_unavailable() -> None:
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
     patch.object(_mod, '_get_integration', return_value=mock_integration),
-    patch('integrations.vestaboard.set_state') as mock_set_state,
+    patch('integrations.vestaboard.set_state_raw') as mock_set_state,
     patch('time.sleep'),
   ):
     with pytest.raises(KeyboardInterrupt):
@@ -1459,7 +1614,7 @@ def test_worker_uses_integration_fn_when_specified() -> None:
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
     patch.object(_mod, '_get_integration', return_value=mock_integration),
-    patch('integrations.vestaboard.set_state'),
+    patch('integrations.vestaboard.set_state_raw'),
     patch('time.sleep'),
   ):
     with pytest.raises(KeyboardInterrupt):
@@ -1788,7 +1943,7 @@ def test_worker_passes_refresh_fn_to_do_hold_for_integration_with_refresh_interv
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
     patch.object(_mod, '_get_integration', return_value=mock_integration),
-    patch('integrations.vestaboard.set_state'),
+    patch('integrations.vestaboard.set_state_raw'),
     patch.object(_mod, '_do_hold', side_effect=_fake_do_hold),
   ):
     with pytest.raises(KeyboardInterrupt):
@@ -1812,7 +1967,7 @@ def test_worker_no_refresh_fn_when_no_refresh_interval() -> None:
 
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
-    patch('integrations.vestaboard.set_state'),
+    patch('integrations.vestaboard.set_state_raw'),
     patch.object(_mod, '_do_hold', side_effect=_fake_do_hold),
   ):
     with pytest.raises(KeyboardInterrupt):
@@ -1840,14 +1995,14 @@ def test_worker_refresh_fn_skips_duplicate_content() -> None:
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
     patch.object(_mod, '_get_integration', return_value=mock_integration),
-    patch('integrations.vestaboard.set_state'),
+    patch('integrations.vestaboard.set_state_raw'),
     patch.object(_mod, '_do_hold', side_effect=_fake_do_hold),
   ):
     with pytest.raises(KeyboardInterrupt):
       _mod.worker()
 
   assert refresh_fn_ref, 'refresh_fn was not captured'
-  with patch('integrations.vestaboard.set_state', side_effect=vb.DuplicateContentError('dup')):
+  with patch('integrations.vestaboard.set_state_raw', side_effect=vb.DuplicateContentError('dup')):
     refresh_fn_ref[0]()  # must not raise
 
 
@@ -1867,7 +2022,7 @@ def test_worker_idle_refresh_called_after_hold_expires() -> None:
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, None, KeyboardInterrupt()]),
     patch.object(_mod, '_get_integration', return_value=mock_integration),
-    patch('integrations.vestaboard.set_state', side_effect=fake_set_state),
+    patch('integrations.vestaboard.set_state_raw', side_effect=fake_set_state),
     patch.object(_mod, '_do_hold'),  # returns immediately
   ):
     with pytest.raises(KeyboardInterrupt):
@@ -1891,7 +2046,7 @@ def test_worker_idle_refresh_cleared_on_new_send() -> None:
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg1, msg2, None, KeyboardInterrupt()]),
     patch.object(_mod, '_get_integration', return_value=mock_integration),
-    patch('integrations.vestaboard.set_state', side_effect=fake_set_state),
+    patch('integrations.vestaboard.set_state_raw', side_effect=fake_set_state),
     patch.object(_mod, '_do_hold'),  # returns immediately
   ):
     with pytest.raises(KeyboardInterrupt):
@@ -1917,7 +2072,7 @@ def test_worker_idle_refresh_error_logged_and_continues(caplog: pytest.LogCaptur
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, None, KeyboardInterrupt()]),
     patch.object(_mod, '_get_integration', return_value=mock_integration),
-    patch('integrations.vestaboard.set_state', side_effect=fake_set_state),
+    patch('integrations.vestaboard.set_state_raw', side_effect=fake_set_state),
     patch.object(_mod, '_do_hold'),
   ):
     with pytest.raises(KeyboardInterrupt):
@@ -1936,7 +2091,7 @@ def test_worker_idle_refresh_not_set_for_non_integration_message() -> None:
 
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, None, KeyboardInterrupt()]),
-    patch('integrations.vestaboard.set_state', side_effect=fake_set_state),
+    patch('integrations.vestaboard.set_state_raw', side_effect=fake_set_state),
     patch.object(_mod, '_do_hold'),
   ):
     with pytest.raises(KeyboardInterrupt):
@@ -1963,7 +2118,7 @@ def test_worker_idle_refresh_skipped_when_queue_pending() -> None:
     with (
       patch.object(_mod, 'pop_valid_message', side_effect=[msg, None, KeyboardInterrupt()]),
       patch.object(_mod, '_get_integration', return_value=mock_integration),
-      patch('integrations.vestaboard.set_state', side_effect=fake_set_state),
+      patch('integrations.vestaboard.set_state_raw', side_effect=fake_set_state),
       patch.object(_mod, '_do_hold'),  # returns immediately
     ):
       with pytest.raises(KeyboardInterrupt):
@@ -2187,7 +2342,7 @@ def test_worker_logs_warning_on_integration_data_unavailable(caplog: pytest.LogC
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
     patch.object(_mod, '_get_integration', return_value=mock_integration),
-    patch('integrations.vestaboard.set_state'),
+    patch('integrations.vestaboard.set_state_raw'),
     patch('time.sleep'),
   ):
     with pytest.raises(KeyboardInterrupt):
@@ -2287,7 +2442,7 @@ def test_worker_quiet_mode_stores_virtual_state() -> None:
   try:
     with (
       patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
-      patch('integrations.vestaboard.set_state') as mock_set_state,
+      patch('integrations.vestaboard.set_state_raw') as mock_set_state,
       patch.object(_mod, '_do_hold'),
     ):
       with pytest.raises(KeyboardInterrupt):
@@ -2529,7 +2684,7 @@ def test_board_showing_private_set_false_on_non_private_send() -> None:
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
     patch('public.is_public', return_value=False),
-    patch('integrations.vestaboard.set_state'),
+    patch('integrations.vestaboard.set_state_raw'),
     patch.object(_mod, '_do_hold', side_effect=lambda *a, **kw: None),
     patch.object(_mod, '_hold_interrupt'),
   ):
@@ -2548,7 +2703,7 @@ def test_board_showing_private_set_true_on_private_send() -> None:
   with (
     patch.object(_mod, 'pop_valid_message', side_effect=[msg, KeyboardInterrupt()]),
     patch('public.is_public', return_value=False),
-    patch('integrations.vestaboard.set_state'),
+    patch('integrations.vestaboard.set_state_raw'),
     patch.object(_mod, '_do_hold', side_effect=lambda *a, **kw: None),
     patch.object(_mod, '_hold_interrupt'),
   ):

--- a/tests/core/test_webhook.py
+++ b/tests/core/test_webhook.py
@@ -1080,6 +1080,35 @@ def test_health_endpoint_returns_200_when_healthy() -> None:
       assert data['status'] == 'healthy'
       assert 'weather' in data['integrations']
       assert data['integrations']['weather']['status'] == 'healthy'
+      # Vestaboard target is reported under its own top-level key, not under
+      # integrations. It starts UNKNOWN on a fresh reset — does not drive
+      # top-level status.
+      assert 'vestaboard' in data
+      assert data['vestaboard'] is not None
+      assert 'vestaboard' not in data['integrations']
+    finally:
+      server.shutdown()
+      _health_mod.reset()
+
+
+@pytest.mark.skipif(_CRED_HASH is None, reason='argon2-cffi not installed')
+def test_health_endpoint_returns_503_when_vestaboard_errored() -> None:
+  """A vestaboard send failure drives the endpoint to 503 even with healthy integrations."""
+  _health_mod.reset()
+  _health_mod.init()
+  _health_mod.register('weather')
+  _health_mod.record_success('weather')
+  _health_mod.record_error(_health_mod.VESTABOARD_TARGET, 'HTTP 500')
+
+  with patch.dict('config._config', _health_cred_config()):
+    server, port = _start_test_server()
+    try:
+      status, body = _get(port, '/health')
+      assert status == 503
+      data = json.loads(body)
+      assert data['status'] == 'error'
+      assert data['vestaboard']['status'] == 'error'
+      assert data['integrations']['weather']['status'] == 'healthy'
     finally:
       server.shutdown()
       _health_mod.reset()

--- a/uv.lock
+++ b/uv.lock
@@ -275,7 +275,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.16.2"
+version = "1.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Closes #512.

## Summary

Adds a reserved `vestaboard` health target for the Vestaboard send path itself, separate from integration fetch attribution. Previously a Vestaboard backend outage would smear across every integration's health status — and conversely, a single flaky integration was indistinguishable from a vestaboard-wide problem.

- **Phase split in the worker**: fetch + render → attributed to integration; POST → attributed to `vestaboard`. Applied to both the main worker loop (`worker()`) and the idle/hold refresh closure (`_do_refresh`). `_clear_private_content`'s blank-POST on public-mode activation is also attributed to `vestaboard`.
- **`vestaboard` target auto-registered** at `health.init()` so /health always reports it. It starts UNKNOWN on fresh deploy and does not drive top-level status until real events accumulate.
- **New `vestaboard` top-level key** in `/health` response, separate from `integrations`. Status rollup still considers it — a vestaboard `error` drives top-level to `error` regardless of integration health.
- **New `LOCKED` event type** for 423 responses (quiet hours, brief backend lock). Tracked via `last_locked` / `locked_events` but deliberately excluded from the success-rate denominator so nightly quiet-hours 423s do not tank vestaboard status.
- **409 DuplicateContentError** still counts as vestaboard success — the user's content is on the board, which is the goal. Integration also records success (fetch succeeded).
- **Quiet mode** records the integration fetch success but no vestaboard event — recording a fake success when no POST hits the network would mask real outages whenever quiet mode is active.
- **Cleans up an old oddity** in `_do_refresh`: `except vestaboard.DuplicateContentError, IntegrationDataUnavailableError` was a valid (but confusing) Python 3 tuple expression. Replaced with explicit phase-split handlers.
- **No migration** of historical `data/health.jsonl` entries. Old integration-attributed send failures stay in the log as a historical artifact and age out after `_PURGE_DAYS`. "Start fresh" was the explicitly-chosen design.

## Tests

- `tests/core/test_health.py` — 7 new tests:
  - `test_record_locked_event` (new event type surfaces in detail)
  - `test_locked_excluded_from_success_rate`
  - `test_locked_does_not_mask_errors`
  - `test_vestaboard_target_registered_on_init`
  - `test_vestaboard_errored_drives_rollup`
  - `test_vestaboard_unknown_does_not_drive_rollup`
  - `test_locked_persisted_and_reloaded`
- `tests/core/test_scheduler.py` — 5 new worker-level tests for phase-split attribution:
  - `test_worker_fetch_failure_records_integration_not_vestaboard`
  - `test_worker_send_failure_records_integration_success_and_vestaboard_error`
  - `test_worker_duplicate_content_records_both_success`
  - `test_worker_board_locked_records_integration_success_and_vestaboard_locked`
  - `test_worker_quiet_mode_no_vestaboard_health_event`
- `tests/core/test_webhook.py` — 1 new endpoint test + update existing test:
  - `test_health_endpoint_returns_503_when_vestaboard_errored` (vestaboard error → endpoint 503)
  - `test_health_endpoint_returns_200_when_healthy` now also asserts `vestaboard` is a top-level key and not inside `integrations`
- Existing tests updated: scheduler tests that patched `integrations.vestaboard.set_state` now patch `set_state_raw` (worker now calls `render()` then `set_state_raw()` directly for clean phase attribution). `test_health.py` direct-access test renamed `_integrations` → `_targets`.

## Docs

- `README.md` health response example updated with the new `vestaboard` top-level key and `last_locked` / `locked_events` fields. Added prose explaining the separation and the locked-events semantics.

## Check suite

- [x] `uv run pytest` — 1382 passed, 21 deselected
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv run bandit -c pyproject.toml -r .`

## Version

1.16.2 → 1.17.0 (minor bump — new public `/health` response shape, additive).

— *Claude Code*
