### PR TITLE
chore: extract on-demand skills, fix dependabot config, address health-review findings

### DIFF
--- a/.agents/skills/health-review/SKILL.md
+++ b/.agents/skills/health-review/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: health-review
+description: Run the periodic project health audit for e-note-ion. Comprehensive checklist covering test coverage, code patterns, dependency CVEs, security posture, docs drift, stale comments, CI/CD hygiene, branch ruleset integrity, integration test status, GitHub-managed workflows, and issue hygiene. Invoke when the user asks for a "health check", "audit", "project review", at natural breakpoints (before a minor/major release, after a sprint of feature work), or whenever broad cross-cutting drift seems likely.
+---
+
+# Periodic Health Review
+
+## Description
+
+Comprehensive, repeatable audit of project health across code, tests, dependencies, docs, CI/CD, and the issue tracker. Designed to surface drift before it compounds.
+
+## When to Use
+
+- User asks for a "health check", "audit", "project review", or similar
+- Before a minor or major release (any time `version` is about to bump)
+- After a sprint of feature work (multiple PRs merged in close succession)
+- When you suspect cross-cutting drift (docs feel stale, "that hasn't been touched in a while" feeling)
+
+## Process
+
+1. **Run quick local checks first** (cheap, no agents needed):
+   - `uv run pip-audit` — flag any open CVEs
+   - `gh run list --workflow CI --branch main --limit 8` — confirm recent runs green
+   - `gh api repos/JasonPuglisi/e-note-ion/code-scanning/alerts ...` and `.../dependabot/alerts` — open alerts
+   - `gh issue list --state open --json number,labels,milestone | jq` — count untriaged issues
+   - `gh api repos/JasonPuglisi/e-note-ion/rulesets/13082160 --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'` — check ruleset
+   - `grep -rn "TODO\|FIXME\|XXX\|HACK" integrations/ *.py` — stale comments
+   - `grep -rn "# nosec" integrations/ *.py` — review every suppression for current justification
+2. **Spawn parallel subagents** for the breadth-heavy checks (test coverage, code-pattern consistency, docs drift, issue hygiene). Use `Explore` for read-only scans; use `general-purpose` when the agent needs Bash. Brief each agent with a tight scope and a word cap.
+3. **VERIFY every agent claim against the source before filing or fixing.** Subagents produce confident-sounding false positives — typically misreading conventions, missing recent changes, or applying generic intuition. A health-review pass that mostly trusts agents will file noise issues.
+4. **Apply the issue-volume convention** (see Constraints) to decide between inline fixes, individual issues, and a tracking issue.
+5. **Fix inline what's small** (one-line cleanups, missing docs entries, unassigned issues). File issues for substantive work. Use AskUserQuestion when the call is genuinely ambiguous, not for things you can grep.
+6. **Report back** with: clean ✅ findings, filed/fixed items, false positives caught (worth flagging — shapes how to interpret these reviews), and any meta improvements to the checklist itself.
+
+## Checklist
+
+1. **Test coverage** — gaps in unit tests; retroactive coverage for untested logic. Check `uv run pytest --cov=integrations --cov=. --cov-report=term-missing` for actual numbers (report-only, no threshold).
+2. **Code patterns** — consistency across integrations: import aliases (`_vb`, `_media`, `_sched`, `_config_mod`), error handling, `requests` calls always have `timeout=`, `# nosec` always has rule ID + justification.
+3. **Dependency health** — `uv run pip-audit`; flag any CVEs. Be opportunistic: if any deps can be upgraded cleanly, run `uv lock --upgrade` regardless of whether a CVE forces it.
+4. **Security posture** — timeouts on all HTTP calls; secrets not logged; `# nosec` justifications still valid; no new credentials introduced without webhook autogen wiring.
+5. **Docs drift** — README / AGENTS.md / sidecar docs accurate and not duplicating each other; env var lists synced across the five locations (conftest.py, ci.yml, .env.example, README.md, AGENTS.md).
+6. **Stale comments** — no unresolved TODO/FIXME in source; no superseded inline notes.
+7. **CI/CD hygiene** — job permissions minimal; step names accurate; post-merge `main` runs passing clean.
+   - **7b. GitHub-managed workflows.** Beyond CI, check `Dependency Graph`, `Auto Release`, `CodeQL`, and any "automatic dependency submission" workflow on recent main runs. These don't appear in `.github/workflows/` but failures here are easy to miss because they're not part of "the runs we care about".
+8. **Branch ruleset integrity** — required status check names match actual CI job names in `ci.yml`:
+   ```
+   gh api repos/JasonPuglisi/e-note-ion/rulesets/13082160 --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
+   ```
+9. **Integration test hygiene** — advisory CI job passing on `main`; GitHub environment secrets/vars match the env var lists; new integrations have `test_<name>_integration.py` and env vars in `tests/integrations/conftest.py`.
+   - `TRAKT_ACCESS_TOKEN` expires every ~90 days — copy from `config.toml` if Trakt integration tests start failing with auth errors.
+   - `GOOGLE_REFRESH_TOKEN`: Production OAuth mode → no expiry. Testing mode → 7-day expiry (Google constraint).
+10. **Issue hygiene**:
+    - Every open issue has at least one label and a milestone; no untriaged issues.
+    - Blocking relationships explicit. Prefer GitHub's native **issue dependencies** ("Add dependency" via the issue UI / `gh api`) over free-text "Blocked by #N" — they update automatically and surface in the UI.
+    - **Stale blocker cleanup**: when a blocker closes, audit any open issues that referenced it. Confirm they're now actionable; add a "blocker resolved — now actionable" comment or update the body. (Free-text "Blocked by #N" notes left around after the blocker closes are easy to miss.)
+    - Tracking issues have sub-issues linked (`gh api repos/JasonPuglisi/e-note-ion/issues/<n>/sub_issues`).
+    - Stale or superseded issues closed with a note.
+    - Milestone assignments reflect current priorities (move issues between Next/Later as needed).
+
+## Constraints
+
+- **Read-only investigation; verify before fixing.** Don't act on agent claims without grepping the source first.
+- **Issue-volume convention**:
+  - **≤3 findings** → file individual issues (or fix inline if each is one line).
+  - **>3 findings** → open one tracking issue with sub-issues, link from each PR. Avoids tracker clutter.
+- **Don't file issues for one-line cleanups** — fix inline in the same PR that surfaces them.
+- **Don't propose closing issues without strong evidence.** Stale ≠ superseded.
+- **Don't widen scope.** Health review surfaces and triages; it doesn't fix everything in one pass.
+
+## Reference
+
+### Quick commands
+
+```bash
+# Open security alerts (CodeQL + Dependabot)
+gh api 'repos/JasonPuglisi/e-note-ion/code-scanning/alerts?state=open' --jq '.[] | {rule: .rule.id, severity: .rule.severity, path: .most_recent_instance.location.path}'
+gh api repos/JasonPuglisi/e-note-ion/dependabot/alerts --jq '.[] | select(.state=="open") | {pkg: .security_vulnerability.package.name, severity: .security_advisory.severity}'
+
+# Untriaged issues (no label or no milestone)
+gh issue list --state open --limit 100 --json number,title,labels,milestone | jq '[.[] | select((.labels|length)==0 or .milestone == null)] | length'
+
+# Required status checks vs actual CI job names
+gh api repos/JasonPuglisi/e-note-ion/rulesets/13082160 --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
+grep -E "^\s+name:" .github/workflows/ci.yml
+```
+
+### Five-location env-var sync
+
+When checking env vars, all five must agree:
+1. `tests/integrations/conftest.py` (`_INTEGRATION_VARS`)
+2. `.github/workflows/ci.yml` (env block)
+3. `.env.example`
+4. `README.md` (integration test required-keys table)
+5. `AGENTS.md` (integration tests section + GitHub secrets list)
+
+### Subagent prompts that work
+
+- For broad cross-cutting reviews: spawn 4 agents in parallel (test coverage, code patterns, docs drift, issue hygiene). Cap each at ~300 words.
+- Always tell agents: "don't propose fixes, just enumerate findings."
+- Always tell agents: "use file:line references" — makes verification trivial.
+- Tradeoff: `Explore` agent is faster but doesn't have Bash; reach for `general-purpose` when filesystem traversal or `gh` calls are needed.
+
+### Cadence
+
+Roughly: any time before a minor/major release, after a sprint of feature work, or when explicitly requested. Codifying a calendar cadence doesn't fit a hobby project's irregular activity — let triggers drive it.

--- a/.agents/skills/new-integration/SKILL.md
+++ b/.agents/skills/new-integration/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: new-integration
+description: Add a new integration to the e-note-ion content scheduler. Covers integration module conventions (config import alias, vestaboard/media aliases, HTTP via shared helper, error handling), webhook integration shape (handle_webhook signature, WebhookMessage, supersede_tag, autogen credentials), scheduler.py registration (_KNOWN_INTEGRATIONS, _WEBHOOK_AUTOGEN), content JSON template, sidecar doc requirement, and the five-location env-var sync. Invoke when the task is "add an integration for X", "wire up Y as a content source", "support Z webhook events", or similar.
+---
+
+# Add a New Integration
+
+## Description
+
+Walkthrough for adding a new integration module to e-note-ion — covers code conventions, scheduler registration, content templates, sidecar docs, env-var sync, and tests. Sized to be the single reference for "I want to add integration X" tasks.
+
+## When to Use
+
+- User wants to add a new integration (data source: API, webhook, RSS, calendar, etc.)
+- User wants to convert an existing webhook-only template into a polled integration (or vice versa)
+- User asks about integration patterns / conventions when proposing a new integration
+
+## Process
+
+1. **Decide the trigger model** — polled (cron-scheduled), webhook-only, or both. See "Decision: polled vs webhook" in Reference.
+2. **Create `integrations/<name>.py`** following the module conventions below.
+3. **Register the integration** in `scheduler.py` (`_KNOWN_INTEGRATIONS`; also `_WEBHOOK_AUTOGEN` if webhook with autogen credentials).
+4. **Create `content/contrib/<name>.json`** with one or more templates. See `content/README.md` for full JSON spec.
+5. **Create `content/contrib/<name>.md`** sidecar doc. Use `content/contrib/TEMPLATE.md` as the starting point. Add a row to the contrib table in `content/README.md`. If cron-scheduled, add a row to the schedule map in the same file.
+6. **Add unit tests** at `tests/test_<name>.py` or `tests/core/test_<name>.py`. Mock all HTTP with `unittest.mock`.
+7. **Add integration test** at `tests/integrations/test_<name>_integration.py` if the integration has external API calls. Mark with `@pytest.mark.integration` and `@pytest.mark.require_env('VAR', ...)`.
+8. **Sync env vars across the five locations** (see Reference).
+9. **Add a `[<name>]` block to `config.example.toml`** documenting required and optional config keys.
+10. **Run the full check suite** before committing (see Reference).
+11. **Update `AGENTS.md`** Project Structure listing with the new module + content files.
+
+## Module conventions
+
+- **2-space indent, single quotes, type hints on every signature.** Target 80 cols, 120 max.
+- **Logger:** `logger = logging.getLogger(__name__)` at module top.
+- **Imports inside functions, with underscore aliases**, for everything that touches runtime state:
+  ```python
+  import config as _config_mod      # not at module top — keeps integrations importable in tests
+  import integrations.vestaboard as _vb
+  import integrations.media as _media
+  import scheduler as _sched         # only inside webhook handlers / enqueue paths
+  ```
+  Module-level `import config` blocks `pytest` from collecting tests when `config.toml` is absent.
+- **HTTP**:
+  - Use `integrations.http.fetch_with_retry` and `user_agent()` for shared retry / UA logic. Direct `requests.*` calls are acceptable for OAuth token endpoints and uncommon HTTP methods (PROPFIND, REPORT) — always pass `timeout=`.
+  - Treat all remote data as untrusted. Bounds-check lengths, strip unexpected characters before rendering to the display.
+- **Error handling**:
+  - Raise `IntegrationDataUnavailableError(msg, expected=True/False)` from `exceptions.py` for transient unavailability. The worker catches and logs without crashing the scheduler.
+  - Background-thread exceptions must be caught and logged — never silently swallowed.
+- **Bandit suppressions:** every `# nosec` includes the rule ID AND a justification (`# nosec B311 — visual scatter grid, not a security context`). No bare `# nosec`.
+- **Secrets:** never log API keys; never echo into errors. Token-clearing writes (e.g. on auth failure) need a `# nosec B105` justification noting the empty strings are intentional.
+
+## Polled integration shape
+
+```python
+def get_variables() -> dict[str, list[list[str]]]:
+  """Fetch data and return template variables.
+
+  Variable values: dict mapping variable name → list of options → list of lines.
+  Raise IntegrationDataUnavailableError(expected=True) when the API has nothing
+  to show (e.g. no upcoming events) — worker logs at DEBUG.
+  Raise IntegrationDataUnavailableError(expected=False) for outages — worker
+  logs at WARNING.
+  """
+```
+
+A single integration may expose multiple data sources via additional functions (`get_variables_<flavor>`); reference them in JSON templates with `"integration_fn": "get_variables_<flavor>"`.
+
+## Webhook integration shape
+
+```python
+def handle_webhook(payload: dict[str, Any], credential_name: str | None = None) -> WebhookMessage | None:
+  """Parse the payload; return WebhookMessage to enqueue, or None to discard.
+
+  All handlers must accept credential_name as a keyword argument (used for
+  multi-tenant credential routing — see message.py for an example).
+  """
+```
+
+Use `WebhookMessage` from `scheduler.py`. Common patterns:
+- `interrupt=True` for time-sensitive state changes (Plex pause/resume) that should preempt current display.
+- `indefinite=True` for playback-state messages that should hold until a stop event arrives. The `hold` field acts as a safety ceiling.
+- `interrupt_only=True` for stop/end events that clear the display without enqueueing new content.
+- `supersede_tag='<integration>'` so the next event replaces stale queued messages from the same integration before they reach the board.
+
+If the integration auto-creates its credential on first startup, also add it to `_WEBHOOK_AUTOGEN` in `scheduler.py` with the credential name. Otherwise the user has to create the credential manually.
+
+## scheduler.py registration
+
+```python
+# scheduler.py
+_KNOWN_INTEGRATIONS: frozenset[str] = frozenset({
+  'bart', 'calendar', ..., '<name>',  # ADD HERE
+})
+
+# Only if webhook + autogen credentials:
+_WEBHOOK_AUTOGEN: dict[str, str] = {
+  'plex': 'plex',
+  ..., '<name>': '<name>',  # ADD HERE
+}
+```
+
+## Content JSON quick-reference
+
+See `content/README.md` for the full spec. Minimum viable contrib JSON:
+
+```json
+{
+  "templates": {
+    "<template_name>": {
+      "schedule": { "cron": "0 8 * * *", "hold": 600, "timeout": 600 },
+      "priority": 5,
+      "private": false,
+      "truncation": "ellipsis",
+      "integration": "<name>",
+      "templates": [
+        { "format": ["[G] HEADER", "{var_one}", "{var_two}"] }
+      ]
+    }
+  }
+}
+```
+
+For webhook-only templates: omit `cron`, set `"webhook": true`.
+
+## Constraints
+
+- **Don't add new integrations that depend on heavyweight packages** without prior discussion. Every dep increases attack surface and Docker image size.
+- **Don't introduce breaking changes** to the content JSON spec, CLI flags, Docker env vars, or `config.toml` keys without a major version bump.
+- **Don't use module-level `import config`** — keeps integration importable in tests without a loaded config.
+- **Don't add data-source defaults that hit a real API in tests** — tests must work offline with mocked HTTP.
+- **Don't skip the sidecar doc.** Every contrib JSON needs a matching `<name>.md` (CI enforces this).
+
+## Reference
+
+### Decision: polled vs webhook
+
+| Trigger | Use polled (`cron`) | Use webhook |
+|---|---|---|
+| Data changes on a schedule (weather, calendar, Trakt calendar) | ✓ | |
+| External system pushes events (Plex, iOS Shortcut, Notion) | | ✓ |
+| Want real-time updates and the source supports webhooks | | ✓ |
+| Source is read-only and only available via API | ✓ | |
+| Both apply (Trakt watching: poll + webhook would be redundant) | poll only | |
+
+### Five-location env-var sync
+
+When adding new integration env vars, update **all five**:
+1. `tests/integrations/conftest.py` — add to `_INTEGRATION_VARS`
+2. `.github/workflows/ci.yml` — add to the integration job's `env:` block (`secrets.X` for sensitive, `vars.X` for non-sensitive)
+3. `.env.example`
+4. `README.md` integration-test required-keys table
+5. `AGENTS.md` integration-tests env vars list + the GitHub secrets/vars sub-list
+
+### GitHub environment secrets/vars
+
+Store as **environment** secrets/vars on the `integration` GitHub Actions environment (Settings → Environments), restricted to the `main` branch. Repo-wide secrets are over-scoped.
+
+### Pre-commit hook for staged integrations
+
+`scripts/staged-integration-tests.sh` runs `tests/integrations/test_<name>_integration.py` automatically when the matching `integrations/<name>.py` is staged. Without `.env`, the hook prints a hint and passes (graceful degradation). With `.env` set up, real API calls catch contract / output-format mismatches before merge.
+
+### Full check suite
+
+Run before every commit:
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run bandit -c pyproject.toml -r .
+uv run pip-audit
+uv run pre-commit run pretty-format-json --all-files
+uv run pytest --cov=integrations --cov=. --cov-report=term-missing
+```
+
+### Examples to copy from
+
+- Polled API integration: `integrations/bart.py` (compact, well-tested)
+- Polled with TMDb canonicalization: `integrations/trakt.py`
+- Webhook with state machine: `integrations/plex.py`
+- Webhook with multi-tenant credentials: `integrations/message.py`
+- OAuth device-code flow (shared): `integrations/google.py` + `integrations/youtube.py`

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,11 @@ updates:
     # treats every .txt file in the repo as a pip requirements file and
     # chokes parsing LICENSE.txt. Exclude it explicitly until the upstream
     # fix (PR #14197) ships.
+    # NOTE: paths are repo-root-relative — leading slash is rejected by
+    # Dependabot's config validator (the waylay-sdk-py example with leading
+    # slash is wrong; ours uses the bare path).
     exclude-paths:
-      - "/LICENSE.txt"
+      - "LICENSE.txt"
     groups:
       all:
         patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,15 +41,21 @@ jobs:
         run: uv run bandit -c pyproject.toml -r .
 
       - name: pip-audit
-        # CVE-2026-4539: pygments ReDoS, dev-only, no fix available
-        # CVE-2026-3219: pip in build env, dev-only, no fix available
-        run: uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219
+        run: uv run pip-audit
 
       - name: Pretty-format JSON
         run: uv run pre-commit run pretty-format-json --all-files
 
-      - name: Run tests
-        run: uv run pytest
+      - name: Run tests with coverage
+        run: uv run pytest --cov --cov-report=term --cov-report=xml
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          retention-days: 7
 
   # Required by the main branch ruleset. If you rename this job, update the
   # ruleset at https://github.com/JasonPuglisi/e-note-ion/rules/13082160

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ content/user/*
 
 # Runtime data (health event log, etc. — persisted via Docker volume)
 data/
+
+# Coverage tool output (pytest-cov)
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,19 @@ columns). Each character can show one of 64 values: A–Z, 0–9, punctuation,
 colored squares, or ❤️ (Note) / ° (Flagship) at code 62. The display connects
 over Wi-Fi and is controlled via a Read/Write API key.
 
+## Skills
+
+On-demand skills live under `.agents/skills/<name>/SKILL.md`. They follow the
+[Agent Skills](https://agentskills.io) format (YAML frontmatter + markdown
+body) and are vendor-neutral — any agent that reads this file can discover
+them. Load a skill's body when the user's task matches its trigger; don't
+preload all of them.
+
+| Skill | Load when |
+|---|---|
+| [`health-review`](.agents/skills/health-review/SKILL.md) | User asks for a "health check", "audit", or "project review"; before a minor/major release; after a sprint of feature work. |
+| [`new-integration`](.agents/skills/new-integration/SKILL.md) | User wants to add a new integration (data source, webhook, content template). |
+
 ## Persona
 
 Act as a senior software engineer and information security practitioner working
@@ -16,7 +29,8 @@ on this project collaboratively with the user.
 - Prefer simple, minimal solutions; avoid over-engineering and premature
   abstraction
 - Design new integrations (`integrations/`) to be consistent with existing
-  patterns in structure, naming, and error handling
+  patterns in structure, naming, and error handling — see the `new-integration`
+  skill for the full walkthrough
 - Keep the scheduler, queue, and worker logic reliable — exceptions in
   background threads must be caught and logged, never silently swallowed
 
@@ -91,6 +105,9 @@ integrations/unraid.py      # Unraid server status (GraphQL API, local network)
 integrations/uptimerobot.py # UptimeRobot service outage alerts (REST API, free tier)
 integrations/ynab.py        # YNAB net worth tracker (REST API, personal access token)
 integrations/youtube.py     # YouTube live streams from subscriptions (RSS + Data API v3)
+.agents/skills/             # On-demand agent skills (vendor-neutral, agentskills.io format)
+  health-review/SKILL.md    # Periodic project health audit walkthrough
+  new-integration/SKILL.md  # Adding a new integration (code + content + tests + docs)
 content/
   README.md                 # Content author reference: JSON format, priority, schedule coordination
   DESIGN.md                 # Visual/design conventions: layout, color, tone, character set
@@ -158,143 +175,9 @@ Update the XML there when adding new Docker config fields (ports, volumes, env v
 The single-threaded worker ensures display messages never overlap — important
 for a physical split-flap device whose flaps need time to settle.
 
-## Content JSON Format
-
-```json
-{
-  "templates": {
-    "<template_name>": {
-      "schedule": {
-        "cron": "0 8 * * *",  // standard 5-field cron expression; omit when "webhook": true
-        "hold": 600,  // seconds to show before pulling next (safety ceiling for indefinite webhook holds)
-        "timeout": 600,  // seconds message can wait before discarding
-        "refresh_interval": 60  // optional: re-fetch integration data every N seconds during hold (min 30; integration templates only)
-      },
-      "priority": 5,           // integer 0–10; higher number = higher priority
-      "private": false,        // if true, hidden when public mode is enabled in config.toml
-      "truncation": "word",    // optional: "hard" (default), "word", "ellipsis"
-      "webhook": false,        // optional: true makes cron optional; template fires on webhook only
-      "templates": [
-        { "format": ["LINE ONE", "LINE {variable}"] }
-      ]
-    }
-  },
-  "variables": {
-    "<variable_name>": [
-      ["VALUE A LINE 1", "VALUE A LINE 2"],
-      ["VALUE B LINE 1", ...]
-    ]
-  }
-}
-```
-
-Each content file is named for its context (e.g. `bart.json`).
-`{variable}` placeholders are replaced at random from `variables` options; a
-standalone `{variable}` entry expands to all lines of the chosen option. Lines
-are word-wrapped to fit `model.cols`; excess rows are silently dropped.
-
-### Integration templates
-
-Templates can include `"integration": "<name>"` instead of (or alongside) a
-static `variables` dict. When the job fires, the worker calls
-`integrations.<name>.get_variables()`, which returns the same
-`dict[str, list[list[str]]]` structure as static variables. This allows
-dynamic data (e.g. real-time API responses) to populate `{variable}`
-placeholders in the format. The `variables` key is optional when an
-integration is present.
-
-Add `"integration_fn": "<function_name>"` to call a function other than
-`get_variables` on the integration module. This lets a single integration
-expose multiple data sources (e.g. Trakt's `get_variables_calendar` and
-`get_variables_watching`).
-
-Color squares can be embedded in format strings and integration output using
-short tags: `[R]` `[O]` `[Y]` `[G]` `[B]` `[V]` `[W]` `[K]` (red, orange,
-yellow, green, blue, violet, white, black). Each tag encodes to the
-corresponding Vestaboard color square code (63–70).
-
-### Webhook integrations
-
-Integrations can also receive real-time push events from external systems
-(Plex, iOS Shortcuts, etc.) via the optional HTTP webhook listener. To support
-webhooks, an integration implements:
-
-```python
-def handle_webhook(payload: dict[str, Any]) -> WebhookMessage | None:
-    ...
-```
-
-`payload` is the parsed JSON body of the POST request. Return `None` to discard
-the event (e.g. wrong event type). Return a `WebhookMessage` to enqueue a
-display message:
-
-```python
-from scheduler import WebhookMessage
-
-WebhookMessage(
-    data={...},            # same shape as cron-enqueued data (templates, variables, truncation)
-    priority=8,            # 0–10
-    hold=60,               # seconds to show (or safety ceiling when indefinite=True)
-    timeout=120,           # seconds before discarding if not yet shown
-    name='',               # optional: appears in logs (defaults to webhook.<integration>)
-    interrupt=False,       # True to cut the current hold short and show this immediately
-    indefinite=False,      # True to hold until explicitly interrupted (e.g. a stop event)
-    interrupt_only=False,  # True to fire _hold_interrupt without enqueueing (e.g. stop events)
-    supersede_tag='',      # if non-empty, removes earlier same-tagged messages from the queue before enqueueing
-)
-```
-
-Set `interrupt=True` for time-sensitive state changes (e.g. Plex pause/resume)
-that should preempt whatever is currently on the display.
-
-Set `indefinite=True` for playback-state messages that should stay on screen
-until a stop or resume event arrives, rather than timing out after `hold`
-seconds. The `hold` value acts as a safety ceiling in case the stop event is
-never received.
-
-Set `interrupt_only=True` for stop/end events that should clear the display
-immediately without enqueueing any new content. The `data`, `priority`, `hold`,
-and `timeout` fields are ignored when `interrupt_only=True`.
-
-Set `supersede_tag` to a non-empty string to have `enqueue()` automatically
-remove any earlier messages with the same tag before adding the new one. Use
-this when a new event (e.g. Plex track change) makes any queued message for
-the same integration stale — so only the latest state reaches the display.
-
-The webhook listener is activated by adding a `[webhook]` section to
-`config.toml` (see `config.example.toml`). It binds to `127.0.0.1:8080` by
-default. Authentication is handled entirely via **named credentials** defined
-in `[webhook.credentials.<name>]` sections — each scoped to one or more
-integrations via the `webhooks` list. Credentials for diving, health, message-admin,
-notion, plex, and scheduler are auto-generated on first startup if absent (check
-the log for the plaintext secret to copy into your sender). Endpoints:
-`POST /webhook/<integration>` for webhook events, `GET /health` for the
-health monitoring endpoint (returns JSON, 200 when healthy, 503 when
-degraded/errored — see README for response format). Credential secret
-accepted as `X-Webhook-Secret: <secret>` header (preferred) or
-`?secret=<secret>` query parameter (for senders like Plex that cannot set
-custom headers). All
-`handle_webhook` implementations must accept `credential_name: str | None = None`
-as a keyword argument.
-
-Webhook integrations respect the `private` flag from their JSON template
-definition and `config.toml` overrides automatically — the scheduler resolves
-the effective value during content loading and applies it in the worker. No
-integration-level code is needed to propagate the flag.
-
-When adding a new webhook-capable integration, also add its name to
-`_KNOWN_INTEGRATIONS` in `scheduler.py`. If the integration should auto-generate
-a credential on first startup, also add it to `_WEBHOOK_AUTOGEN` in `scheduler.py`.
-
-### Integration dependencies
-
-Add any packages required by a new integration to `pyproject.toml`
-`dependencies` (the base list). All deps are installed unconditionally —
-this keeps the Docker image simple, and Docker is the primary deployment
-target. If an integration is loaded and its deps are missing (e.g. a
-source-install user skipped them), `_get_integration()` will catch the
-`ImportError` and raise a `RuntimeError` with an install hint; the worker
-logs it and skips that message rather than crashing.
+For the full content JSON format spec, see `content/README.md`. For the
+integration module conventions and webhook patterns, see the `new-integration`
+skill.
 
 ## Environment
 
@@ -305,10 +188,12 @@ logs it and skips that message rather than crashing.
 - Python version managed via `.python-version` (uv)
 - Dependencies managed with `uv` / `pyproject.toml`
 - Dev tools: `ruff` (lint + format), `pyright` (type checking), `bandit`
-  (security linting), `pip-audit` (dependency CVE scanning), `pre-commit`
+  (security linting), `pip-audit` (dependency CVE scanning), `pytest-cov`
+  (coverage reporting), `pre-commit`
 - Run checks: `uv run ruff check .`, `uv run ruff format --check .`,
   `uv run pyright`, `uv run bandit -c pyproject.toml -r .`, `uv run pip-audit`,
-  `uv run pre-commit run pretty-format-json --all-files`, `uv run pytest`
+  `uv run pre-commit run pretty-format-json --all-files`,
+  `uv run pytest --cov=integrations --cov=. --cov-report=term-missing`
 - Install hooks (once after cloning): `uv run pre-commit install`
 - Tests live in `tests/`; use `pytest` with `unittest.mock` for HTTP calls
 
@@ -339,7 +224,8 @@ PR labels (apply one or more):
 
 - PRs that introduce new logic **must** include corresponding tests in `tests/`
 - Use `pytest`; mock HTTP calls with `unittest.mock`
-- CI runs `uv run pytest` — tests must pass before merge
+- CI runs `uv run pytest --cov=integrations --cov=. --cov-report=term-missing`
+  — tests must pass before merge; coverage is reported but not gated
 - When working on existing code that lacks tests, add retroactive coverage as
   part of the same PR where feasible
 - When a change affects output format or data shape, grep all test directories
@@ -403,31 +289,11 @@ through the integration test path.
 
 ### Periodic health review
 
-At natural breakpoints (before a minor/major release, after a sprint of feature
-work), run through this checklist. Open issues for gaps found; fix trivial things
-inline. When something slips through, ask why it wasn't caught and add a
-prevention here — not just a one-off fix. See #65 for extended notes.
-
-1. **Test coverage** — gaps in unit tests; retroactive coverage for untested logic
-2. **Code patterns** — consistency across integrations (structure, naming, error handling)
-3. **Dependency health** — `uv run pip-audit`; flag any CVEs
-4. **Security posture** — timeouts on all HTTP calls; secrets not logged; `# nosec` justifications valid
-5. **Docs drift** — README / AGENTS.md / sidecar docs accurate and not duplicating each other
-6. **Stale comments** — no unresolved TODO/FIXME in source
-7. **CI/CD hygiene** — job permissions minimal; step names accurate; post-merge `main` runs passing clean
-8. **Branch ruleset integrity** — required status check names match actual CI job names in `ci.yml`:
-   ```
-   gh api repos/JasonPuglisi/e-note-ion/rulesets/13082160 --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
-   ```
-9. **Integration test hygiene** — advisory CI job passing on `main`; GitHub environment secrets/vars match the lists above and in `ci.yml`; new integrations have `test_<name>_integration.py` and env vars in `tests/integrations/conftest.py`
-   - **`TRAKT_ACCESS_TOKEN` expires every ~90 days** — if the Trakt integration tests start failing with an auth error, copy the current `access_token` from `config.toml` (kept fresh by the prod refresh flow) into the `integration` environment secret
-   - **`GOOGLE_REFRESH_TOKEN`**: In Production mode (recommended), refresh tokens do not expire. In Testing mode, they expire after 7 days (Google-imposed constraint). The YouTube integration test obtains a fresh access token via refresh at runtime.
-10. **Issue hygiene**:
-    - Every open issue has at least one label and a milestone; no untriaged issues
-    - Blocking relationships explicit ("Blocked by #X" in body)
-    - Tracking issues have sub-issues linked (`gh api repos/JasonPuglisi/e-note-ion/issues/<n>/sub_issues`)
-    - Stale or superseded issues closed with a note
-    - Milestone assignments reflect current priorities (move issues between Next/Later as needed)
+Triggered by user request, before a minor/major release, or after a sprint of
+feature work. The full checklist + process lives in the `health-review` skill
+(`.agents/skills/health-review/SKILL.md`) — load it when running an audit. Past
+reviews have surfaced drift in code patterns, docs, dependency CVEs, and the
+issue tracker; the skill captures the prevention rules added in response.
 
 ### Planning before implementation
 
@@ -435,7 +301,9 @@ All non-trivial work follows a plan-then-execute cycle:
 
 1. **Create or identify a GitHub issue.** Assign to JasonPuglisi with a
    milestone. Read all existing comments before proceeding — blockers, prior
-   decisions, and context live there.
+   decisions, and context live there. Prefer GitHub's native **issue
+   dependencies** (Add dependency via the issue UI / `gh api`) over free-text
+   "Blocked by #N" — they update automatically and surface in the UI.
 2. **Post an implementation plan as a comment.** Cover: files and functions to
    change, approach with rationale, edge cases, open questions, and a
    **## Tests** section listing new and updated tests. Do this before any code.
@@ -455,19 +323,29 @@ step may be skipped — use judgement.
    real API before committing — unit test mocks cannot catch API contract
    mismatches. Use `config.toml` with real credentials and confirm the
    integration returns the expected output.
-4. If release-worthy (see below), bump `version` in `pyproject.toml` **in the
-   same commit as the source change** — never a follow-up PR. Rule of thumb:
-   if any `.py` or `.json` file is staged, check whether a bump is needed. Always stage
-   `uv.lock` alongside `pyproject.toml` to avoid pre-commit stash conflicts.
-5. Commit with `Co-Authored-By: Claude <model> <noreply@anthropic.com>`
-   (use your current model name, e.g. `Opus 4.6` or `Sonnet 4.6`;
+4. **Bundle opportunistic cleanups while already in-flight.** If you're already
+   making changes in a PR, take the opportunity to:
+   - Run `uv lock --upgrade` and pull in any clean dep updates (regardless of
+     whether a CVE forces it — see Maintenance § Dependency posture below)
+   - Address any small drift you notice in the files you're already touching
+   - Roll any blocking CVE fix into the same PR rather than spinning up a
+     separate small PR for it
+   The aim is fewer PRs that each carry meaningful change, not one-line PRs
+   that fragment the history.
+5. If release-worthy (see Release Strategy below), bump `version` in
+   `pyproject.toml` **in the same commit as the source change** — never a
+   follow-up PR. Rule of thumb: if any `.py` or `.json` file is staged, check
+   whether a bump is needed. Always stage `uv.lock` alongside `pyproject.toml`
+   to avoid pre-commit stash conflicts.
+6. Commit with `Co-Authored-By: Claude <model> <noreply@anthropic.com>`
+   (use your current model name, e.g. `Opus 4.7` or `Sonnet 4.6`;
    commits are auto-signed via `commit.gpgsign = true` in global git config)
-6. Verify signing succeeded: `git log -1 --show-signature` must show a valid signature before pushing
-7. `git push -u origin feat/description`
-8. `gh pr create --label <label> --assignee JasonPuglisi`
-9. Enable auto-merge: `gh pr merge --squash --delete-branch --auto`
-10. Wait for merge: `gh pr checks <number> --watch`; once all pass and the PR merges, proceed
-11. After merge: `git checkout main && git pull && git branch -d feat/description`;
+7. Verify signing succeeded: `git log -1 --show-signature` must show a valid signature before pushing
+8. `git push -u origin feat/description`
+9. `gh pr create --label <label> --assignee JasonPuglisi`
+10. Enable auto-merge: `gh pr merge --squash --delete-branch --auto`
+11. Wait for merge: `gh pr checks <number> --watch`; once all pass and the PR merges, proceed
+12. After merge: `git checkout main && git pull && git branch -d feat/description`;
     get merge SHA via `git rev-parse HEAD`; run `gh run list --branch main --commit <sha>`
     and watch all in-progress runs to completion (`gh run watch <id>`). This step is
     non-negotiable — run it even when PR checks looked clean.
@@ -475,13 +353,13 @@ step may be skipped — use judgement.
     "Analyze (actions)", "Analyze (python)", and "CodeQL" checks (GitHub's built-in
     code scanning — runs automatically, not defined in `ci.yml`).
     Advisory integration job may fail (missing secrets or API issue) — note but not a blocker.
-12. Keep `README.md` and `AGENTS.md` up to date as part of the same PR —
-    new env vars, CLI flags, content format fields, project structure changes,
-    and workflow changes should all be reflected before merge. When adding or
-    renaming a template in `content/contrib/`, update both the template mapping
-    table and the schedule map in `content/README.md` (enforced by CI via
-    `test_schedule_lint.py`)
-13. For any TODOs identified during work, create a GitHub issue assigned to
+13. Keep `README.md` and `AGENTS.md` (and any affected skill files) up to date
+    as part of the same PR — new env vars, CLI flags, content format fields,
+    project structure changes, and workflow changes should all be reflected
+    before merge. When adding or renaming a template in `content/contrib/`,
+    update both the template mapping table and the schedule map in
+    `content/README.md` (enforced by CI via `test_schedule_lint.py`)
+14. For any TODOs identified during work, create a GitHub issue assigned to
     JasonPuglisi with an appropriate milestone; reference the issue number in
     commit messages and PRs
 
@@ -498,6 +376,7 @@ PR contains **release-worthy** changes:
 | `Dockerfile` changes | Docs-only changes |
 | Security fixes | Repo config / tooling changes |
 |  | Test-only changes (`tests/`) |
+|  | Skill / agent doc changes (`.agents/skills/`) |
 
 Semver rules (strict post-1.0):
 - **Patch** (`x.y.z+1`): bug fixes, dependency updates, security fixes
@@ -533,7 +412,13 @@ Dependencies and pinned versions should be kept current:
   gh api repos/JasonPuglisi/e-note-ion/code-scanning/alerts --jq '.[] | select(.state=="open") | {rule: .rule.id, severity: .rule.severity, path: .most_recent_instance.location.path}'
   gh api repos/JasonPuglisi/e-note-ion/dependabot/alerts --jq '.[] | select(.state=="open") | {pkg: .security_vulnerability.package.name, severity: .security_advisory.severity, summary: .security_advisory.summary}'
   ```
-- **Dependabot PRs** (automated, weekly): review and merge PRs for pip
+- **Dependency posture**: be **opportunistic about upgrading**, regardless of
+  whether a CVE forces it. When already touching `pyproject.toml` or `uv.lock`
+  in any PR, run `uv lock --upgrade` and bundle the upgrades. Classification
+  (runtime vs dev) does not gate the upgrade decision — newer is preferred,
+  full stop. Verify with `uv run pytest` and `uv run pip-audit` before
+  committing.
+- **Dependabot PRs** (automated, weekly): review and merge PRs for `uv`
   dependencies and GitHub Actions SHA/version bumps; these are the primary
   update mechanism for both
 - **Pre-commit hooks**: run `uv run pre-commit autoupdate` monthly to update
@@ -560,7 +445,8 @@ and verify those channels during periodic health reviews.
 
 Every `content/contrib/<name>.json` must have a companion `content/contrib/<name>.md`.
 Use `content/contrib/TEMPLATE.md` as the starting point. After adding a new integration
-doc, add a row to the table in `content/README.md`.
+doc, add a row to the table in `content/README.md`. The full integration-authoring
+walkthrough lives in the `new-integration` skill.
 
 ## Content Design
 
@@ -582,13 +468,18 @@ template output, consult and follow both content docs:
 - Target 80 columns; up to 120 is acceptable when breaking would be awkward;
   past 120 only as a last resort
 - All `requests` calls must include `timeout=`
-- Suppress bandit findings with `# nosec BXXX` (include rule ID); never
-  suppress blindly
+- Suppress bandit findings with `# nosec BXXX — justification` (always include
+  rule ID AND a short reason); never suppress blindly
 - Integration modules must import `config` inside functions (not at module
   level) using the alias `import config as _config_mod` — consistent with
   `_public_mod` / `_quiet_mod` in `scheduler.py`. This keeps integrations
   importable in tests without a loaded config file.
+- Integration modules consistently alias shared modules: `import
+  integrations.vestaboard as _vb`, `import integrations.media as _media`,
+  `import scheduler as _sched`. Underscore-prefix the alias.
 - Runtime state modules (`public.py`, `quiet.py`) follow a symmetric API:
   `set_<name>(bool)` / `is_<name>()` with state persisted as a flat key under
   `[scheduler]` in `config.toml`. New runtime state modules should follow the
   same pattern.
+</content>
+</invoke>

--- a/README.md
+++ b/README.md
@@ -312,5 +312,9 @@ Required keys:
 | `DIVING_LON` | Station longitude |
 | `YNAB_API_KEY` | [app.ynab.com/settings/developer](https://app.ynab.com/settings/developer) → Personal Access Token |
 | `YNAB_BUDGET_ID` | Budget UUID from the YNAB web app URL |
+| `UPTIMEROBOT_API_KEY` | [uptimerobot.com/dashboard.php#mySettings](https://uptimerobot.com/dashboard.php#mySettings) → API Settings → Main API Key |
+| `GOOGLE_CLIENT_ID` | [console.cloud.google.com/apis/credentials](https://console.cloud.google.com/apis/credentials) → OAuth 2.0 Client ID (TV/limited input device) |
+| `GOOGLE_CLIENT_SECRET` | Same OAuth client as above |
+| `GOOGLE_REFRESH_TOKEN` | Run YouTube auth flow once and copy from `config.toml` (Production OAuth mode → no expiry; Testing → 7-day) |
 
 `.env` is git-ignored — never commit it.

--- a/integrations/bart.py
+++ b/integrations/bart.py
@@ -20,7 +20,7 @@ from typing import Any
 
 import requests
 
-import integrations.vestaboard as vestaboard
+import integrations.vestaboard as _vb
 from exceptions import IntegrationDataUnavailableError
 from integrations.http import CacheEntry, fetch_with_retry, user_agent
 
@@ -137,7 +137,7 @@ def _build_line(color_tag: str, estimates: list[dict[str, Any]]) -> str:
   parts: list[str] = []
   for est in estimates:
     t = _format_minutes(est['minutes'])
-    if vestaboard.display_len(base + ' '.join(parts + [t])) > vestaboard.model.cols:
+    if _vb.display_len(base + ' '.join(parts + [t])) > _vb.model.cols:
       break
     parts.append(t)
   return base + (' '.join(parts) if parts else '--')

--- a/integrations/color.py
+++ b/integrations/color.py
@@ -135,7 +135,7 @@ def _kmeans_dominant(pixels: list[tuple[float, float, float]]) -> tuple[float, f
     )
 
   # k-means++ initialization: spread starting centroids across the color space.
-  first = random.choice(pixels)  # nosec S311
+  first = random.choice(pixels)  # nosec S311 — k-means++ centroid init, not a security context
   centroids: list[tuple[float, float, float]] = [first]
 
   for _ in range(k - 1):
@@ -143,7 +143,7 @@ def _kmeans_dominant(pixels: list[tuple[float, float, float]]) -> tuple[float, f
     total = sum(dists)
     if total == 0:
       break
-    threshold = random.random() * total  # nosec S311
+    threshold = random.random() * total  # nosec S311 — weighted distance sampling, not a security context
     cumulative = 0.0
     for p, d in zip(pixels, dists):
       cumulative += d

--- a/integrations/morning.py
+++ b/integrations/morning.py
@@ -61,7 +61,7 @@ def _random_grid(
   min_cells: int,
 ) -> tuple[str, str, str]:
   """Generate a random 7×3 scatter grid with a minimum cell count."""
-  cells = [random.random() < density for _ in range(_GRID_CELLS)]  # nosec B311
+  cells = [random.random() < density for _ in range(_GRID_CELLS)]  # nosec B311 — random visual scatter grid, not a security context
   filled = sum(cells)
   if filled < min_cells:
     empty = [i for i, c in enumerate(cells) if not c]

--- a/integrations/vestaboard.py
+++ b/integrations/vestaboard.py
@@ -433,7 +433,7 @@ def _expand_format(
   triggering variable substitution. Color tag escaping is handled by
   _encode_line (see [[X]] in _next_token).
   """
-  chosen: dict[str, list[str]] = {name: random.choice(options) for name, options in variables.items()}  # nosec B311
+  chosen: dict[str, list[str]] = {name: random.choice(options) for name, options in variables.items()}  # nosec B311 — template variable option selection, not a security context
 
   def _sub(match: re.Match[str]) -> str:
     opt = chosen.get(match.group(1), [''])
@@ -625,7 +625,7 @@ def render(
 
   Returns a model.rows × model.cols grid of integer character codes.
   """
-  template = random.choice(templates)  # nosec B311
+  template = random.choice(templates)  # nosec B311 — template selection, not a security context
   lines = _expand_format(template['format'], variables)
   lines = _wrap_lines(lines, truncation)
   grid = _build_grid(lines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
     "pre-commit>=4.5.1",
     "pyright>=1.1.408",
     "pytest>=9.0.3",
+    "pytest-cov>=7.1.0",
     "ruff>=0.15.2",
 ]
 
@@ -91,3 +92,20 @@ indent-style = "space"
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]  # pycodestyle errors, pyflakes, isort
+
+[tool.coverage.run]
+# Measure coverage on the project source — integrations + root-level modules.
+# Tests themselves are excluded; .venv is excluded by default.
+source = ["integrations", "scheduler", "config", "health", "public", "quiet", "exceptions"]
+
+[tool.coverage.report]
+# Report-only — no fail_under threshold yet. Establish a baseline first; add
+# a threshold once the number is known and intentional.
+show_missing = true
+skip_covered = false
+exclude_lines = [
+  "pragma: no cover",
+  "raise NotImplementedError",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -188,3 +188,107 @@ def test_ensure_authenticated_starts_thread_once() -> None:
     google._ensure_authenticated('scope')
     google._ensure_authenticated('scope')
     assert mock_thread.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# preflight — direct coverage (also exercised indirectly via youtube.preflight)
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_with_no_token_starts_auth_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+  """No stored access_token → preflight kicks off the device-code auth flow."""
+  import config as _config_mod
+
+  monkeypatch.setattr(_config_mod, '_config', {'google': {'client_id': 'x', 'client_secret': 'y'}})
+  with patch('integrations.google._ensure_authenticated') as mock_ensure:
+    google.preflight('test-scope')
+  mock_ensure.assert_called_once_with('test-scope')
+
+
+def test_preflight_with_valid_token_does_nothing() -> None:
+  """Token present and not near expiry → no auth flow, no refresh."""
+  with (
+    patch('integrations.google._ensure_authenticated') as mock_ensure,
+    patch('integrations.google._refresh_token') as mock_refresh,
+  ):
+    google.preflight('test-scope')  # autouse fixture sets expires_at = now + 3600
+  mock_ensure.assert_not_called()
+  mock_refresh.assert_not_called()
+
+
+def test_preflight_refreshes_near_expiry_token(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Token expiring in <300s → preflight proactively refreshes."""
+  import config as _config_mod
+
+  monkeypatch.setattr(
+    _config_mod,
+    '_config',
+    {
+      'google': {
+        'client_id': 'x',
+        'client_secret': 'y',
+        'access_token': 'old',
+        'refresh_token': 'r',
+        'expires_at': int(time.time()) + 60,  # 60s from expiry
+      }
+    },
+  )
+  with patch('integrations.google._refresh_token') as mock_refresh:
+    google.preflight('test-scope')
+  mock_refresh.assert_called_once()
+
+
+def test_preflight_refresh_failure_clears_tokens_and_starts_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Refresh fails → tokens cleared, auth flow restarted."""
+  import config as _config_mod
+
+  monkeypatch.setattr(
+    _config_mod,
+    '_config',
+    {
+      'google': {
+        'client_id': 'x',
+        'client_secret': 'y',
+        'access_token': 'old',
+        'refresh_token': 'r',
+        'expires_at': int(time.time()) + 60,
+      }
+    },
+  )
+  with (
+    patch(
+      'integrations.google._refresh_token',
+      side_effect=requests.HTTPError('refresh failed'),
+    ),
+    patch('integrations.google._clear_tokens') as mock_clear,
+    patch('integrations.google._ensure_authenticated') as mock_ensure,
+  ):
+    google.preflight('test-scope')
+  mock_clear.assert_called_once()
+  mock_ensure.assert_called_once_with('test-scope')
+
+
+def test_preflight_malformed_expires_at_returns_silently(monkeypatch: pytest.MonkeyPatch) -> None:
+  """Non-integer expires_at (corrupt config) → bail out, don't crash."""
+  import config as _config_mod
+
+  monkeypatch.setattr(
+    _config_mod,
+    '_config',
+    {
+      'google': {
+        'client_id': 'x',
+        'client_secret': 'y',
+        'access_token': 'old',
+        'refresh_token': 'r',
+        'expires_at': 'not-a-number',
+      }
+    },
+  )
+  with (
+    patch('integrations.google._refresh_token') as mock_refresh,
+    patch('integrations.google._ensure_authenticated') as mock_ensure,
+  ):
+    google.preflight('test-scope')
+  mock_refresh.assert_not_called()
+  mock_ensure.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -232,6 +232,45 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/7f/d0720730a397a999ffc0fd3f5bebef347338e3a47b727da66fbb228e2ff2/coverage-7.14.0.tar.gz", hash = "sha256:057a6af2f160a85384cde4ab36f0d2777bae1057bae255f95413cdd382aa5c74", size = 919489, upload-time = "2026-05-10T18:02:31.397Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/18/b9a6586d73992807c26f9a5f274131be3d76b56b18a82b9392e2a25d2e45/coverage-7.14.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9aed9fa983514ca032790f3fe0d1c0e42ca7e16b42432af1706b50a9a46bef5d", size = 220036, upload-time = "2026-05-10T18:01:33.057Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/9b/4165a1d56ddc302a0e2d518fd9d412a4fd0b57562618c78c5f21c57194f5/coverage-7.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ba3b8390db29296dbbf49e91b6fe08f990743a90c8f447ba4c2ffc29670dfa63", size = 220368, upload-time = "2026-05-10T18:01:34.705Z" },
+    { url = "https://files.pythonhosted.org/packages/69/aa/c12e52a5ba148d9995229d557e3be6e554fe469addc0e9241b2f0956d8ea/coverage-7.14.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3a5d8e876dfa2f102e970b183863d6dedd023d3c0eeca1fe7a9787bc5f28b212", size = 251417, upload-time = "2026-05-10T18:01:36.949Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/51/ec641c26e6dca1b25a7d2035ba6ecb7c884ef1a100a9e42fbe4ce4405139/coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5ebb8f4614a3787d567e610bbfdf96a4798dd69a1afb1bd8ad228d4111fe6ff3", size = 253924, upload-time = "2026-05-10T18:01:38.985Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c4/59c3de0bd1b538824173fd518fed51c1ce740ca5ed68e74545983f4053a9/coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b9bf47223dd8db3d4c4b2e443b02bace480d428f0822c3f991600448a176c97", size = 255269, upload-time = "2026-05-10T18:01:40.957Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a9/36dfa153a62040296f6e7febfdb20a5720622f6ef5a81a41e8237b9a5344/coverage-7.14.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3485a836550b303d006d57cc06e3d5afaabc642c77050b7c985a97b13e3776b8", size = 257583, upload-time = "2026-05-10T18:01:42.607Z" },
+    { url = "https://files.pythonhosted.org/packages/26/7b/cc2c048d4114d9ab1c2409e9ee365e5ae10736df6dffcfc9444effa6c708/coverage-7.14.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3e7e88110bae996d199d1693ca8ec3fd52441d426401ae963437598667b4c5eb", size = 251434, upload-time = "2026-05-10T18:01:44.537Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/df/6770eaa576e604575e9a78055313250faef5faa84bd6f71a39fece519c43/coverage-7.14.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:15228a6800ce7bdf1b74800595e56db7138cecb338fdbf044806e10dcf182dfe", size = 253280, upload-time = "2026-05-10T18:01:46.175Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/9e/1c0264514a3f98259a6d64765a397b2c8373e3ba59ee722a4802d3ec0c61/coverage-7.14.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9d26ac7f5398bafc5b57421ad994e8a4749e8a7a0e62d05ec7d53014d5963bfa", size = 251241, upload-time = "2026-05-10T18:01:48.732Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/4efdf3e3c4079cdbf0ece56a2fea872df9e8a3e15a13a0af4400e1075944/coverage-7.14.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2fb73254ff43c911c967a899e1359bc5049b4b115d6e8fbdde4937d0a2246cd5", size = 255516, upload-time = "2026-05-10T18:01:50.819Z" },
+    { url = "https://files.pythonhosted.org/packages/93/69/b1de96346603881b3d1bc8d6447c83200e1c9700ffbaff926ba01ff5724c/coverage-7.14.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:454a380af72c6adada298ed270d38c7a391288198dbfb8467f786f588751a90c", size = 251059, upload-time = "2026-05-10T18:01:52.773Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/66/2881853e0363a5e0a724d1103e53650795367471b6afb234f8b49e713bc6/coverage-7.14.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:65c86fb646d2bd2972e96bd1a8b45817ed907cee68655d6295fe7ec031d04cca", size = 252716, upload-time = "2026-05-10T18:01:54.506Z" },
+    { url = "https://files.pythonhosted.org/packages/55/5c/0d3305d002c41dcde873dbe456491e663dc55152ca526b630b5c47efd62f/coverage-7.14.0-cp314-cp314-win32.whl", hash = "sha256:6a6516b02a6101398e19a3f44820f69bab2590697f7def4331f668b14adaf828", size = 222788, upload-time = "2026-05-10T18:01:56.487Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/58/6e1b8f52fdc3184b47dc5037f5070d83a3d11042db1594b02d2a44d786c8/coverage-7.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:45e0f79d8351fa76e256716df91eab12890d32678b9590df7ae1042e4bd4cf5d", size = 223600, upload-time = "2026-05-10T18:01:58.497Z" },
+    { url = "https://files.pythonhosted.org/packages/00/70/a18c408e674bc26281cadaedc7351f929bd2094e191e4b15271c30b084cc/coverage-7.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:4b899594a8b2d81e5cc064a0d7f9cac2081fed91049456cae7676787e41549c9", size = 222168, upload-time = "2026-05-10T18:02:00.411Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/89/2681f071d238b62aff8dfc2ab44fc24cfdb38d1c01f391a80522ff5d3a16/coverage-7.14.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f580f8c80acd94ac72e863efe2cab791d8c38d153e0b463b92dfa000d5c84cd1", size = 220766, upload-time = "2026-05-10T18:02:02.313Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c7/c987babafd9207ffa1995e1ef1f9b26762cf4963aa768a66b6f0501e4616/coverage-7.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a2bd259c442cd43c49b30fbafc51776eb19ea396faf159d26a83e6a0a5f13b0c", size = 221035, upload-time = "2026-05-10T18:02:04.017Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e9/d6a5ac3b333088143d6fc877d398a9a674dc03124a2f776e131f03864823/coverage-7.14.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a706b908dfa85538863504c624b237a3cc34232bf403c057414ebfdb3b4d9f84", size = 262405, upload-time = "2026-05-10T18:02:05.915Z" },
+    { url = "https://files.pythonhosted.org/packages/38/b1/e70838d29a7c08e22d44398a46db90815bbcbf28de06992bd9210d1a8d8e/coverage-7.14.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7333cd944ee4393b9b3d3c1b598c936d4fc8d70573a4c7dacfec5590dd50e436", size = 264530, upload-time = "2026-05-10T18:02:07.582Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/73/5c31ef97763288d03d9995152b96d5475b527c63d91c84b01caea894b83a/coverage-7.14.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f162bc9a15b82d947b02651b0c7e1609d6f7a8735ca330cfadec8481dd97d5a", size = 266932, upload-time = "2026-05-10T18:02:09.401Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/76/dd56d80f29c5f05b4d76f7e7c6d47cafacae017189c75c5759d24f9ff0cc/coverage-7.14.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:362cb78e01a5dc82009d88004cf60f2e6b6d6fcbfdec05b05af73b0abf40118f", size = 268062, upload-time = "2026-05-10T18:02:11.399Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c7/27ba85cd5b95614f159ff93ebff1901584a8d192e2e5e24c4943a7453f59/coverage-7.14.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:acebd068fca5512c3a6fde9c045f901613478781a73f0e82b307b214daef23fb", size = 261504, upload-time = "2026-05-10T18:02:13.257Z" },
+    { url = "https://files.pythonhosted.org/packages/13/2e/e8149f60ab5d5684c6eee881bdf34b127115cddbb958b196768dd9d63473/coverage-7.14.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:29fe3da551dface75deb2ccbf87b6b66e2e7ef38f6d89050b428be94afff3490", size = 264398, upload-time = "2026-05-10T18:02:15.063Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/7f/1261b025285323225f4b4abffa5a643649dfd67e25ddca7ebcbdea3b7cb3/coverage-7.14.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b4cc4fce8672fffcb09b0eafc167b396b3ba53c4a7230f54b7aaffbf6c835fa9", size = 262000, upload-time = "2026-05-10T18:02:16.756Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/dc/829c54f60b9d08389439c00f813c752781c496fc5788c78d8006db4b4f2b/coverage-7.14.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:5d4a51aad8ba8bdcd2b8bd8f03d4aca19693fa2327a3470e4718a25b03481020", size = 265732, upload-time = "2026-05-10T18:02:18.817Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b0/70bd1419941652fa062689cba9c3eeafb8f5e6fbb890bce41c3bdda5dbd6/coverage-7.14.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:9f323af3e1e4f68b60b7b247e37b8515563a61375518fa59de1af48ba28a3db6", size = 260847, upload-time = "2026-05-10T18:02:20.528Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/73/be40b2390656c654d35ea0015ea7ba3d945769cf80790ad5e0bb2d56d2ba/coverage-7.14.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1a0abc7342ea9711c469dd8b821c6c311e6bc6aac1442e5fbd6b27fae0a8f3db", size = 263166, upload-time = "2026-05-10T18:02:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/29/55/4a643f712fcf7cf2881f8ec1e0ccb7b164aff3108f69b51801246c8799f2/coverage-7.14.0-cp314-cp314t-win32.whl", hash = "sha256:a9f864ef57b7172e2db87a096642dd51e179e085ab6b2c371c29e885f65c8fb2", size = 223573, upload-time = "2026-05-10T18:02:24.11Z" },
+    { url = "https://files.pythonhosted.org/packages/27/96/3acae5da0953be042c0b4dea6d6789d2f080701c77b88e44d5bd41b9219b/coverage-7.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:29943e552fdc08e082eb51400fb2f58e118a83b5542bd06531214e084399b644", size = 224680, upload-time = "2026-05-10T18:02:25.896Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/6ab5d2dd8325d838737c6f8d83d62eb6230e0d70b87b51b57bbfd08fa767/coverage-7.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:742a73ea621953b012f2c4c2219b512180dd84489acf5b1596b0aafc55b9100b", size = 222703, upload-time = "2026-05-10T18:02:27.822Z" },
+    { url = "https://files.pythonhosted.org/packages/61/e8/cb8e80d6f9f55b99588625062822bf946cf03ed06315df4bd8397f5632a1/coverage-7.14.0-py3-none-any.whl", hash = "sha256:8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1", size = 211764, upload-time = "2026-05-10T18:02:29.538Z" },
+]
+
+[[package]]
 name = "cyclonedx-python-lib"
 version = "11.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -294,6 +333,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "ruff" },
 ]
 
@@ -315,6 +355,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "ruff", specifier = ">=0.15.2" },
 ]
 
@@ -760,6 +801,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #534
Closes #536
Closes #537
Closes #538

## Summary

Bundled chore PR from the periodic health review on 2026-05-10. Three workstreams in one because they all came out of the same audit and consolidating beats fragmenting the history.

### 1. Skills extracted to \`.agents/skills/\`

- \`health-review/SKILL.md\` — the periodic audit walkthrough, with the new items added (subagent verification, GitHub-managed workflow check, stale-blocker cleanup, issue-volume convention).
- \`new-integration/SKILL.md\` — adding integrations end-to-end (module conventions, registration, sidecar+test+env-var sync, polled vs webhook decision, copy-from examples).

Vendor-neutral path per Codex's convention; AGENTS.md exposes them via a Skills index so any agent reading AGENTS.md gets discovery without knowing our directory layout. agentskills.io SKILL.md format (YAML frontmatter + body); structure modeled on Howl's Notion skill craft (Description / When to Use / Process / Constraints / Reference).

### 2. AGENTS.md trim + new policy rules

- Removed the heavy spec sections that now live in the new-integration skill (Content JSON Format, Webhook Integrations, Integration Dependencies) and the health-review skill (full Periodic Review checklist).
- Be opportunistic about dep upgrades regardless of runtime/dev classification.
- Bundle dep upgrades and small drift fixes into in-flight PRs.
- Added GitHub-managed workflow check (7b) to the health-review checklist.
- Prefer GitHub native issue dependencies over free-text \"Blocked by #N\".
- Codified ≤3 / >3 issue-volume convention.
- nosec comments now require \"BXXX — justification\" (rule ID + reason).
- Integration alias rule (\`_vb\`, \`_media\`, \`_sched\`) made explicit.

### 3. pytest-cov + health-review findings + CI cleanup

- \`pytest-cov>=7.1.0\` dev dep + \`[tool.coverage]\` config (report-only, no threshold). Baseline **91%**.
- Health findings fixed inline (closes #536, #537, #538): bart import alias, 5 nosec justifications, README integration-test table sync, direct google.preflight() tests.
- Removed CVE-2026-4539 and CVE-2026-3219 ignores from ci.yml pip-audit step (both fixed by v1.18.0 upgrade).

### 4. Dependabot config fix (closes #534 properly)

The previous fix in #535 used \`exclude-paths: [\"/LICENSE.txt\"]\` based on a community example, but Dependabot's config validator rejects the leading slash:

\`\`\`
The property '#/updates/0/exclude-paths/0' should be relative to the repository root.
\`\`\`

Bare path \`LICENSE.txt\` is correct. Same bug also broke the May 6 Dependabot Updates security run.

## Issue hygiene done outside the PR

- Assigned #522 and #523 (were unassigned).
- Commented on 7 issues (#527, #523, #502, #503, #504, #483, #168) whose \"Blocked by\" notes pointed at now-closed blockers — now actionable.

## Not release-worthy — committed with --no-verify

The .py changes here are alias rename + nosec comment additions + new tests; none affect shipped behavior. Pyproject.toml change is dev deps + coverage config. Per the check-version-bump.sh hook author's own guidance (\"Not release-worthy? Bypass with: git commit --no-verify\"), bypassed with explicit user approval. No version bump, no Auto Release.

## Test plan

- [x] 1405 tests pass; 91% coverage baseline reported
- [x] Full check suite passes (ruff, ruff format, pyright, bandit, pip-audit, pre-commit, pytest)
- [ ] Verify after merge: next \"Graph Update: uv in /.\" run on main passes
- [ ] Verify on next weekly Dependabot cycle: version-update PRs still fire and target uv.lock correctly

— *Claude Code*