### PR TITLE
chore(dev): pre-commit hook to run integration tests for staged integrations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,10 @@ repos:
         language: script
         pass_filenames: false
         always_run: true
+
+      - id: staged-integration-tests
+        name: integration tests for staged integrations
+        entry: scripts/staged-integration-tests.sh
+        language: script
+        pass_filenames: false
+        always_run: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,6 +358,14 @@ A setup table prints at session start showing which env vars are set or missing.
 The `.env` file is git-ignored — never commit it. CI has no `.env` file; secrets
 come from GitHub secrets env vars directly.
 
+When `integrations/<name>.py` is staged, the `staged-integration-tests`
+pre-commit hook automatically runs `tests/integrations/test_<name>_integration.py`.
+Without `.env`, the hook prints a hint and passes (graceful degradation); with
+`.env` set up, real API calls catch contract / output-format mismatches before
+they reach `main`. CI's integration job is advisory (`continue-on-error: true`),
+so this local hook is the primary guard against regressions reaching `main`
+through the integration test path.
+
 - Mark tests with `@pytest.mark.integration` and `@pytest.mark.require_env('VAR', ...)`
 - Tests skip automatically when required env vars are absent (no failures)
 - Required env vars per integration (real API keys only; other settings are

--- a/scripts/staged-integration-tests.sh
+++ b/scripts/staged-integration-tests.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# staged-integration-tests.sh
+#
+# Pre-commit hook: when an integrations/<name>.py file is staged, run the
+# matching tests/integrations/test_<name>_integration.py if present.
+#
+# Catches API-contract / output-format mismatches before they reach main,
+# where they would otherwise only surface in the advisory CI integration job.
+#
+# Behavior:
+#   - Skips silently when no integration source files are staged.
+#   - Skips files in the SHARED_MODULES set (no per-name test exists).
+#   - Skips when the matching test file does not exist.
+#   - Treats pytest exit code 5 (no tests collected — all skipped due to
+#     missing env vars) as success with a hint pointing at .env setup.
+#   - Pytest exit code 1 (real failure) blocks the commit.
+
+set -uo pipefail
+
+# Shared modules used by other integrations — no per-name test by convention.
+SHARED_MODULES='__init__.py http.py media.py color.py tmdb.py google.py'
+
+is_shared() {
+  local name="$1"
+  for shared in $SHARED_MODULES; do
+    if [ "$name" = "$shared" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+tests_to_run=''
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  base="${file#integrations/}"
+  if is_shared "$base"; then
+    continue
+  fi
+  name="${base%.py}"
+  test_file="tests/integrations/test_${name}_integration.py"
+  if [ -f "$test_file" ]; then
+    tests_to_run="$tests_to_run $test_file"
+  fi
+done < <(git diff --cached --name-only --diff-filter=ACM | grep -E '^integrations/[^/]+\.py$' || true)
+
+# Trim leading whitespace.
+tests_to_run="${tests_to_run# }"
+
+if [ -z "$tests_to_run" ]; then
+  exit 0
+fi
+
+echo "Running integration tests for staged integrations: $tests_to_run"
+
+# shellcheck disable=SC2086  # intentional word-splitting for the file list
+uv run pytest -m integration -v $tests_to_run
+status=$?
+
+if [ $status -eq 0 ]; then
+  exit 0
+fi
+
+if [ $status -eq 5 ]; then
+  echo
+  echo "Integration tests skipped (missing env vars). Set up .env per AGENTS.md"
+  echo "to enable local integration test coverage on commit."
+  exit 0
+fi
+
+exit $status


### PR DESCRIPTION
## Summary

- Adds `scripts/staged-integration-tests.sh` and a matching local pre-commit hook entry.
- When `integrations/<name>.py` is staged, the hook runs `tests/integrations/test_<name>_integration.py`.
- Catches API-contract / output-format regressions before they reach `main` (the gap that caused #529).
- Local-only — relies on developer's `.env` per AGENTS.md. Without it, tests skip and the hook prints a hint and passes.

Closes #530

— *Claude Code*

## Test plan

- [x] No integration files staged → hook exits 0 silently
- [x] `integrations/ynab.py` staged → hook runs ynab integration test (passed locally)
- [x] `integrations/http.py` (shared module) staged → hook exits 0 silently
- [ ] Verify on next real integration change (e.g. when #527 lands)
