### PR TITLE
fix(ci): switch dependabot pip→uv ecosystem and exclude LICENSE.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,15 @@
 version: 2
 updates:
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: weekly
+    # Workaround for dependabot/dependabot-core#13960: the uv FileFetcher
+    # treats every .txt file in the repo as a pip requirements file and
+    # chokes parsing LICENSE.txt. Exclude it explicitly until the upstream
+    # fix (PR #14197) ships.
+    exclude-paths:
+      - "/LICENSE.txt"
     groups:
       all:
         patterns: ["*"]


### PR DESCRIPTION
Closes #534

## Summary

- Switch \`.github/dependabot.yml\` from \`package-ecosystem: pip\` to \`uv\` — aligns the config with how we actually manage deps (uv.lock, pyproject.toml). \`uv\` ecosystem GA'd Mar 2025; security updates added Dec 2025.
- Add \`exclude-paths: ["/LICENSE.txt"]\` to work around [dependabot-core#13960](https://github.com/dependabot/dependabot-core/issues/13960) — the uv FileFetcher matches all \`.txt\` files and tries to parse them as pip requirements, choking on \`MIT License\` (line 1 of LICENSE.txt). Upstream fix [PR #14197](https://github.com/dependabot/dependabot-core/pull/14197) is approved but unmerged.

This unblocks the auto "Graph Update: uv in /." workflow that has been failing on every push to main.

## Test plan

- [x] YAML parses (pre-commit hooks pass)
- [ ] Verify after merge: next "Graph Update: uv in /." run on main passes
- [ ] Verify on the next weekly Dependabot cycle: version-update PRs still fire and target uv.lock correctly

— *Claude Code*