### PR TITLE
feat(scheduler): calendar-driven gating for cron-triggered enqueues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ integrations/http.py        # Shared HTTP helper with retry logic
 integrations/weather.py     # Current weather via Open-Meteo (no API key required)
 integrations/morning.py     # Morning weather visual grid (optional; falls back to sunrise)
 integrations/calendar.py    # Today's calendar events (ICS feeds + iCloud CalDAV)
+integrations/calendar_schedule.py # Calendar-driven gating for cron-triggered enqueues (vestaboard: keywords)
 integrations/bart.py        # BART real-time departures integration
 integrations/discogs.py     # Daily vinyl suggestion from Discogs collection
 integrations/google.py      # Shared Google OAuth 2.0 device code flow (used by youtube)

--- a/README.md
+++ b/README.md
@@ -134,6 +134,27 @@ Key `[scheduler]` settings:
 | `timezone` | system TZ | IANA timezone for cron job scheduling (e.g. `"America/Los_Angeles"`) |
 | `min_hold` | `60` | Minimum seconds any message stays on display before a high-priority (≥8) queued message can interrupt it. Set to `0` to disable (not recommended for physical displays). |
 
+### Calendar-driven gating
+
+Optionally let calendar events open or close template gates at runtime. When the
+gate is closed, the cron continues to fire but the enqueue is silently dropped
+until a covering event reopens it. The motivating use case: "show BART only on
+days I commute" — list `bart.departures` in `gated_templates`, then mark commute
+days on a calendar event with `vestaboard:bart.departures` in the description.
+
+Reuses the calendars already configured under `[calendar]` (both ICS and CalDAV).
+In any event description, write `vestaboard:<token>` keywords (one per line,
+case-insensitive). The token is a file stem (`bart`) or fully-qualified template
+id (`bart.departures`); prefix with `!` to deny instead of allow. Deny wins on
+conflict. Webhook and refresh enqueues are not gated — only cron firings are.
+
+```toml
+[scheduler.calendar_schedule]
+gated_templates = ["bart.departures"]   # closed by default; calendar opens
+```
+
+See `config.example.toml` for the full keyword grammar and edge cases.
+
 ## Health monitoring
 
 When the [webhook listener](#configuration) is enabled, a health endpoint is

--- a/config.example.toml
+++ b/config.example.toml
@@ -37,6 +37,34 @@
 # displays — flaps need time to settle). Default: 60.
 # min_hold = 60
 
+# ── Calendar-driven gating (optional) ──────────────────────────────────────────
+# Let calendar events open or close template gates. When the gate is closed for
+# a template, its cron continues to fire but the enqueue is silently dropped
+# until the gate reopens. Reuses the calendars configured under [calendar]
+# (both ICS and CalDAV) — no extra calendar setup.
+#
+# In the event description, write keywords (one per line, case-insensitive):
+#   vestaboard:bart                — open all templates in bart.json
+#   vestaboard:bart.departures     — open just bart.departures
+#   vestaboard:!discogs            — close all templates in discogs.json
+#   vestaboard:!youtube.live       — close just youtube.live
+#
+# Use cases:
+#   - "Show BART only on commute days" — list bart.departures in
+#     gated_templates, then mark commute days on a calendar event with
+#     "vestaboard:bart.departures" in the description.
+#   - "Suppress vinyl spin during focus blocks" — drop a focus event with
+#     "vestaboard:!discogs.morning_spin" in the description.
+#
+# Conflict resolution: deny wins. Specific template_id overrides win over
+# stem-level. Webhook and refresh enqueues are not gated — only cron firings.
+#
+# [scheduler.calendar_schedule]
+# # File stems or fully-qualified template ids that are closed by default.
+# # Unlisted templates remain open by default and can only be closed via a
+# # vestaboard:!name event.
+# gated_templates = ["bart.departures"]
+
 # ── Schedule overrides ─────────────────────────────────────────────────────────
 # Override schedule fields or visibility for any named template without editing
 # JSON. Section name: [<integration>.schedules.<template-name>]. All fields are

--- a/integrations/calendar_schedule.py
+++ b/integrations/calendar_schedule.py
@@ -1,0 +1,214 @@
+# integrations/calendar_schedule.py
+#
+# Calendar-driven gating for cron-triggered template enqueues.
+#
+# Reads `vestaboard:<token>` keywords from event descriptions in the user's
+# configured `[calendar]` calendars (ICS and CalDAV). Tokens decide whether
+# templates are allowed to enqueue while the event is active.
+#
+# Token grammar (one keyword per description line, case-insensitive):
+#   vestaboard:<file_stem>             — open all templates in that file
+#   vestaboard:<file_stem>.<template>  — open one specific template
+#   vestaboard:!<file_stem>            — close all templates in that file
+#   vestaboard:!<file_stem>.<template> — close one specific template
+#
+# Resolution (deny wins on conflict):
+#   1. specific template_id override (allow or deny)
+#   2. file-stem override (allow or deny)
+#   3. default — closed if matched by [scheduler.calendar_schedule].gated_templates,
+#      else open
+#
+# Section absent from config = feature disabled, no gating applied.
+
+import logging
+import re
+import threading
+import time
+from datetime import datetime, timedelta
+from typing import Any
+
+from icalendar.cal import Component
+
+logger = logging.getLogger(__name__)
+
+# One keyword per line in event description text. Case-insensitive.
+# Token charset: alphanumeric, underscore, dot, with optional leading bang.
+_KEYWORD_RE = re.compile(
+  r'^\s*vestaboard\s*:\s*(!?\s*[a-zA-Z0-9_.]+)\s*$',
+  re.IGNORECASE | re.MULTILINE,
+)
+
+# Resolved-override cache: { 'bart.departures': True, 'discogs': False, ... }.
+# Refreshed at most once per _CACHE_TTL seconds.
+_cache: dict[str, bool] = {}
+_cache_at: float = 0.0
+_cache_lock = threading.Lock()
+_CACHE_TTL = 60  # seconds — re-extract overrides at most this often
+
+
+def _is_enabled() -> bool:
+  """True if the [scheduler.calendar_schedule] section exists in config."""
+  import config as _config_mod
+
+  return 'calendar_schedule' in _config_mod._config.get('scheduler', {})
+
+
+def _gated_templates() -> set[str]:
+  """Return the set of template_ids and stems closed by default."""
+  import config as _config_mod
+
+  raw = _config_mod._config.get('scheduler', {}).get('calendar_schedule', {}).get('gated_templates', [])
+  if not isinstance(raw, list):
+    return set()
+  return {str(x) for x in raw if isinstance(x, str)}
+
+
+def _parse_token(token: str) -> tuple[bool, str]:
+  """Return (allow, target). allow=False means deny (`!` prefix)."""
+  t = token.strip()
+  if t.startswith('!'):
+    return False, t[1:].strip()
+  return True, t
+
+
+def _extract_keywords(description: str) -> list[tuple[bool, str]]:
+  """Return [(allow, target), ...] from one event description string."""
+  if not description:
+    return []
+  return [_parse_token(m.group(1)) for m in _KEYWORD_RE.finditer(description)]
+
+
+def _is_active_now(component: Component, now: datetime, tz: Any) -> bool:
+  """True if this VEVENT covers `now` in the display timezone.
+
+  All-day events span [DTSTART, DTEND) where DTEND defaults to start + 1 day
+  for single-day events. Timed events use [DTSTART, DTEND); point-in-time
+  events with no DTEND or DURATION are treated as not active (a gate that
+  flips for an instant has no useful semantics here).
+  """
+  from integrations.calendar import _event_end, _event_start, _is_allday
+
+  start = _event_start(component, tz)
+  end = _event_end(component, tz, start)
+  if _is_allday(component) and end is None:
+    end = start + timedelta(days=1)
+  if end is None:
+    return False
+  return start <= now < end
+
+
+def _fetch_active_events(now: datetime, tz: Any) -> list[Component]:
+  """Collect calendar events currently active at `now`.
+
+  Reuses the ICS and CalDAV fetchers in `integrations/calendar.py`, which
+  already cache network responses (30-min ICS cache, process-lifetime
+  CalDAV calendar cache). Returns an empty list on fetch failure with a
+  warning logged — gating must not crash the scheduler.
+  """
+  import config as _config_mod
+  import integrations.calendar as _cal
+
+  cal_cfg = _config_mod._config.get('calendar', {})
+  if not isinstance(cal_cfg, dict) or not cal_cfg:
+    return []
+
+  active: list[Component] = []
+
+  if cal_cfg.get('urls'):
+    try:
+      for component, _, _ in _cal._collect_candidates_ics(cal_cfg, now, tz):
+        if _is_active_now(component, now, tz):
+          active.append(component)
+    except Exception as e:  # noqa: BLE001
+      logger.warning('calendar_schedule: ICS fetch failed: %s', e)
+
+  if cal_cfg.get('caldav_url'):
+    try:
+      for component, _, _ in _cal._collect_candidates_caldav(cal_cfg, now, tz):
+        if _is_active_now(component, now, tz):
+          active.append(component)
+    except Exception as e:  # noqa: BLE001
+      logger.warning('calendar_schedule: CalDAV fetch failed: %s', e)
+
+  return active
+
+
+def _resolve_overrides(events: list[Component]) -> dict[str, bool]:
+  """Reduce active events to a flat target → allow/deny mapping.
+
+  Applies deny-wins-on-conflict: once a target is denied, subsequent allows
+  for the same target are ignored.
+  """
+  out: dict[str, bool] = {}
+  for component in events:
+    desc = str(component.get('DESCRIPTION', '') or '')
+    for allow, target in _extract_keywords(desc):
+      if not target:
+        continue
+      if out.get(target) is False:
+        continue  # deny already won
+      out[target] = allow
+  return out
+
+
+def _refresh(now: datetime | None = None) -> None:
+  """Refresh the resolved-overrides cache. Acquires _cache_lock."""
+  import config as _config_mod
+  import integrations.calendar as _cal
+
+  global _cache_at
+
+  tz = _config_mod.get_timezone()
+  if now is None:
+    now = _cal._get_now(tz)
+
+  events = _fetch_active_events(now, tz)
+  resolved = _resolve_overrides(events)
+
+  with _cache_lock:
+    _cache.clear()
+    _cache.update(resolved)
+    _cache_at = time.monotonic()
+
+
+def _get_overrides() -> dict[str, bool]:
+  """Return the cached overrides, refreshing if stale."""
+  with _cache_lock:
+    age = time.monotonic() - _cache_at
+    fresh = age < _CACHE_TTL and _cache_at > 0
+  if fresh:
+    return dict(_cache)
+  _refresh()
+  with _cache_lock:
+    return dict(_cache)
+
+
+def is_open(template_id: str, stem: str) -> bool:
+  """True if the named template is currently allowed to enqueue.
+
+  template_id is `<file_stem>.<template_name>` (e.g. 'bart.departures').
+  stem is the file stem alone ('bart').
+
+  When [scheduler.calendar_schedule] is absent, returns True (no gating).
+  Otherwise applies override resolution and falls back to the default state
+  (open unless template_id or stem is in `gated_templates`).
+  """
+  if not _is_enabled():
+    return True
+
+  overrides = _get_overrides()
+  if template_id in overrides:
+    return overrides[template_id]
+  if stem in overrides:
+    return overrides[stem]
+
+  gated = _gated_templates()
+  return template_id not in gated and stem not in gated
+
+
+def reset_cache() -> None:
+  """Clear the resolved-overrides cache. Intended for tests."""
+  global _cache_at
+  with _cache_lock:
+    _cache.clear()
+    _cache_at = 0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.20.0"
+version = "1.21.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/scheduler.py
+++ b/scheduler.py
@@ -1106,6 +1106,31 @@ def _validate_template(name: str, template: dict[str, Any]) -> None:
     raise ValueError(f'{name}: integration_fn must be a string, got {integration_fn!r}')
 
 
+def _make_gated_enqueue(template_id: str, stem: str) -> Callable[..., None]:
+  """Wrap enqueue() with a calendar_schedule gate check.
+
+  The returned callable has the same signature as enqueue(). When the gate
+  is closed (calendar-driven override or [scheduler.calendar_schedule].gated_templates
+  default), the cron fire is silently dropped after a debug log.
+  """
+
+  def _gated(
+    priority: int,
+    data: dict[str, Any],
+    hold: int,
+    timeout: int,
+    name: str = '',
+  ) -> None:
+    import integrations.calendar_schedule as _cs
+
+    if not _cs.is_open(template_id, stem):
+      logger.debug('cron %s suppressed by calendar_schedule', name)
+      return
+    enqueue(priority, data, hold, timeout, name)
+
+  return _gated
+
+
 def _load_file(
   scheduler: BackgroundScheduler,
   content_file: Path,
@@ -1217,8 +1242,13 @@ def _load_file(
       data['refresh_interval'] = ri
     elif 'refresh_interval' in data:
       del data['refresh_interval']
+    # The gated-enqueue closure consults calendar_schedule before forwarding to
+    # enqueue(). Webhook-triggered and refresh-triggered enqueues bypass this
+    # entirely — only cron firings go through the gate.
+    template_id = f'{content_file.stem}.{template_name}'
+    gated = _make_gated_enqueue(template_id, content_file.stem)
     scheduler.add_job(
-      enqueue,
+      gated,
       trigger='cron',
       args=[priority, data, effective['hold'], effective['timeout'], job_id],
       id=job_id,
@@ -1305,6 +1335,46 @@ def load_content(
     found = user_stems | contrib_stems
     for stem in sorted(content_enabled - found):
       logger.warning('content file not found for enabled stem %r — check [scheduler] enabled in config.toml', stem)
+
+  _validate_calendar_schedule(scheduler)
+
+
+def _validate_calendar_schedule(scheduler: BackgroundScheduler) -> None:
+  """Warn about gated_templates entries that don't match any loaded template.
+
+  Each entry must be either a file stem (e.g. 'bart') or a fully-qualified
+  template id ('bart.departures'). Bare template names without a stem are
+  rejected — silent ambiguity in keyword-driven config is a footgun.
+  """
+  cs_cfg = _config_mod._config.get('scheduler', {}).get('calendar_schedule', {})
+  if not isinstance(cs_cfg, dict) or not cs_cfg:
+    return
+  raw = cs_cfg.get('gated_templates', [])
+  if not isinstance(raw, list):
+    logger.warning('calendar_schedule.gated_templates must be a list, got %r', raw)
+    return
+
+  loaded_stems: set[str] = set()
+  loaded_template_ids: set[str] = set()
+  for job in scheduler.get_jobs():
+    # job.id is '<dir>.<stem>.<template_name>' (e.g. 'contrib.bart.departures').
+    parts = job.id.split('.', 2)
+    if len(parts) == 3:
+      _, stem, template_name = parts
+      loaded_stems.add(stem)
+      loaded_template_ids.add(f'{stem}.{template_name}')
+
+  for entry in raw:
+    if not isinstance(entry, str):
+      logger.warning('calendar_schedule.gated_templates entry must be a string, got %r', entry)
+      continue
+    if entry in loaded_stems or entry in loaded_template_ids:
+      continue
+    logger.warning(
+      'calendar_schedule.gated_templates entry %r does not match any loaded '
+      'file stem or template id — entries must be "<stem>" or "<stem>.<template>"',
+      entry,
+    )
 
 
 def _validate_startup(config_path: Path) -> None:

--- a/tests/core/test_calendar_schedule.py
+++ b/tests/core/test_calendar_schedule.py
@@ -1,0 +1,318 @@
+from datetime import datetime, timedelta, timezone
+from typing import Any, Generator
+from unittest.mock import patch
+
+import pytest
+from icalendar import Event
+
+import integrations.calendar_schedule as cs
+
+_UTC = timezone.utc
+_NOW = datetime(2026, 5, 14, 12, 0, 0, tzinfo=_UTC)
+
+
+@pytest.fixture(autouse=True)
+def reset_state(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+  """Reset module caches and config between tests."""
+  import config as _config_mod
+
+  monkeypatch.setattr(_config_mod, '_config', {})
+  cs.reset_cache()
+  yield
+  cs.reset_cache()
+
+
+def _enable(
+  monkeypatch: pytest.MonkeyPatch,
+  *,
+  gated: list[str] | None = None,
+  with_calendar: bool = True,
+) -> None:
+  """Set [scheduler.calendar_schedule] in config and (optionally) [calendar]."""
+  import config as _config_mod
+
+  cfg: dict[str, Any] = {
+    'scheduler': {'calendar_schedule': {'gated_templates': gated or []}},
+  }
+  if with_calendar:
+    cfg['calendar'] = {'urls': ['https://example.com/cal.ics']}
+  monkeypatch.setattr(_config_mod, '_config', cfg)
+
+
+def _make_event(
+  *,
+  description: str,
+  start: datetime,
+  end: datetime | None = None,
+  all_day: bool = False,
+) -> Any:
+  ev = Event()
+  ev.add('SUMMARY', 'Test event')
+  ev.add('DESCRIPTION', description)
+  if all_day:
+    ev.add('DTSTART', start.date())
+    if end:
+      ev.add('DTEND', end.date())
+  else:
+    ev.add('DTSTART', start)
+    if end:
+      ev.add('DTEND', end)
+  return ev
+
+
+# ── _extract_keywords ──────────────────────────────────────────────────────────
+
+
+def test_extract_keywords_single_allow() -> None:
+  assert cs._extract_keywords('vestaboard:bart') == [(True, 'bart')]
+
+
+def test_extract_keywords_single_deny() -> None:
+  assert cs._extract_keywords('vestaboard:!discogs.morning_spin') == [(False, 'discogs.morning_spin')]
+
+
+def test_extract_keywords_multiple_lines() -> None:
+  desc = 'vestaboard:bart\nvestaboard:!discogs.morning_spin\nvestaboard:weather'
+  assert cs._extract_keywords(desc) == [
+    (True, 'bart'),
+    (False, 'discogs.morning_spin'),
+    (True, 'weather'),
+  ]
+
+
+def test_extract_keywords_inline_prose_does_not_match() -> None:
+  desc = "let's talk about vestaboard:bart timing in the meeting"
+  assert cs._extract_keywords(desc) == []
+
+
+def test_extract_keywords_with_other_lines() -> None:
+  desc = 'Meeting with team\nvestaboard:bart\nReview Q2 plan'
+  assert cs._extract_keywords(desc) == [(True, 'bart')]
+
+
+def test_extract_keywords_case_insensitive() -> None:
+  assert cs._extract_keywords('VESTABOARD:BART') == [(True, 'BART')]
+
+
+def test_extract_keywords_whitespace_tolerated() -> None:
+  assert cs._extract_keywords('  vestaboard : bart  ') == [(True, 'bart')]
+  assert cs._extract_keywords('vestaboard:! bart') == [(False, 'bart')]
+
+
+def test_extract_keywords_empty_description() -> None:
+  assert cs._extract_keywords('') == []
+
+
+# ── _resolve_overrides (deny wins) ─────────────────────────────────────────────
+
+
+def test_resolve_overrides_single_allow() -> None:
+  ev = _make_event(description='vestaboard:bart', start=_NOW)
+  assert cs._resolve_overrides([ev]) == {'bart': True}
+
+
+def test_resolve_overrides_single_deny() -> None:
+  ev = _make_event(description='vestaboard:!bart', start=_NOW)
+  assert cs._resolve_overrides([ev]) == {'bart': False}
+
+
+def test_resolve_overrides_deny_wins_on_conflict() -> None:
+  ev1 = _make_event(description='vestaboard:bart', start=_NOW)
+  ev2 = _make_event(description='vestaboard:!bart', start=_NOW)
+  assert cs._resolve_overrides([ev1, ev2]) == {'bart': False}
+  # Order-independent.
+  assert cs._resolve_overrides([ev2, ev1]) == {'bart': False}
+
+
+def test_resolve_overrides_specific_and_stem_independent() -> None:
+  # Stem and specific-template tokens resolve as separate keys; the
+  # combination is interpreted at gate-check time, not here.
+  ev1 = _make_event(description='vestaboard:bart', start=_NOW)
+  ev2 = _make_event(description='vestaboard:!bart.departures', start=_NOW)
+  assert cs._resolve_overrides([ev1, ev2]) == {'bart': True, 'bart.departures': False}
+
+
+# ── is_open semantics ─────────────────────────────────────────────────────────
+
+
+def test_is_open_returns_true_when_feature_disabled() -> None:
+  # No [scheduler.calendar_schedule] section in config.
+  assert cs.is_open('bart.departures', 'bart') is True
+
+
+def test_is_open_default_open_when_not_gated(monkeypatch: pytest.MonkeyPatch) -> None:
+  _enable(monkeypatch, gated=[])
+  with patch.object(cs, '_fetch_active_events', return_value=[]):
+    assert cs.is_open('bart.departures', 'bart') is True
+
+
+def test_is_open_default_closed_when_gated_by_template_id(monkeypatch: pytest.MonkeyPatch) -> None:
+  _enable(monkeypatch, gated=['bart.departures'])
+  with patch.object(cs, '_fetch_active_events', return_value=[]):
+    assert cs.is_open('bart.departures', 'bart') is False
+
+
+def test_is_open_default_closed_when_gated_by_stem(monkeypatch: pytest.MonkeyPatch) -> None:
+  _enable(monkeypatch, gated=['bart'])
+  with patch.object(cs, '_fetch_active_events', return_value=[]):
+    assert cs.is_open('bart.departures', 'bart') is False
+    assert cs.is_open('bart.alerts', 'bart') is False
+
+
+def test_is_open_calendar_opens_gated_template(monkeypatch: pytest.MonkeyPatch) -> None:
+  _enable(monkeypatch, gated=['bart.departures'])
+  ev = _make_event(
+    description='vestaboard:bart.departures', start=_NOW - timedelta(hours=1), end=_NOW + timedelta(hours=1)
+  )
+  with patch.object(cs, '_fetch_active_events', return_value=[ev]):
+    assert cs.is_open('bart.departures', 'bart') is True
+
+
+def test_is_open_calendar_closes_default_open_template(monkeypatch: pytest.MonkeyPatch) -> None:
+  _enable(monkeypatch, gated=[])
+  ev = _make_event(
+    description='vestaboard:!discogs.morning_spin', start=_NOW - timedelta(hours=1), end=_NOW + timedelta(hours=1)
+  )
+  with patch.object(cs, '_fetch_active_events', return_value=[ev]):
+    assert cs.is_open('discogs.morning_spin', 'discogs') is False
+
+
+def test_is_open_specific_override_wins_over_stem(monkeypatch: pytest.MonkeyPatch) -> None:
+  _enable(monkeypatch, gated=[])
+  # Stem says open, specific template says closed — specific wins.
+  ev1 = _make_event(description='vestaboard:bart', start=_NOW - timedelta(hours=1), end=_NOW + timedelta(hours=1))
+  ev2 = _make_event(
+    description='vestaboard:!bart.departures', start=_NOW - timedelta(hours=1), end=_NOW + timedelta(hours=1)
+  )
+  with patch.object(cs, '_fetch_active_events', return_value=[ev1, ev2]):
+    assert cs.is_open('bart.departures', 'bart') is False
+    assert cs.is_open('bart.alerts', 'bart') is True
+
+
+def test_is_open_stem_override_open_falls_through_to_default_for_other_stems(monkeypatch: pytest.MonkeyPatch) -> None:
+  _enable(monkeypatch, gated=['discogs'])
+  ev = _make_event(description='vestaboard:bart', start=_NOW - timedelta(hours=1), end=_NOW + timedelta(hours=1))
+  with patch.object(cs, '_fetch_active_events', return_value=[ev]):
+    assert cs.is_open('bart.departures', 'bart') is True  # opened by event
+    assert cs.is_open('discogs.morning_spin', 'discogs') is False  # gated, no event
+
+
+# ── _is_active_now (event time windows) ───────────────────────────────────────
+
+
+def test_is_active_now_timed_event_within_window() -> None:
+  ev = _make_event(description='', start=_NOW - timedelta(hours=1), end=_NOW + timedelta(hours=1))
+  assert cs._is_active_now(ev, _NOW, _UTC) is True
+
+
+def test_is_active_now_timed_event_before_start() -> None:
+  ev = _make_event(description='', start=_NOW + timedelta(hours=1), end=_NOW + timedelta(hours=2))
+  assert cs._is_active_now(ev, _NOW, _UTC) is False
+
+
+def test_is_active_now_timed_event_after_end() -> None:
+  ev = _make_event(description='', start=_NOW - timedelta(hours=2), end=_NOW - timedelta(hours=1))
+  assert cs._is_active_now(ev, _NOW, _UTC) is False
+
+
+def test_is_active_now_timed_event_at_end_boundary_excluded() -> None:
+  # [DTSTART, DTEND) — end boundary is exclusive.
+  ev = _make_event(description='', start=_NOW - timedelta(hours=1), end=_NOW)
+  assert cs._is_active_now(ev, _NOW, _UTC) is False
+
+
+def test_is_active_now_all_day_event_today() -> None:
+  ev = _make_event(description='', start=_NOW, all_day=True)
+  assert cs._is_active_now(ev, _NOW, _UTC) is True
+
+
+def test_is_active_now_all_day_event_yesterday() -> None:
+  yesterday = _NOW - timedelta(days=1)
+  ev = _make_event(description='', start=yesterday, all_day=True)
+  assert cs._is_active_now(ev, _NOW, _UTC) is False
+
+
+def test_is_active_now_point_event_no_end_returns_false() -> None:
+  # Point-in-time event with no DTEND or DURATION — gating semantics undefined.
+  ev = _make_event(description='', start=_NOW)
+  assert cs._is_active_now(ev, _NOW, _UTC) is False
+
+
+# ── Cache behavior ────────────────────────────────────────────────────────────
+
+
+def test_cache_refresh_only_once_within_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+  _enable(monkeypatch, gated=[])
+  call_count = {'n': 0}
+
+  def fake_fetch(now: datetime, tz: Any) -> list[Any]:
+    call_count['n'] += 1
+    return []
+
+  with patch.object(cs, '_fetch_active_events', side_effect=fake_fetch):
+    cs.is_open('bart.departures', 'bart')
+    cs.is_open('bart.departures', 'bart')
+    cs.is_open('weather.now', 'weather')
+  assert call_count['n'] == 1
+
+
+def test_cache_refresh_after_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+  _enable(monkeypatch, gated=[])
+  call_count = {'n': 0}
+
+  def fake_fetch(now: datetime, tz: Any) -> list[Any]:
+    call_count['n'] += 1
+    return []
+
+  with patch.object(cs, '_fetch_active_events', side_effect=fake_fetch):
+    cs.is_open('bart.departures', 'bart')
+    cs.reset_cache()
+    cs.is_open('bart.departures', 'bart')
+  assert call_count['n'] == 2
+
+
+# ── Fetch error handling ──────────────────────────────────────────────────────
+
+
+def test_fetch_active_events_no_calendar_section_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _config_mod
+
+  monkeypatch.setattr(_config_mod, '_config', {})
+  assert cs._fetch_active_events(_NOW, _UTC) == []
+
+
+def test_fetch_active_events_ics_failure_logged(
+  monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+  import config as _config_mod
+  import integrations.calendar as _cal
+
+  monkeypatch.setattr(_config_mod, '_config', {'calendar': {'urls': ['https://example.com/cal.ics']}})
+  monkeypatch.setattr(_cal, '_collect_candidates_ics', lambda *a, **kw: (_ for _ in ()).throw(RuntimeError('boom')))
+  with caplog.at_level('WARNING'):
+    result = cs._fetch_active_events(_NOW, _UTC)
+  assert result == []
+  assert 'ICS fetch failed' in caplog.text
+
+
+def test_get_overrides_handles_fetch_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+  _enable(monkeypatch, gated=[])
+  with patch.object(cs, '_fetch_active_events', side_effect=RuntimeError('boom')):
+    # The error propagates from _refresh; gate falls back to default-open.
+    # _refresh does not swallow exceptions raised inside it (unlike the
+    # per-source fetchers which catch their own); document this behavior.
+    with pytest.raises(RuntimeError):
+      cs.is_open('bart.departures', 'bart')
+
+
+# ── Recurring events (smoke test via _resolve_overrides) ──────────────────────
+
+
+def test_recurring_weekday_only_today() -> None:
+  # Pretend recurring expansion already happened and the active-now filter
+  # picked out exactly today's instance. _resolve_overrides operates on
+  # whatever events the fetcher hands back.
+  today_morning = _NOW.replace(hour=8, minute=0)
+  today_evening = _NOW.replace(hour=10, minute=0)
+  ev = _make_event(description='vestaboard:bart.departures', start=today_morning, end=today_evening)
+  assert cs._resolve_overrides([ev]) == {'bart.departures': True}

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -2419,7 +2419,7 @@ def test_known_integrations_covers_all_integration_modules() -> None:
   from pathlib import Path
 
   integrations_dir = Path(importlib.import_module('integrations').__file__).parent  # type: ignore[arg-type]
-  _util_modules = {'__init__', 'vestaboard', 'http', 'color', 'google', 'media', 'tmdb'}
+  _util_modules = {'__init__', 'vestaboard', 'http', 'color', 'google', 'media', 'tmdb', 'calendar_schedule'}
   modules = {p.stem for p in integrations_dir.glob('*.py') if p.stem not in _util_modules}
   missing = modules - _mod._KNOWN_INTEGRATIONS
   assert not missing, f'Integrations missing from _KNOWN_INTEGRATIONS: {missing}'
@@ -2814,3 +2814,125 @@ def test_board_showing_private_set_true_on_private_send() -> None:
     with pytest.raises(KeyboardInterrupt):
       _mod.worker()
   assert _mod._board_showing_private is True
+
+
+# --- _make_gated_enqueue ---
+
+
+def test_gated_enqueue_calls_through_when_open() -> None:
+  with (
+    patch('integrations.calendar_schedule.is_open', return_value=True),
+    patch.object(_mod, 'enqueue') as mock_enq,
+  ):
+    gated = _mod._make_gated_enqueue('bart.departures', 'bart')
+    gated(5, {'foo': 1}, 60, 60, 'contrib.bart.departures')
+  mock_enq.assert_called_once_with(5, {'foo': 1}, 60, 60, 'contrib.bart.departures')
+
+
+def test_gated_enqueue_drops_when_closed(caplog: pytest.LogCaptureFixture) -> None:
+  with (
+    patch('integrations.calendar_schedule.is_open', return_value=False),
+    patch.object(_mod, 'enqueue') as mock_enq,
+  ):
+    gated = _mod._make_gated_enqueue('bart.departures', 'bart')
+    with caplog.at_level('DEBUG'):
+      gated(5, {'foo': 1}, 60, 60, 'contrib.bart.departures')
+  mock_enq.assert_not_called()
+  assert 'suppressed by calendar_schedule' in caplog.text
+
+
+def test_load_file_registers_gated_enqueue(sched: BackgroundScheduler, tmp_path: Path) -> None:
+  """Cron jobs registered by _load_file go through the gate, not enqueue() directly."""
+  f = tmp_path / 'mytest.json'
+  f.write_text(json.dumps(_make_content()))
+  _mod._load_file(sched, f)
+  jobs = sched.get_jobs()
+  assert len(jobs) == 1
+  # The wrapped function is a closure named _gated, not the bare enqueue.
+  assert jobs[0].func is not _mod.enqueue
+  assert jobs[0].func.__name__ == '_gated'
+
+
+# --- _validate_calendar_schedule ---
+
+
+def test_validate_calendar_schedule_warns_on_unknown_entry(
+  sched: BackgroundScheduler,
+  tmp_path: Path,
+  monkeypatch: pytest.MonkeyPatch,
+  caplog: pytest.LogCaptureFixture,
+) -> None:
+  import config as _config_mod
+
+  monkeypatch.setattr(
+    _config_mod,
+    '_config',
+    {'scheduler': {'calendar_schedule': {'gated_templates': ['nonexistent']}}},
+  )
+  user_dir = tmp_path / 'content' / 'user'
+  user_dir.mkdir(parents=True)
+  _make_file(user_dir, 'mytest.json')
+  monkeypatch.chdir(tmp_path)
+  with caplog.at_level('WARNING'):
+    _mod.load_content(sched, content_enabled=None)
+  assert 'gated_templates entry' in caplog.text
+  assert "'nonexistent'" in caplog.text
+
+
+def test_validate_calendar_schedule_accepts_stem_match(
+  sched: BackgroundScheduler,
+  tmp_path: Path,
+  monkeypatch: pytest.MonkeyPatch,
+  caplog: pytest.LogCaptureFixture,
+) -> None:
+  import config as _config_mod
+
+  monkeypatch.setattr(
+    _config_mod,
+    '_config',
+    {'scheduler': {'calendar_schedule': {'gated_templates': ['mytest']}}},
+  )
+  user_dir = tmp_path / 'content' / 'user'
+  user_dir.mkdir(parents=True)
+  _make_file(user_dir, 'mytest.json')
+  monkeypatch.chdir(tmp_path)
+  with caplog.at_level('WARNING'):
+    _mod.load_content(sched, content_enabled=None)
+  assert 'gated_templates entry' not in caplog.text
+
+
+def test_validate_calendar_schedule_accepts_template_id_match(
+  sched: BackgroundScheduler,
+  tmp_path: Path,
+  monkeypatch: pytest.MonkeyPatch,
+  caplog: pytest.LogCaptureFixture,
+) -> None:
+  import config as _config_mod
+
+  monkeypatch.setattr(
+    _config_mod,
+    '_config',
+    {'scheduler': {'calendar_schedule': {'gated_templates': ['mytest.tmpl']}}},
+  )
+  user_dir = tmp_path / 'content' / 'user'
+  user_dir.mkdir(parents=True)
+  _make_file(user_dir, 'mytest.json')
+  monkeypatch.chdir(tmp_path)
+  with caplog.at_level('WARNING'):
+    _mod.load_content(sched, content_enabled=None)
+  assert 'gated_templates entry' not in caplog.text
+
+
+def test_validate_calendar_schedule_no_op_when_section_absent(
+  sched: BackgroundScheduler,
+  tmp_path: Path,
+  monkeypatch: pytest.MonkeyPatch,
+  caplog: pytest.LogCaptureFixture,
+) -> None:
+  user_dir = tmp_path / 'content' / 'user'
+  user_dir.mkdir(parents=True)
+  _make_file(user_dir, 'mytest.json')
+  monkeypatch.chdir(tmp_path)
+  with caplog.at_level('WARNING'):
+    _mod.load_content(sched, content_enabled=None)
+  assert 'gated_templates' not in caplog.text

--- a/uv.lock
+++ b/uv.lock
@@ -314,7 +314,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.20.0"
+version = "1.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Closes #542.

## Summary

Opt-in `[scheduler.calendar_schedule]` section that lets calendar events open or close template gates at runtime. Reuses the existing `[calendar]` ICS/CalDAV plumbing — no extra calendar setup. Per the [approved plan](https://github.com/JasonPuglisi/e-note-ion/issues/542#issuecomment-4452113154) (gate-on-enqueue, not cascade-tier).

- Keyword grammar in event descriptions: `vestaboard:<token>` (one per line, case-insensitive, line-anchored to avoid prose collisions). Token is a file stem (`bart`) or fully-qualified template id (`bart.departures`); `!` prefix denies
- Templates in `gated_templates` are closed by default; calendar events open them. All other templates are open by default; calendar events can close them via `!`
- Specific-template overrides win over stem-level. Deny wins on conflict
- Webhook and refresh enqueues are unaffected — only cron firings go through the gate
- Resolved-overrides cache is refreshed at most once per 60s, on top of `calendar.py`'s existing 30-min ICS cache
- Calendar fetch failures log a warning and fall back to defaults (gating must never crash the scheduler)
- `_validate_calendar_schedule` warns at startup when a `gated_templates` entry doesn't match any loaded template

## Out of scope (deferred)

- Cron-string mutation during event windows (`vestaboard:cron:*/2 ...`). Defer until needed
- Free-text triggers in arbitrary calendars beyond the configured `[calendar]` set. Reuse only for v1
- Bare template names (`vestaboard:morning_spin`). Rejected by design — silent ambiguity in keyword config is a footgun

## Test plan

- [x] Unit: `tests/core/test_calendar_schedule.py` — 33 tests covering keyword extraction (line anchoring, case, whitespace, prose-collision negative), override resolution (deny wins), `is_open` semantics (default-open vs `gated_templates`, calendar opens, calendar closes, specific-wins-over-stem), `_is_active_now` boundaries (timed, all-day, point-in-time, end-exclusive), cache TTL behavior, fetch failure handling
- [x] Unit: `tests/core/test_scheduler.py` — `_make_gated_enqueue` calls through when open, drops when closed; `_load_file` registers the gated wrapper (not raw enqueue); `_validate_calendar_schedule` warns on unknown entries and accepts both stem and template-id matches
- [x] `uv run pytest --cov` — 1486 passed, 95% coverage
- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run pyright`, `uv run bandit`, `uv run pip-audit`, `pretty-format-json` — all clean

## Versioning

New optional config section, backwards-compatible default, no behavior change without opt-in. Bumped to `1.21.0` (minor).

— *Claude Code*