### PR TITLE
feat(diving): wind unit knob, integer-rounded swell, recalibrated condition colors

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -142,8 +142,11 @@ token = "your-discogs-personal-access-token"
 # longitude = -121.9
 
 # Unit system: "imperial" (ft, °F, default) or "metric" (m, °C).
-# Wind is always displayed in knots regardless of this setting.
 # units = "imperial"
+
+# Wind display unit: "knots" (default), "mph", or "kmh". Condition scoring
+# always uses knots internally — only the displayed wind value changes.
+# wind_units = "knots"
 
 # Date of the most recent dive — written by the diving webhook, or
 # set manually. Format: YYYY-MM-DD. Shows daily at 10am when present.

--- a/content/contrib/diving.md
+++ b/content/contrib/diving.md
@@ -62,8 +62,11 @@ ndbc_station_id = "46014"
 # longitude = -121.9
 
 # Unit system: "imperial" (ft, °F, default) or "metric" (m, °C).
-# Wind is always displayed in knots regardless of this setting.
 # units = "imperial"
+
+# Wind display unit: "knots" (default), "mph", or "kmh". Condition scoring
+# always uses knots internally — only the displayed wind value changes.
+# wind_units = "knots"
 
 # Date of the most recent dive — written by the webhook, or set manually.
 # Format: YYYY-MM-DD. The last_dive template shows once this is present.
@@ -76,6 +79,7 @@ ndbc_station_id = "46014"
 | `latitude` | Yes (if no NDBC) | Decimal latitude for Open-Meteo fallback |
 | `longitude` | Yes (if no NDBC) | Decimal longitude for Open-Meteo fallback |
 | `units` | No | `"imperial"` (default) or `"metric"` |
+| `wind_units` | No | `"knots"` (default), `"mph"`, or `"kmh"` — display only |
 | `last_dived_on` | No | Most recent dive date (`YYYY-MM-DD`); written by webhook |
 
 ## Webhook setup
@@ -138,18 +142,20 @@ with your webhook URL and the plaintext secret from the scheduler log.
 The header color square reflects subjective dive condition quality based on
 wave height and wind speed. The worst of the two determines the rating, with
 a period modifier that bumps marginal conditions to poor when waves are short
-and choppy (period / wave height < 2).
+and choppy (period / wave height < 1.5).
 
 | Color | Wave height | Wind speed |
 |---|---|---|
-| 🟩 Green | ≤ 2 ft | ≤ 10 kt |
-| 🟨 Yellow | ≤ 4 ft | ≤ 20 kt |
-| 🟥 Red | > 4 ft | > 20 kt |
+| 🟩 Green | ≤ 3 ft | ≤ 12 kt |
+| 🟨 Yellow | ≤ 5 ft | ≤ 20 kt |
+| 🟥 Red | > 5 ft | > 20 kt |
 
-Thresholds are based on recreational dive operator consensus. Conditions that
-are yellow by height and wind but have a period-to-height ratio below 2 are
-shown as red (e.g. 3 ft waves at 5s period). Yellow is shown when key data
-fields are unavailable.
+Thresholds are based on recreational dive operator consensus: 3 ft is the
+beginner-friendly upper bound, 5 ft is the typical op-cancel zone, and 20 kt
+matches the NWS Small Craft Advisory lower bound. Conditions that are yellow
+by height and wind but have a period-to-height ratio below 1.5 are shown as
+red (e.g. 3 ft waves at 4s period). Yellow is shown when key data fields are
+unavailable.
 
 ## Keeping data current
 

--- a/integrations/bart.py
+++ b/integrations/bart.py
@@ -185,7 +185,7 @@ def get_variables() -> dict[str, list[list[str]]]:
     )
     r.raise_for_status()
   except requests.RequestException as e:
-    if isinstance(e, requests.HTTPError):
+    if isinstance(e, requests.HTTPError) and e.response is not None:
       msg = f'BART API error: {e.response.status_code} {e.response.reason}'
     else:
       msg = str(e)

--- a/integrations/discogs.py
+++ b/integrations/discogs.py
@@ -186,7 +186,7 @@ def get_variables() -> dict[str, list[list[str]]]:
     release = releases[index]
 
   except requests.RequestException as e:
-    if isinstance(e, requests.HTTPError):
+    if isinstance(e, requests.HTTPError) and e.response is not None:
       msg = f'Discogs API error: {e.response.status_code} {e.response.reason}'
     else:
       msg = str(e)

--- a/integrations/diving.py
+++ b/integrations/diving.py
@@ -28,7 +28,9 @@
 #
 # Optional config.toml keys:
 #   units         — "imperial" (ft, °F, default) or "metric" (m, °C).
-#                   Wind is always displayed in knots regardless of this setting.
+#   wind_units    — "knots" (default), "mph", or "kmh". Controls only the
+#                   displayed wind value; condition scoring stays in knots
+#                   internally (the thresholds are anchored to marine norms).
 #   last_dived_on — YYYY-MM-DD date of the most recent dive, written by the
 #                   webhook handler. Can also be set manually.
 
@@ -54,15 +56,19 @@ _CACHE_TTL = 3600
 _cache: CacheEntry | None = None
 
 # Condition scoring thresholds based on recreational dive operator consensus.
-# Wave height in feet, wind speed in knots.
-_WAVE_GREEN_FT = 2.0
-_WAVE_YELLOW_FT = 4.0
-_WIND_GREEN_KT = 10.0
+# Wave height in feet, wind speed in knots. Wave green ≤ 3 ft matches the
+# beginner-friendly upper bound; yellow ≤ 5 ft is the typical op-cancel zone.
+# Wind green ≤ 12 kt accommodates routine "easy day" anecdotes; yellow ≤ 20 kt
+# is anchored to the NWS Small Craft Advisory lower bound.
+_WAVE_GREEN_FT = 3.0
+_WAVE_YELLOW_FT = 5.0
+_WIND_GREEN_KT = 12.0
 _WIND_YELLOW_KT = 20.0
 
 # Period-to-height ratio below which a choppy sea bumps the rating one step
-# worse (e.g. 3 ft waves at 5s period: ratio 1.7 < 2.0 → bump to red).
-_PERIOD_RATIO_THRESHOLD = 2.0
+# worse (e.g. 3 ft waves at 4s period: ratio 1.33 < 1.5 → bump). Aligned with
+# the "uncomfortable choppy" cutoff in NJ Scuba's period heuristic.
+_PERIOD_RATIO_THRESHOLD = 1.5
 
 _CARDINALS = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW']
 
@@ -75,12 +81,13 @@ def _degrees_to_cardinal(deg: float) -> str:
 def _fmt_wave(m: float, units: str) -> str:
   """Format wave/swell height with unit suffix.
 
-  Uses one decimal place below 10 and no decimal at or above 10 to keep the
-  string within 6 characters (e.g. '9.9FT', '10FT', '1.2M', '10M').
+  Imperial rounds to whole feet — sub-foot precision sits below NDBC's ±0.2 m
+  (~0.7 ft) accuracy spec and just adds noise on a split-flap display.
+  Metric keeps one decimal below 10 m, since 1 m of resolution is meaningful
+  where 1 ft isn't (a meter is ~3.3 ft).
   """
   if units == 'imperial':
-    ft = m * 3.28084
-    return f'{ft:.0f}FT' if ft >= 10 else f'{ft:.1f}FT'
+    return f'{round(m * 3.28084)}FT'
   return f'{m:.0f}M' if m >= 10 else f'{m:.1f}M'
 
 
@@ -91,9 +98,18 @@ def _fmt_temp(c: float, units: str) -> str:
   return f'{round(c)}C'
 
 
-def _fmt_wind_kt(ms: float) -> str:
-  """Convert m/s wind speed to knots and format with KT suffix."""
-  return f'{round(ms * 1.94384)}KT'
+# Multiplier from m/s and display suffix for each supported wind_units value.
+_WIND_UNITS: dict[str, tuple[float, str]] = {
+  'knots': (1.94384, 'KT'),
+  'mph': (2.23694, 'MPH'),
+  'kmh': (3.6, 'KMH'),
+}
+
+
+def _fmt_wind(ms: float, wind_units: str) -> str:
+  """Convert m/s wind speed to the configured unit and format with a suffix."""
+  multiplier, suffix = _WIND_UNITS[wind_units]
+  return f'{round(ms * multiplier)}{suffix}'
 
 
 def _condition_color(
@@ -265,6 +281,10 @@ def get_variables() -> dict[str, list[list[str]]]:
 
   station_id = _config_mod.get_optional('diving', 'ndbc_station_id')
   units = _config_mod.get_optional('diving', 'units') or 'imperial'
+  wind_units = _config_mod.get_optional('diving', 'wind_units') or 'knots'
+  if wind_units not in _WIND_UNITS:
+    logger.warning('Dive conditions: unknown wind_units %r — falling back to knots', wind_units)
+    wind_units = 'knots'
 
   if _cache is not None and _cache.is_valid(_CACHE_TTL):
     logger.debug('Dive conditions: cache hit')
@@ -299,8 +319,8 @@ def get_variables() -> dict[str, list[list[str]]]:
   period = f'{round(data["period_s"])}S' if data['period_s'] is not None else '--'
   swell = f'SWELL {wave} {period}'
 
-  # Wind row: speed in knots and cardinal direction.
-  wind_spd = _fmt_wind_kt(data['wind_speed_ms']) if data['wind_speed_ms'] is not None else '--'
+  # Wind row: speed in configured unit and cardinal direction.
+  wind_spd = _fmt_wind(data['wind_speed_ms'], wind_units) if data['wind_speed_ms'] is not None else '--'
   wind_dir = _degrees_to_cardinal(data['wind_dir_deg']) if data['wind_dir_deg'] is not None else '--'
   wind = f'WIND {wind_spd} {wind_dir}'
 

--- a/integrations/google.py
+++ b/integrations/google.py
@@ -81,8 +81,8 @@ def _refresh_token() -> None:
   )
   try:
     r.raise_for_status()
-  except requests.HTTPError as e:
-    raise requests.HTTPError(f'Google token refresh failed: {e.response.status_code} {e.response.reason}') from None
+  except requests.HTTPError:
+    raise requests.HTTPError(f'Google token refresh failed: {r.status_code} {r.reason}') from None
   _store_tokens(r.json())
   logger.debug('Google: token refreshed successfully')
 

--- a/integrations/trakt.py
+++ b/integrations/trakt.py
@@ -112,8 +112,8 @@ def _refresh_token() -> None:
   )
   try:
     r.raise_for_status()
-  except requests.HTTPError as e:
-    raise requests.HTTPError(f'Trakt token refresh failed: {e.response.status_code} {e.response.reason}') from None
+  except requests.HTTPError:
+    raise requests.HTTPError(f'Trakt token refresh failed: {r.status_code} {r.reason}') from None
   _store_tokens(r.json())
   logger.debug('Trakt: token refreshed successfully')
 
@@ -437,7 +437,7 @@ def get_variables_calendar() -> dict[str, list[list[str]]]:
       r = fetch_with_retry('GET', url, headers=_request_headers(token, client_id), timeout=10)
     r.raise_for_status()
   except requests.RequestException as e:
-    if isinstance(e, requests.HTTPError):
+    if isinstance(e, requests.HTTPError) and e.response is not None:
       msg = f'Trakt calendar API error: {e.response.status_code} {e.response.reason}'
     else:
       msg = str(e)
@@ -549,10 +549,8 @@ def get_variables_watching() -> dict[str, list[list[str]]]:
 
   try:
     r.raise_for_status()
-  except requests.HTTPError as e:
-    raise IntegrationDataUnavailableError(
-      f'Trakt watching API error: {e.response.status_code} {e.response.reason}'
-    ) from None
+  except requests.HTTPError:
+    raise IntegrationDataUnavailableError(f'Trakt watching API error: {r.status_code} {r.reason}') from None
 
   data = r.json()
   media_type = data.get('type')
@@ -611,7 +609,7 @@ def get_variables_next_up() -> dict[str, list[list[str]]]:
       r = fetch_with_retry('GET', watched_url, headers=_request_headers(token, client_id), timeout=10)
     r.raise_for_status()
   except requests.RequestException as e:
-    if isinstance(e, requests.HTTPError):
+    if isinstance(e, requests.HTTPError) and e.response is not None:
       msg = f'Trakt watched/shows API error: {e.response.status_code} {e.response.reason}'
     else:
       msg = str(e)
@@ -634,7 +632,7 @@ def get_variables_next_up() -> dict[str, list[list[str]]]:
         r2 = fetch_with_retry('GET', progress_url, headers=_request_headers(token, client_id), timeout=10)
       r2.raise_for_status()
     except requests.RequestException as e:
-      if isinstance(e, requests.HTTPError):
+      if isinstance(e, requests.HTTPError) and e.response is not None:
         msg = f'Trakt progress API error: {e.response.status_code} {e.response.reason}'
       else:
         msg = str(e)

--- a/integrations/vestaboard.py
+++ b/integrations/vestaboard.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 _HOST = 'https://rw.vestaboard.com'
 
 
-def _get_headers() -> dict[str, str]:
+def _get_headers() -> dict[str, str | bytes]:
   """Return the auth headers for the Vestaboard API.
 
   Imports config inside the function so the module can be imported without a
@@ -343,8 +343,8 @@ def get_state(color: VestaboardColor = VestaboardColor.BLACK) -> VestaboardState
       )
     try:
       r.raise_for_status()
-    except requests.HTTPError as e:
-      raise requests.HTTPError(f'Vestaboard API error: {e.response.status_code} {e.response.reason}') from None
+    except requests.HTTPError:
+      raise requests.HTTPError(f'Vestaboard API error: {r.status_code} {r.reason}') from None
     return VestaboardState(r.json(), color)
   raise RuntimeError('unreachable')  # pragma: no cover
 
@@ -667,8 +667,8 @@ def set_state_raw(grid: list[list[int]]) -> None:
       )
     try:
       r.raise_for_status()
-    except requests.HTTPError as e:
-      raise requests.HTTPError(f'Vestaboard API error: {e.response.status_code} {e.response.reason}') from None
+    except requests.HTTPError:
+      raise requests.HTTPError(f'Vestaboard API error: {r.status_code} {r.reason}') from None
     return
 
 

--- a/integrations/weather.py
+++ b/integrations/weather.py
@@ -179,11 +179,9 @@ def _geocode(city_query: str, country_code: str | None) -> tuple[float, float, s
     raise IntegrationDataUnavailableError(f'Weather: geocoding request failed — {e}') from None
   try:
     r.raise_for_status()
-  except requests.HTTPError as e:
-    logger.warning('Weather: geocoding error %d %s', e.response.status_code, e.response.reason)
-    raise IntegrationDataUnavailableError(
-      f'Weather geocoding error: {e.response.status_code} {e.response.reason}'
-    ) from None
+  except requests.HTTPError:
+    logger.warning('Weather: geocoding error %d %s', r.status_code, r.reason)
+    raise IntegrationDataUnavailableError(f'Weather geocoding error: {r.status_code} {r.reason}') from None
 
   results = r.json().get('results', [])
   if not results:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.18.0"
+version = "1.19.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/test_diving.py
+++ b/tests/test_diving.py
@@ -63,9 +63,12 @@ def test_degrees_to_cardinal(deg: float, expected: str) -> None:
 @pytest.mark.parametrize(
   'meters,units,expected',
   [
-    (0.5, 'imperial', '1.6FT'),
-    (1.5, 'imperial', '4.9FT'),
-    (3.05, 'imperial', '10FT'),  # >= 10ft → no decimal
+    # Imperial rounds to whole feet — sub-foot precision is noise on the buoy.
+    (0.5, 'imperial', '2FT'),  # 1.64 ft → 2
+    (1.5, 'imperial', '5FT'),  # 4.92 ft → 5
+    (3.05, 'imperial', '10FT'),  # 10.00 ft → 10
+    (0.1, 'imperial', '0FT'),  # 0.33 ft → 0 — confirmed acceptable
+    # Metric keeps one decimal below 10 m — 1 m would be too coarse.
     (0.5, 'metric', '0.5M'),
     (9.5, 'metric', '9.5M'),
     (10.0, 'metric', '10M'),  # >= 10m → no decimal
@@ -94,20 +97,33 @@ def test_fmt_temp(celsius: float, units: str, expected: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# _fmt_wind_kt
+# _fmt_wind
 # ---------------------------------------------------------------------------
 
 
-def test_fmt_wind_kt_converts_from_ms() -> None:
-  # 5.144 m/s ≈ 10 kt
-  result = dc._fmt_wind_kt(5.144)
-  assert result == '10KT'
-
-
-def test_fmt_wind_kt_rounds() -> None:
-  result = dc._fmt_wind_kt(10.0)
-  assert result.endswith('KT')
-  assert result[:-2].isdigit()
+@pytest.mark.parametrize(
+  'ms,wind_units,expected',
+  [
+    # calm (1 m/s)
+    (1.0, 'knots', '2KT'),
+    (1.0, 'mph', '2MPH'),
+    (1.0, 'kmh', '4KMH'),
+    # breezy (5 m/s)
+    (5.0, 'knots', '10KT'),
+    (5.0, 'mph', '11MPH'),
+    (5.0, 'kmh', '18KMH'),
+    # blustery (10 m/s)
+    (10.0, 'knots', '19KT'),
+    (10.0, 'mph', '22MPH'),
+    (10.0, 'kmh', '36KMH'),
+    # gale (20 m/s)
+    (20.0, 'knots', '39KT'),
+    (20.0, 'mph', '45MPH'),
+    (20.0, 'kmh', '72KMH'),
+  ],
+)
+def test_fmt_wind(ms: float, wind_units: str, expected: str) -> None:
+  assert dc._fmt_wind(ms, wind_units) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -120,35 +136,48 @@ def test_fmt_wind_kt_rounds() -> None:
   [
     # Both clearly green
     (0.3, 2.0, 14.0, '[G]'),  # 1ft wave, 4kt wind
-    # Wave marginal, wind green → yellow
-    (0.9, 2.0, 14.0, '[Y]'),  # 3ft wave, 4kt wind
-    # Wind marginal, wave green → yellow
+    # Wave marginal (>3ft), wind green → yellow
+    (1.1, 2.0, 14.0, '[Y]'),  # 3.6ft wave, 4kt wind
+    # Wind marginal (>12kt), wave green → yellow
     (0.3, 7.7, 14.0, '[Y]'),  # 1ft wave, 15kt wind
     # Both marginal → yellow
-    (0.9, 7.7, 14.0, '[Y]'),  # 3ft wave, 15kt wind
-    # Wave red → red
-    (1.8, 2.0, 14.0, '[R]'),  # 6ft wave, 4kt wind
-    # Wind red → red
+    (1.1, 7.7, 14.0, '[Y]'),  # 3.6ft wave, 15kt wind
+    # Wave red (>5ft) → red
+    (1.8, 2.0, 14.0, '[R]'),  # 5.9ft wave, 4kt wind
+    # Wind red (>20kt) → red
     (0.3, 12.9, 14.0, '[R]'),  # 1ft wave, 25kt wind
     # Both red → red
     (1.8, 12.9, 14.0, '[R]'),
     # Period modifier: green wave+wind but choppy period → yellow
-    # 0.45m ≈ 1.5ft; period 2.0s; ratio 2.0/1.5 = 1.33 < 2.0 → bump green→yellow
+    # 0.45m ≈ 1.5ft; period 2.0s; ratio 2.0/1.5 = 1.33 < 1.5 → bump green→yellow
     (0.45, 2.0, 2.0, '[Y]'),
     # Period modifier: yellow → red
-    # 0.9m ≈ 3ft; period 5s; ratio 5/3 ≈ 1.67 < 2.0 → bump yellow→red
-    (0.9, 2.0, 5.0, '[R]'),
+    # 1.1m ≈ 3.6ft; period 5s; ratio 5/3.6 ≈ 1.39 < 1.5 → bump yellow→red
+    (1.1, 2.0, 5.0, '[R]'),
     # Period modifier: already red → stays red (no over-bump)
     (1.8, 2.0, 2.0, '[R]'),
-    # Period ratio exactly at threshold (= 2.0) → no bump
-    # 0.60m ≈ 1.97ft; period 4s; ratio 4/1.97 ≈ 2.03, not < 2.0 → no bump (green)
-    (0.60, 2.0, 4.0, '[G]'),
+    # Period ratio exactly at threshold (= 1.5) → no bump
+    # 0.60m ≈ 1.97ft; period 3s; ratio 3/1.97 ≈ 1.52, not < 1.5 → no bump (green)
+    (0.60, 2.0, 3.0, '[G]'),
     # Missing wave data → yellow
     (None, 5.0, 14.0, '[Y]'),
     # Missing wind data → yellow
     (0.5, None, 14.0, '[Y]'),
     # Missing period → no modifier applied
     (0.3, 2.0, None, '[G]'),
+    # Validation rows from the threshold-change plan (regression coverage):
+    # 0.85m ≈ 2.8ft, 12s, 8kt — typical "easy" day under new thresholds
+    # (would have been yellow under the old 2ft wave threshold).
+    (0.85, 4.1, 12.0, '[G]'),
+    # 0.9m ≈ 2.95ft, 12s, 11.7kt — both axes near the new green ceiling
+    # (would have been yellow under both old 2ft and old 10kt thresholds).
+    (0.9, 6.0, 12.0, '[G]'),
+    # 1.5m ≈ 4.9ft, 8s, 15kt — bumpy but fine; ratio 1.63 > 1.5 → no bump.
+    (1.5, 7.7, 8.0, '[Y]'),
+    # 1.5m ≈ 4.9ft, 6s, 15kt — short-period chop; ratio 1.22 < 1.5 → Y→R.
+    (1.5, 7.7, 6.0, '[R]'),
+    # 1.8m ≈ 5.9ft regardless of period — wave alone is red.
+    (1.8, 2.0, 14.0, '[R]'),
   ],
 )
 def test_condition_color(
@@ -305,7 +334,7 @@ def test_cache_hit_avoids_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
 
   monkeypatch.setattr(_config_mod, '_config', _patched_config())
 
-  cached_value: dict = {'header': [['[G] WATER 55F']], 'swell': [['SWELL 1.5FT 14S']], 'wind': [['WIND 10KT W']]}
+  cached_value: dict = {'header': [['[G] WATER 55F']], 'swell': [['SWELL 5FT 14S']], 'wind': [['WIND 10KT W']]}
   dc._cache = dc.CacheEntry(cached_value)  # type: ignore[attr-defined]
 
   with patch('integrations.diving.fetch_with_retry') as mock_fetch:
@@ -342,7 +371,7 @@ def test_expired_cache_fetches_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
 
   monkeypatch.setattr(_config_mod, '_config', _patched_config())
 
-  stale_value: dict = {'header': [['[G] WATER 55F']], 'swell': [['SWELL 1.5FT 14S']], 'wind': [['WIND 10KT W']]}
+  stale_value: dict = {'header': [['[G] WATER 55F']], 'swell': [['SWELL 5FT 14S']], 'wind': [['WIND 10KT W']]}
   dc._cache = dc.CacheEntry(stale_value)  # type: ignore[attr-defined]
   # Force the cache to appear expired.
   dc._cache.cached_at = time.monotonic() - dc._CACHE_TTL - 1
@@ -367,7 +396,7 @@ def test_stale_cache_served_on_fetch_failure(monkeypatch: pytest.MonkeyPatch) ->
 
   monkeypatch.setattr(_config_mod, '_config', _patched_config())
 
-  stale_value: dict = {'header': [['[Y] WATER 55F']], 'swell': [['SWELL 1.5FT 14S']], 'wind': [['WIND 10KT W']]}
+  stale_value: dict = {'header': [['[Y] WATER 55F']], 'swell': [['SWELL 5FT 14S']], 'wind': [['WIND 10KT W']]}
   dc._cache = dc.CacheEntry(stale_value)  # type: ignore[attr-defined]
   dc._cache.cached_at = time.monotonic() - dc._CACHE_TTL - 1
 
@@ -481,22 +510,78 @@ def test_get_variables_missing_data_shows_placeholder(monkeypatch: pytest.Monkey
   dc._cache = None
 
 
-def test_get_variables_wind_always_in_knots(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_variables_wind_units_default_is_knots(monkeypatch: pytest.MonkeyPatch) -> None:
   import config as _config_mod
 
-  for units in ('imperial', 'metric'):
-    monkeypatch.setattr(_config_mod, '_config', _patched_config(units=units))
-    dc._cache = None
+  monkeypatch.setattr(_config_mod, '_config', _patched_config())
+  dc._cache = None
 
-    mock_resp = MagicMock()
-    mock_resp.text = _NDBC_SAMPLE
-    mock_resp.raise_for_status = MagicMock()
+  mock_resp = MagicMock()
+  mock_resp.text = _NDBC_SAMPLE
+  mock_resp.raise_for_status = MagicMock()
 
+  with patch('integrations.diving.fetch_with_retry', return_value=mock_resp):
+    result = dc.get_variables()
+
+  assert 'KT' in result['wind'][0][0]
+  dc._cache = None
+
+
+@pytest.mark.parametrize(
+  'wind_units,suffix',
+  [
+    ('mph', 'MPH'),
+    ('kmh', 'KMH'),
+  ],
+)
+def test_get_variables_uses_configured_wind_units(
+  monkeypatch: pytest.MonkeyPatch, wind_units: str, suffix: str
+) -> None:
+  import config as _config_mod
+
+  monkeypatch.setattr(
+    _config_mod,
+    '_config',
+    {'diving': {'ndbc_station_id': '46042', 'units': 'imperial', 'wind_units': wind_units}},
+  )
+  dc._cache = None
+
+  mock_resp = MagicMock()
+  mock_resp.text = _NDBC_SAMPLE
+  mock_resp.raise_for_status = MagicMock()
+
+  with patch('integrations.diving.fetch_with_retry', return_value=mock_resp):
+    result = dc.get_variables()
+
+  assert suffix in result['wind'][0][0]
+  dc._cache = None
+
+
+def test_get_variables_invalid_wind_units_falls_back(
+  monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+  import logging
+
+  import config as _config_mod
+
+  monkeypatch.setattr(
+    _config_mod,
+    '_config',
+    {'diving': {'ndbc_station_id': '46042', 'units': 'imperial', 'wind_units': 'furlongs'}},
+  )
+  dc._cache = None
+
+  mock_resp = MagicMock()
+  mock_resp.text = _NDBC_SAMPLE
+  mock_resp.raise_for_status = MagicMock()
+
+  with caplog.at_level(logging.WARNING, logger='integrations.diving'):
     with patch('integrations.diving.fetch_with_retry', return_value=mock_resp):
       result = dc.get_variables()
 
-    assert 'KT' in result['wind'][0][0], f'wind should be in KT for units={units}'
-    dc._cache = None
+  assert 'KT' in result['wind'][0][0]
+  assert any('unknown wind_units' in r.message for r in caplog.records)
+  dc._cache = None
 
 
 def test_get_variables_missing_lat_lon_raises(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -314,7 +314,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.18.0"
+version = "1.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },
@@ -414,11 +414,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -831,15 +831,15 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.3.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/e0/cc5a8653e9a24f6cf84768f05064aa8ed5a83dcefd5e2a043db14a1c5f44/python_discovery-1.3.0.tar.gz", hash = "sha256:d098f1e86be5d45fe4d14bf1029294aabbd332f4321179dec85e76cddce834b0", size = 63925, upload-time = "2026-05-05T14:38:39.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/60/e88788207d81e46362cfbef0d4aaf4c0f49efc3c12d4c3fa3f542c34ebec/python_discovery-1.3.1.tar.gz", hash = "sha256:62f6db28064c9613e7ca76cb3f00c38c839a07c31c00dfe7ed0986493d2150a6", size = 68011, upload-time = "2026-05-12T20:53:36.336Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/d4/24d543ab8b8158b7f5a97113c831205f5c900c92c8762b1e7f44b7ea0405/python_discovery-1.3.0-py3-none-any.whl", hash = "sha256:441d9ced3dfce36e113beb35ca302c71c7ef06f3c0f9c227a0b9bb3bd49b9e9f", size = 33124, upload-time = "2026-05-05T14:38:38.539Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/6f/a05a317a66fee0aad270011461f1a63a453ed12471249f172f7d2e2bc7b4/python_discovery-1.3.1-py3-none-any.whl", hash = "sha256:ed188687ebb3b82c01a17cd5ac62fc94d9f6487a7f1a0f9dfe89753fec91039c", size = 33185, upload-time = "2026-05-12T20:53:34.969Z" },
 ]
 
 [[package]]
@@ -927,7 +927,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.33.1"
+version = "2.34.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -935,9 +935,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/36/7180e7f077c38108945dbbdf60fe04db681c3feb6e96419f8c6dc8723741/requests-2.34.1.tar.gz", hash = "sha256:0fc5669f2b69704449fe1552360bd2a73a54512dfd03e65529157f1513322beb", size = 142783, upload-time = "2026-05-13T19:20:24.662Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5a/4a949d170476de3c04ac036b5466422fbcbf348a917d8042eedf2cac7d1b/requests-2.34.1-py3-none-any.whl", hash = "sha256:bf38a3ff993960d3dd819c08862c40b3c703306eb7c744fcd9f4ddbb95b548f0", size = 73085, upload-time = "2026-05-13T19:20:22.827Z" },
 ]
 
 [[package]]
@@ -1082,21 +1082,21 @@ wheels = [
 
 [[package]]
 name = "urllib3-future"
-version = "2.20.901"
+version = "2.20.904"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "h11" },
     { name = "jh2" },
     { name = "qh3", marker = "(platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'ARM64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'i686' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'ppc64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'ppc64le' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'riscv64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'riscv64gc' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 's390x' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'x86' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'ARM64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'i686' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'ppc64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'ppc64le' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'riscv64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'riscv64gc' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 's390x' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'ARM64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'i686' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'ppc64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'ppc64le' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'riscv64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'riscv64gc' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 's390x' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'x86' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/1c/3f14136ee0d27f04576af02834a374912dd04299e9ff922b593515f4869f/urllib3_future-2.20.901.tar.gz", hash = "sha256:3b78fd8381bf3f261cc2208b15222f5c27ab1a05e518019c9af7f0b3497bd08a", size = 1263135, upload-time = "2026-05-10T05:54:17.977Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/d9/ef97b7a7364e4e14eff0a0a81e4ea359ec00e68412c656a4e21ba2ce5eb4/urllib3_future-2.20.904.tar.gz", hash = "sha256:11aa6b3eda9a1c8da9716c22481af8e3b761f0e9785b51baad0810e4cdb4db96", size = 1276622, upload-time = "2026-05-13T03:11:05.401Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/e4/51085009a548d6be1d80f3462b3b56cd8dd46b5368098c99c8f7cd823f7f/urllib3_future-2.20.901-py3-none-any.whl", hash = "sha256:f28afc5fce3ac6ebbb5c0bf3aee255697b9b501feef9f76b90933470b289aaee", size = 750076, upload-time = "2026-05-10T05:54:16.375Z" },
+    { url = "https://files.pythonhosted.org/packages/62/1a/d73ab2738c374c224b755545a8791112572d3d966a37d79749c56ec3f3fc/urllib3_future-2.20.904-py3-none-any.whl", hash = "sha256:2813888d84e0ff461fb14e94ce6a808dc875c6a776335ad4a473fcaeb58cee67", size = 754436, upload-time = "2026-05-13T03:11:03.608Z" },
 ]
 
 [[package]]
 name = "virtualenv"
-version = "21.3.1"
+version = "21.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -1104,9 +1104,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/0d/915c02c94d207b85580eb09bffab54438a709e7288524094fe781da526c2/virtualenv-21.3.1.tar.gz", hash = "sha256:c2305bc1fddeec40699b8370d13f8d431b0701f00ce895061ce493aeded4426b", size = 7613791, upload-time = "2026-05-05T01:34:31.402Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/ba/1f6e8c957e4932be060dcdc482d339c12e0216351478add3645cdaa53c05/virtualenv-21.3.3.tar.gz", hash = "sha256:f5bda277e553b1c2b3c1a8debfc30496e1288cc93ce6b7b71b3280047e317328", size = 7613784, upload-time = "2026-05-13T18:01:30.19Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/4f/f71e641e504111a5a74e3a20bc52d01bd86788b22699dd3fee1c63253cf6/virtualenv-21.3.1-py3-none-any.whl", hash = "sha256:d1a71cf58f2f9228fff23a1f6ec15d39785c6b32e03658d104974247145edd35", size = 7594539, upload-time = "2026-05-05T01:34:28.98Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/34/a9dbe051de88a63eb7408ea66630bac38e72f7f6077d4be58737106860d9/virtualenv-21.3.3-py3-none-any.whl", hash = "sha256:7d5987d8369e098e41406efb780a3d4ca79280097293899e351a6407ee153ab3", size = 7594554, upload-time = "2026-05-13T18:01:27.815Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Combined display refresh for the diving integration. Closes #540, #543, #544.

- **#543** — new `[diving] wind_units` knob (`"knots"` default, `"mph"`, `"kmh"`). Condition scoring stays in knots internally; only the displayed value changes.
- **#540** — swell wave height rounds to whole feet in imperial. Metric keeps one decimal below 10 m, since 1 m of resolution is meaningful where 1 ft isn't.
- **#544** — recalibrated condition color thresholds: green ≤ 3 ft / ≤ 12 kt, yellow ≤ 5 ft / ≤ 20 kt, period-ratio cutoff lowered to 1.5. Routine 3–5 ft days at moderate wind no longer read red. Full second-pass research and validation rows in [the plan comment](https://github.com/JasonPuglisi/e-note-ion/issues/543#issuecomment-4447615842).

Plan reviewed and approved (👍) at #543.

### Opportunistic bundle

- `uv lock --upgrade` for `idna`, `python-discovery`, `requests`, `urllib3-future`, `virtualenv`.
- Fixed pyright errors surfaced by stricter `requests` 2.34 stubs: `e.response` narrowing across 10 sites (bart, discogs, google, trakt, vestaboard, weather) and `_get_headers()` return type widened to `dict[str, str | bytes]` in vestaboard.

## Test plan

- [x] Unit suite — 1424 passed locally (`uv run pytest`)
- [x] Diving integration test — `uv run pytest -m integration tests/integrations/test_diving_integration.py` (NDBC + Open-Meteo paths green)
- [x] ruff lint + format
- [x] pyright (0 errors)
- [x] bandit (0 issues)
- [x] pip-audit (no known vulnerabilities)
- [x] pre-commit `pretty-format-json`
- [ ] Manual visual check on the Flagship after merge (Note is verified within 15-col budget; Flagship's 22 cols is comfortable but worth eyeballing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)