### PR TITLE
fix(media): drop S<n> when season missing; strip trailing punctuation before ellipsis

### DIFF
--- a/integrations/media.py
+++ b/integrations/media.py
@@ -2,6 +2,8 @@
 #
 # Shared media title utilities used by Plex and Trakt integrations.
 
+import integrations.vestaboard as _vb
+
 _LEADING_ARTICLES = ('THE ', 'AN ', 'A ')
 
 
@@ -20,8 +22,14 @@ def strip_leading_article_if_needed(title: str, max_width: int, prefix: str = ''
   return strip_leading_article(title)
 
 
-def format_episode_ref(season: int, episode: int) -> str:
-  """Return a compact episode ref, e.g. S9E8 (no zero-padding)."""
+def format_episode_ref(season: int | None, episode: int) -> str:
+  """Return a compact episode ref, e.g. S9E8 (no zero-padding).
+
+  When season is None, returns just E<n> — used when upstream metadata
+  lacks season info. Season 0 (specials) renders normally as S0E<n>.
+  """
+  if season is None:
+    return f'E{episode}'
   return f'S{season}E{episode}'
 
 
@@ -59,5 +67,5 @@ def wrap_title_to_rows(title: str, cols: int, max_rows: int) -> list[str]:
     rows.append(' '.join(current))
   if len(rows) > max_rows:
     rows = rows[:max_rows]
-    rows[-1] = rows[-1][: cols - 3].rstrip() + '...'
+    rows[-1] = _vb.trim_for_ellipsis(rows[-1][: cols - 3]) + '...'
   return rows

--- a/integrations/plex.py
+++ b/integrations/plex.py
@@ -526,7 +526,7 @@ def _build_metadata(
       episode=metadata.get('index'),
     )
     show_name_rows = [_vb.truncate_line(raw_show.upper(), _vb.model.cols, 'ellipsis')]
-    episode_ref = _media.format_episode_ref(metadata['parentIndex'], metadata['index'])
+    episode_ref = _media.format_episode_ref(metadata.get('parentIndex'), metadata['index'])
     plex_ep_title = (metadata.get('title') or '').strip()
     episode_title = tmdb_ep_title or plex_ep_title
     episode_detail = _media.strip_leading_article_if_needed(episode_title.upper(), _vb.model.cols, f'{episode_ref} ')

--- a/integrations/trakt.py
+++ b/integrations/trakt.py
@@ -329,18 +329,19 @@ def _ensure_authenticated() -> None:
 def _canonicalize_episode(
   show_data: dict[str, Any],
   ep_data: dict[str, Any],
-) -> tuple[str, int, int, str]:
+) -> tuple[str, int | None, int, str]:
   """Return (show_name, season, number, ep_title) canonicalized via TMDb if configured.
 
   Uses the show's TMDb ID for the canonical title and the episode's TVDb ID to
   resolve the correct TMDb season/episode numbers (important for anime, where
   Trakt uses TVDb single-season ordering). Falls back to Trakt data if TMDb is
-  unconfigured or any lookup fails.
+  unconfigured or any lookup fails. Season may be None when upstream metadata
+  lacks season info — callers pass it through to format_episode_ref unchanged.
   """
   import integrations.tmdb as _tmdb
 
   title = show_data['title']
-  season: int = ep_data['season']
+  season: int | None = ep_data.get('season')
   number: int = ep_data['number']
   ep_title: str = ep_data.get('title') or ''
 

--- a/integrations/vestaboard.py
+++ b/integrations/vestaboard.py
@@ -469,6 +469,20 @@ def display_len(text: str) -> int:
   return count
 
 
+# Trailing chars stripped before appending '...' on ellipsis truncation.
+# Includes separator punctuation (hyphen, colon, comma, semicolon, en/em dash),
+# quotes (a cut after a closing quote reads as '... '... '), and whitespace.
+# Sentence terminators (. ! ?) are intentionally excluded — stripping them
+# would mangle valid abbreviations like 'U.S.', and a finished sentence
+# followed by truncation is rare in this codebase's content formats.
+_ELLIPSIS_TRIM_CHARS = ' \t-:,;\'"–—'
+
+
+def trim_for_ellipsis(s: str) -> str:
+  """Strip trailing whitespace and separator punctuation before appending '...'."""
+  return s.rstrip(_ELLIPSIS_TRIM_CHARS)
+
+
 def truncate_line(
   text: str,
   max_cols: int,
@@ -503,7 +517,7 @@ def truncate_line(
     i += consumed
     count += tok_display
   if strategy == 'ellipsis':
-    return ''.join(result).rstrip() + '...'
+    return trim_for_ellipsis(''.join(result)) + '...'
   if strategy == 'hard' or last_word_end < 0:
     return ''.join(result)
   # If the loop exited right at a word boundary (next char is a space or end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.21.0"
+version = "1.21.1"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_media.py
+++ b/tests/core/test_media.py
@@ -17,6 +17,16 @@ def test_format_episode_ref_single_digit_each() -> None:
   assert media.format_episode_ref(1, 1) == 'S1E1'
 
 
+def test_format_episode_ref_missing_season_drops_prefix() -> None:
+  # When upstream metadata has no season info, render as E<n> only.
+  assert media.format_episode_ref(None, 5) == 'E5'
+
+
+def test_format_episode_ref_season_zero_renders_normally() -> None:
+  # Season 0 is the universal "Specials" designator — it's real data.
+  assert media.format_episode_ref(0, 5) == 'S0E5'
+
+
 # --- strip_leading_article ---
 
 
@@ -113,6 +123,17 @@ def test_wrap_title_overflows_two_rows_ellipsis_on_last_kept_row() -> None:
   assert result[0] == 'WORDS WORDS'
   assert result[1].endswith('...')
   assert len(result[1]) <= 15
+
+
+def test_wrap_title_overflow_strips_trailing_separator_before_ellipsis() -> None:
+  # When the final kept row's truncation point lands on a separator, the
+  # separator should be stripped so the ellipsis reads cleanly.
+  # cols=10, max_rows=1, so first row is truncated to 7 chars + '...'.
+  # 'FOO - BAR BAZ QUX' truncated to 7 chars = 'FOO - B' → strip trailing
+  # 'B' is kept, but try a phrase where the cut lands right after ' - '.
+  # 'FOO -  EXTRA STUFF' → first 7 chars = 'FOO -  ' → strip to 'FOO' → 'FOO...'
+  result = media.wrap_title_to_rows('FOO -  EXTRA STUFF MORE', 10, 1)
+  assert result == ['FOO...']
 
 
 def test_wrap_title_single_word_too_long_hard_cuts() -> None:

--- a/tests/core/test_plex.py
+++ b/tests/core/test_plex.py
@@ -760,6 +760,16 @@ def test_handle_webhook_episode_keeps_article_when_it_fits() -> None:
   assert mock_enqueue.call_args.kwargs['data']['variables']['episode_line'] == [['S2E1 A NEW HOPE']]
 
 
+def test_handle_webhook_episode_missing_parent_index_drops_season() -> None:
+  """When Plex omits parentIndex, episode_line drops 'S<n>' and shows only E<n>."""
+  payload = _episode_payload('media.play', title='Pilot')
+  del payload['Metadata']['parentIndex']
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(payload)
+    _fire_play_timer()
+  assert mock_enqueue.call_args.kwargs['data']['variables']['episode_line'] == [['E1 PILOT']]
+
+
 def test_handle_webhook_show_name_preserves_article() -> None:
   """Show names are NOT article-stripped — "THE BEAR" stays "THE BEAR"."""
   with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):

--- a/tests/core/test_trakt.py
+++ b/tests/core/test_trakt.py
@@ -957,6 +957,30 @@ def test_get_variables_calendar_skips_past_entries(
   assert result['episode_ref'] == [['S2E5']]
 
 
+def test_get_variables_calendar_missing_season_drops_prefix(
+  config_with_tokens: Path,
+) -> None:
+  """When upstream metadata has no season key, episode_ref becomes 'E<n>'."""
+  response = [
+    {
+      'first_aired': '2099-09-16T01:00:00.000Z',
+      'episode': {
+        'number': 5,
+        'title': 'The One With The Test',
+      },
+      'show': {'title': 'Great Show'},
+    }
+  ]
+  mock_response = MagicMock()
+  mock_response.status_code = 200
+  mock_response.json.return_value = response
+
+  with patch('integrations.trakt.fetch_with_retry', return_value=mock_response):
+    result = trakt.get_variables_calendar()
+
+  assert result['episode_ref'] == [['E5']]
+
+
 def test_get_variables_calendar_http_error_raised(
   config_with_tokens: Path,
 ) -> None:

--- a/tests/core/test_vestaboard.py
+++ b/tests/core/test_vestaboard.py
@@ -162,6 +162,45 @@ def test_truncate_ellipsis_strips_trailing_space() -> None:
   assert vb.truncate_line('HELLO WORLD', 9, 'ellipsis') == 'HELLO...'
 
 
+def test_truncate_ellipsis_strips_trailing_hyphen() -> None:
+  # 'FOO - BAR' truncated to 8 chars (5+3): hard-cut to 'FOO - ' → strip ' - '
+  assert vb.truncate_line('FOO - BAR EXTRA', 8, 'ellipsis') == 'FOO...'
+
+
+def test_truncate_ellipsis_strips_trailing_colon() -> None:
+  # 'FOO: BAR' truncated to 8 chars (5+3): hard-cut to 'FOO: ' → strip ': '
+  assert vb.truncate_line('FOO: BAR EXTRA', 8, 'ellipsis') == 'FOO...'
+
+
+def test_truncate_ellipsis_strips_trailing_comma() -> None:
+  assert vb.truncate_line('FOO, BAR EXTRA', 8, 'ellipsis') == 'FOO...'
+
+
+def test_truncate_ellipsis_strips_trailing_semicolon() -> None:
+  assert vb.truncate_line('FOO; BAR EXTRA', 8, 'ellipsis') == 'FOO...'
+
+
+def test_truncate_ellipsis_strips_trailing_em_dash() -> None:
+  # em-dash counts as one display char
+  assert vb.truncate_line('FOO—BAR EXTRA', 7, 'ellipsis') == 'FOO...'
+
+
+def test_truncate_ellipsis_strips_trailing_apostrophe() -> None:
+  # Cut lands after a closing apostrophe — strip it so '...' reads cleanly.
+  # target=9 (12-3): keeps "SAID 'HI'", trim drops trailing apostrophe.
+  assert vb.truncate_line("SAID 'HI' AGAIN", 12, 'ellipsis') == "SAID 'HI..."
+
+
+def test_truncate_ellipsis_strips_trailing_double_quote() -> None:
+  assert vb.truncate_line('SAID "HI" AGAIN', 12, 'ellipsis') == 'SAID "HI...'
+
+
+def test_truncate_ellipsis_preserves_period() -> None:
+  # Period is intentionally excluded from the trim set so abbreviations like
+  # 'U.S.' aren't mangled. Result keeps the period; user sees four dots total.
+  assert vb.truncate_line('U.S. ARMY GUYS', 7, 'ellipsis') == 'U.S....'
+
+
 def test_truncate_ellipsis_no_word_backtrack() -> None:
   # ellipsis must NOT backtrack to the word boundary — result is longer than word cut
   word_result = vb.truncate_line('HELLO WORLD', 10, 'word')

--- a/uv.lock
+++ b/uv.lock
@@ -314,7 +314,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.21.0"
+version = "1.21.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Closes #548
Closes #549

## Summary
- `format_episode_ref` now accepts `int | None` and renders just `E<n>` when season is missing. Season `0` stays as `S0E<n>` (Specials is real data; verified via Trakt/TMDb live API against Helluva Boss, which legitimately has a populated Season 0).
- Plex switches `metadata['parentIndex']` → `.get('parentIndex')` so missing season flows through cleanly.
- Trakt's `_canonicalize_episode` returns `int | None` for season; all three call sites pass it through unchanged.
- New `trim_for_ellipsis` helper in vestaboard.py strips trailing whitespace + separator punctuation (`- : , ; – —`), apostrophes, and straight double quotes before appending `...`. Sentence terminators (`. ! ?`) are intentionally preserved so abbreviations like `U.S.` aren't mangled.
- Wired into both ellipsis paths: `truncate_line` (vestaboard.py) and `wrap_title_to_rows` overflow tail (media.py).

## Test plan
- [x] `uv run pytest --cov=integrations --cov=. --cov-report=term-missing` — 1499 passed
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pyright` — 0 errors
- [x] `uv run bandit -c pyproject.toml -r .`
- [x] `uv run pip-audit` — no known vulnerabilities
- [x] New unit tests: `format_episode_ref` with `season=None` and `season=0`; ellipsis truncation against hyphen / colon / comma / semicolon / em-dash / apostrophe / double quote / period (preserved); plex webhook with missing `parentIndex` renders `E<n>`; trakt calendar with missing season key renders `E<n>`.

— *Claude Code*