### PR TITLE
fix(scheduler): preserve webhook interrupt intent across set_state window

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.17.2"
+version = "1.17.3"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -139,6 +139,7 @@ class QueuedMessage:
   timeout: int  # seconds message can wait in queue before being discarded
   indefinite: bool = False  # if True, hold runs until explicitly interrupted
   supersede_tag: str = ''  # if non-empty, enqueue() removes earlier same-tagged messages first
+  interrupt: bool = False  # if True, post-set_state re-fire block will re-arm _hold_interrupt to break the new hold
 
   def __lt__(self, other: 'QueuedMessage') -> bool:
     # PriorityQueue is a min-heap, so we invert priority comparison so that
@@ -182,6 +183,7 @@ def enqueue(
   name: str = '',
   indefinite: bool = False,
   supersede_tag: str = '',
+  interrupt: bool = False,
 ) -> None:
   global _counter
   with _counter_lock:
@@ -198,6 +200,7 @@ def enqueue(
     timeout=timeout,
     indefinite=indefinite,
     supersede_tag=supersede_tag,
+    interrupt=interrupt,
   )
 
   if supersede_tag:
@@ -662,15 +665,22 @@ def worker() -> None:
 
     # Clear any interrupt that fired before this hold began (e.g. the webhook
     # interrupt that preempted the previous hold and triggered enqueueing of
-    # this message) so it cannot exit the new hold instantly. But if a same-tag
-    # message arrived during the set_state API call above, re-fire the interrupt
-    # so _do_hold exits immediately and the worker processes the newer event.
+    # this message) so it cannot exit the new hold instantly. But if a newer
+    # message arrived during the set_state API call above that wants to cut
+    # through — either because it shares our supersede_tag, or because it
+    # carries its own interrupt=True intent and we (the new hold) are below
+    # the priority interrupt threshold — re-fire the interrupt so _do_hold
+    # exits immediately and the worker processes the newer event.
     _hold_interrupt.clear()
-    if message.supersede_tag:
-      with _queue.mutex:
-        if any(m.supersede_tag == message.supersede_tag for m in _queue.queue):
-          logger.debug('[hold] %s re-firing interrupt: same-tag message queued during set_state', message.name)
+    with _queue.mutex:
+      for m in _queue.queue:
+        same_tag = bool(message.supersede_tag) and m.supersede_tag == message.supersede_tag
+        interrupt_intent = m.interrupt and message.priority < _INTERRUPT_PRIORITY_THRESHOLD
+        if same_tag or interrupt_intent:
+          reason = 'same-tag' if same_tag else 'interrupt intent'
+          logger.debug('[hold] %s re-firing interrupt (%s): message queued during set_state', message.name, reason)
           _hold_interrupt.set()
+          break
     _do_hold(message, _get_min_hold(), refresh_fn=_refresh_fn, refresh_interval=refresh_interval)
     with _current_hold_lock:
       _current_hold_supersede_tag = ''
@@ -847,6 +857,7 @@ def _make_webhook_handler() -> type:
         name=result.name or f'webhook.{integration_name}',
         indefinite=result.indefinite,
         supersede_tag=result.supersede_tag,
+        interrupt=result.interrupt,
       )
       if result.interrupt:
         # Same-tag supersede always interrupts regardless of priority threshold —

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -1013,6 +1013,110 @@ def test_worker_refires_interrupt_when_same_tag_message_queued_during_set_state(
   )
 
 
+def test_worker_refires_interrupt_when_distinct_tag_interrupt_message_queued_during_set_state() -> None:
+  # Regression: a webhook-driven message with interrupt=True AND a distinct
+  # supersede_tag that arrives during the prior message's set_state_raw used
+  # to be silently dropped — the worker's post-set_state _hold_interrupt.clear()
+  # only re-fired on same-tag supersession. Now the re-fire block also covers
+  # distinct-tag interrupt intent when the new hold is below the priority
+  # interrupt threshold (mirrors the webhook-server-side gate).
+  hello = _mod.QueuedMessage(
+    priority=7,
+    seq=0,
+    name='webhook.notion',
+    scheduled_at=time.monotonic(),
+    data={'templates': [{'format': ['HELLO']}], 'variables': {}, 'truncation': 'hard'},
+    hold=120,
+    timeout=120,
+    supersede_tag='notion.hello',
+  )
+  urgent = _mod.QueuedMessage(
+    priority=7,
+    seq=1,
+    name='webhook.notion',
+    scheduled_at=time.monotonic(),
+    data={'templates': [{'format': ['URGENT']}], 'variables': {}, 'truncation': 'hard'},
+    hold=120,
+    timeout=120,
+    supersede_tag='notion.alert',
+    interrupt=True,
+  )
+
+  interrupt_state_at_hold: list[bool] = []
+
+  def _fake_do_hold(m: Any, min_hold: Any, **kw: Any) -> None:
+    interrupt_state_at_hold.append(_mod._hold_interrupt.is_set())
+    raise KeyboardInterrupt()
+
+  def _fake_set_state(*_args: Any, **_kwargs: Any) -> None:
+    # Simulate the urgent alert arriving during the set_state API call for hello.
+    _mod._queue.put(urgent)
+
+  with (
+    patch.object(_mod, 'pop_valid_message', return_value=hello),
+    patch('integrations.vestaboard.set_state_raw', side_effect=_fake_set_state),
+    patch.object(_mod, '_do_hold', side_effect=_fake_do_hold),
+  ):
+    with pytest.raises(KeyboardInterrupt):
+      _mod.worker()
+
+  assert interrupt_state_at_hold == [True], (
+    '_hold_interrupt must be re-fired when a distinct-tag interrupt=True message is queued during set_state'
+  )
+
+
+def test_worker_does_not_refire_interrupt_when_interrupt_message_priority_is_uninterruptible() -> None:
+  # Complement to the above: if the new hold is at or above the priority
+  # interrupt threshold (e.g. pri 8+, like a Plex now-playing), an
+  # unrelated interrupt=True message in the queue must NOT re-fire — the
+  # current hold should run its full duration, consistent with the
+  # webhook-server-side `_current_hold_is_interruptible` gate.
+  high_pri = _mod.QueuedMessage(
+    priority=_mod._INTERRUPT_PRIORITY_THRESHOLD,
+    seq=0,
+    name='webhook.plex',
+    scheduled_at=time.monotonic(),
+    data={'templates': [{'format': ['NOW PLAYING']}], 'variables': {}, 'truncation': 'hard'},
+    hold=14400,
+    timeout=30,
+    indefinite=True,
+    supersede_tag='plex',
+  )
+  urgent = _mod.QueuedMessage(
+    priority=7,
+    seq=1,
+    name='webhook.notion',
+    scheduled_at=time.monotonic(),
+    data={'templates': [{'format': ['URGENT']}], 'variables': {}, 'truncation': 'hard'},
+    hold=120,
+    timeout=120,
+    supersede_tag='notion.alert',
+    interrupt=True,
+  )
+
+  interrupt_state_at_hold: list[bool] = []
+
+  def _fake_do_hold(m: Any, min_hold: Any, **kw: Any) -> None:
+    interrupt_state_at_hold.append(_mod._hold_interrupt.is_set())
+    raise KeyboardInterrupt()
+
+  def _fake_set_state(*_args: Any, **_kwargs: Any) -> None:
+    _mod._queue.put(urgent)
+
+  with (
+    patch.object(_mod, 'pop_valid_message', return_value=high_pri),
+    patch('integrations.vestaboard.set_state_raw', side_effect=_fake_set_state),
+    patch.object(_mod, '_do_hold', side_effect=_fake_do_hold),
+  ):
+    with pytest.raises(KeyboardInterrupt):
+      _mod.worker()
+
+  assert interrupt_state_at_hold == [False], (
+    '_hold_interrupt must NOT be re-fired for an interrupt=True message '
+    'when the new hold is at/above the priority threshold'
+  )
+
+
 # --- Worker health attribution (phase split: fetch vs send) ---
 
 

--- a/tests/core/test_webhook.py
+++ b/tests/core/test_webhook.py
@@ -383,6 +383,7 @@ def test_handle_webhook_result_enqueues_message() -> None:
             name='test.webhook',
             indefinite=False,
             supersede_tag='',
+            interrupt=False,
           )
         finally:
           server.shutdown()

--- a/uv.lock
+++ b/uv.lock
@@ -275,7 +275,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.17.1"
+version = "1.17.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

Closes #520.

When a webhook-driven message with `interrupt=True` arrived while the worker was mid-`set_state_raw()` sending the previous message to the Vestaboard, the interrupt was silently cleared by `worker()` before `_do_hold` started. The existing re-fire block (`scheduler.py` ~L668) only preserved intent for same-`supersede_tag` supersession, so a distinct-tag urgent message was dropped — it sat in the queue for the previous message's full hold (120s), then got discarded as timed-out.

### Fix

- New `interrupt: bool = False` field on `QueuedMessage`, threaded through `enqueue()` and propagated from `WebhookMessage.interrupt` at the webhook server's enqueue call.
- Post-`set_state_raw` re-fire block broadened: also fires `_hold_interrupt` when any queued message has `interrupt=True` AND the new hold's priority is below `_INTERRUPT_PRIORITY_THRESHOLD` (pri 8). That gate mirrors the webhook-server-side `_current_hold_is_interruptible()` check, so the re-fire path matches the immediate-arrival path exactly.

### Deviations from the #520 plan comment

- The plan initially proposed gating on `queued.priority`. The correct gate is on the *new hold's* priority (the message about to `_do_hold`), mirroring the webhook-side `_current_hold_is_interruptible` check. Fixed during implementation.
- The plan flagged a question about "consuming" the interrupt flag on re-fire. Determined unnecessary: once re-fired, `_do_hold` breaks, the worker pops the next message, and the interrupt-intent message (if it's the popped one) is no longer in `_queue.queue` for the next iteration's re-fire scan. No double-fire risk.

### Tests

- `test_worker_refires_interrupt_when_distinct_tag_interrupt_message_queued_during_set_state` — the repro: pri-7 hello + pri-7 urgent with distinct tag enqueued during set_state, asserts `_hold_interrupt` is set when `_do_hold` runs.
- `test_worker_does_not_refire_interrupt_when_interrupt_message_priority_is_uninterruptible` — complement: pri-8 Plex hold + pri-7 interrupt=True notion message, asserts NO re-fire (mirrors the webhook-side gate).
- Updated `test_handle_webhook_result_enqueues_message` for the new `interrupt` kwarg on the enqueue call.
- Existing same-tag re-fire regression test continues to pass.

## Test plan

- Reviewed semantics against the immediate-arrival webhook path in `scheduler.py`'s webhook server (L836–L859) to ensure the re-fire gate is identical.
- Full check suite passed locally: `ruff check`, `ruff format --check`, `pyright` (0 errors), `bandit` (0 issues), `pip-audit` (no known vulnerabilities), `pre-commit pretty-format-json`, `pytest` (1374 passed, up from 1372 with two new tests added).
- Patch version bump 1.17.2 → 1.17.3 per the AGENTS.md release-worthy matrix (bug fix).
