### PR TITLE
fix(bart): shorten schedule window to 07–08 to unblock discogs

### DIFF
--- a/content/README.md
+++ b/content/README.md
@@ -259,7 +259,7 @@ new integrations in overnight windows unless there's a specific reason
 | `11:45` daily | `unraid.status` | Hobbies | 3 | 300 s | 3600 s | Private; solo `:45` slot |
 | `:00` at 12/20 | `trakt.next_up` | Entertainment | 4 | 1200 s | 1800 s | Private; noon = plan for evening, 20:00 = settle in |
 | `21:00` daily | `morning_night.good_night` | Ambient | 4 | 300 s | 3600 s | Moon phase visual; queues behind weather |
-| `*/5` 07–09 Mon–Fri | `bart.departures` | Logistics | 8 | 290 s | 60 s | Refresh 60 s; dominates weekday mornings |
+| `*/5` 07–08 Mon–Fri | `bart.departures` | Logistics | 8 | 290 s | 60 s | Refresh 60 s; dominates weekday mornings |
 | `*/3` 07–23 daily | `trakt.watching` | Entertainment | 7 | 180 s | 120 s | Refresh 30 s; no-op when not watching |
 | `:45` at 12/20 | `youtube.live` | Entertainment | 4 | 300 s | 3600 s | Private; no-op when nothing live |
 | webhook only | `plex` (3 templates) | Entertainment | 8 | 14400 / 60 s | 30 s | Private; indefinite semantics (14400 s = 4 h safety ceiling); interrupts on state change |

--- a/content/contrib/bart.json
+++ b/content/contrib/bart.json
@@ -2,7 +2,7 @@
   "templates": {
     "departures": {
       "schedule": {
-        "cron": "*/5 7-9 * * mon-fri",
+        "cron": "*/5 7-8 * * mon-fri",
         "hold": 290,
         "timeout": 60,
         "refresh_interval": 60

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dev = [
     "pip-audit>=2.10.0",
     "pre-commit>=4.5.1",
     "pyright>=1.1.408",
-    "pytest>=8.3.5",
+    "pytest>=9.0.3",
     "ruff>=0.15.2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.17.0"
+version = "1.17.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -314,7 +314,7 @@ dev = [
     { name = "pip-audit", specifier = ">=2.10.0" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pyright", specifier = ">=1.1.408" },
-    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "ruff", specifier = ">=0.15.2" },
 ]
 
@@ -748,7 +748,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -757,9 +757,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -275,7 +275,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.17.0"
+version = "1.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

## Summary

- Shorten BART departures schedule from `*/5 7-9 * * mon-fri` to `*/5 7-8 * * mon-fri`
- Last BART fire moves from 09:55 to 08:55 (hold ends ~09:00)
- Frees the 09:00+ window for lower-priority queued content like discogs morning_spin

## Context

Log analysis showed that BART departures (priority 8, every 5 min, 290s hold) completely dominated the 07:00–09:55 weekday window. Discogs morning_spin (priority 5, fires at 08:30) could only reach the display during rare ~5-second gaps between BART holds when no other priority 6+ message happened to be queued — essentially a coin flip. On two of the last eight weekdays, discogs timed out without ever being shown.

With BART ending at ~09:00, discogs (enqueued at 08:30 with a 1-hour timeout) will reliably display once BART's last hold expires.

## Test plan

- [x] `uv run pytest` — 1382 passed
- [x] `test_schedule_lint.py` — schedule map in `content/README.md` updated and passing
- [x] Full check suite (ruff, pyright, bandit, pip-audit, pre-commit) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
