### PR TITLE
fix(ynab): drop '/' assertion in integration test

### DIFF
--- a/tests/integrations/test_ynab_integration.py
+++ b/tests/integrations/test_ynab_integration.py
@@ -47,7 +47,8 @@ def test_get_variables(require_env: None, monkeypatch: pytest.MonkeyPatch) -> No
   assert amount.startswith('$'), f'amount missing $ prefix: {amount!r}'
 
   delta = result['delta'][0][0]
-  assert '/' in delta, f'delta missing month separator: {delta!r}'
+  assert delta[0] in ('+', '-'), f'delta missing sign prefix: {delta!r}'
+  assert delta.endswith('%') or delta.endswith('$0'), f'delta missing % or $0 suffix: {delta!r}'
 
   ynab._cache = None
   ynab._resolved_budget_id = None


### PR DESCRIPTION
## Summary

- Fixes the YNAB integration test that still asserted `'/' in delta`, which broke after #528 dropped the month-separator suffix.
- Replaces with assertions on sign prefix and percent/dollar-fallback suffix.

Test-only change, no version bump.

— *Claude Code*

## Test plan

- [x] Failing assertion in `tests/integrations/test_ynab_integration.py:50` updated
- [ ] Advisory CI integration test job passes on main after merge
