### PR TITLE
fix(uptimerobot): use API logs for outage start, coarsen duration formatter (#551)

### DIFF
--- a/content/contrib/uptimerobot.md
+++ b/content/contrib/uptimerobot.md
@@ -51,20 +51,34 @@ within the free tier limit.
 ```
 [R] OUTAGE
 API.EXAMPLE.COM
-DOWN 14 MIN
+DOWN 15 MINUTES
 ```
 
 - Row 1: `[R]` red square + `OUTAGE`
-- Row 2: Friendly name of the monitor that has been down longest (truncated
-  with ellipsis if needed)
-- Row 3: Elapsed downtime since first detection
+- Row 2: Friendly name of the monitor whose outage started earliest
+  (truncated with ellipsis if needed)
+- Row 3: Elapsed downtime, sourced from the UptimeRobot API's latest down
+  log so it reflects the true outage start (survives restarts)
+
+Duration formatting uses a single unit, rounded down, with coarser steps as
+the outage ages — keeps the display readable and reduces flap updates:
+
+| Elapsed | Output |
+|---|---|
+| `< 60 s` | `0 MINUTES` |
+| `1–9 min` | `N MINUTE` / `N MINUTES` (per-minute) |
+| `10–59 min` | `N MINUTES` rounded down to nearest 5 |
+| `1–23 hr` | `N HOUR` / `N HOURS` |
+| `≥ 24 hr` | `N DAY` / `N DAYS` |
 
 When all monitors recover, the template is silently skipped and normal
 content resumes on the next cycle.
 
 ## API details
 
-**Endpoint:** `POST https://api.uptimerobot.com/v2/getMonitors`
+**Endpoint:** `POST https://api.uptimerobot.com/v2/getMonitors` with
+`logs=1, logs_limit=1` so the latest log entry per monitor (used to derive
+true outage start) is included.
 **Auth:** API key sent as a form parameter in the POST body.
 **Rate limit:** 10 req/min (free plan); 5000 req/min (Pro plan).
 

--- a/integrations/uptimerobot.py
+++ b/integrations/uptimerobot.py
@@ -38,30 +38,62 @@ _DOWN_STATUSES = frozenset({_STATUS_SEEMS_DOWN, _STATUS_DOWN})
 _CACHE_TTL = 30
 _cache: CacheEntry | None = None
 
-# Tracks when each monitor was first observed as down (monotonic clock).
-# Used to compute elapsed downtime for the display. Ephemeral — lost on
-# restart; duration resets to 0 on the next detection.
+# Fallback: tracks first-observation time (wall clock) for down monitors when
+# the API's log data is missing or unparseable. Normally the API provides the
+# actual outage start via logs[0].datetime, which survives restarts.
 _first_seen_down: dict[int, float] = {}
+
+# UptimeRobot log entry types.
+_LOG_TYPE_DOWN = 1
 
 
 def _fmt_duration(seconds: int) -> str:
-  """Format a duration in seconds for display (fits 15-col Note row)."""
+  """Format an outage duration for display.
+
+  Single-unit, rounded-down. Steps coarsen as duration grows to keep the
+  display readable and reduce flap updates on long outages:
+    < 60 s         → '0 MINUTES'
+    < 10 min       → 'N MINUTE' / 'N MINUTES' (per-minute)
+    < 60 min       → 'N MINUTES' rounded down to nearest 5
+    < 24 hr        → 'N HOUR' / 'N HOURS' (rounded down)
+    >= 24 hr       → 'N DAY' / 'N DAYS' (rounded down)
+  Longest output 'N MINUTES' fits 15-col Note with 'DOWN ' prefix.
+  """
   if seconds < 0:
     seconds = 0
   if seconds < 60:
-    return f'{seconds} SEC'
-  if seconds < 3600:
-    return f'{seconds // 60} MIN'
-  hours = seconds // 3600
+    return '0 MINUTES'
+  mins = seconds // 60
+  if mins < 10:
+    return '1 MINUTE' if mins == 1 else f'{mins} MINUTES'
+  if mins < 60:
+    return f'{(mins // 5) * 5} MINUTES'
+  hours = mins // 60
   if hours < 24:
-    mins = (seconds % 3600) // 60
-    return f'{hours}H {mins}M' if mins else f'{hours} HR'
+    return '1 HOUR' if hours == 1 else f'{hours} HOURS'
   days = hours // 24
-  return f'{days} DAY' if days == 1 else f'{days} DAYS'
+  return '1 DAY' if days == 1 else f'{days} DAYS'
+
+
+def _outage_start(monitor: dict[str, Any], mid: int, now: float) -> float:
+  """Return the Unix timestamp when this monitor's current outage began.
+
+  Prefers the most recent type=1 log entry's `datetime` field (true start,
+  survives process restarts). Falls back to first-observation time when the
+  API omits logs or the entry is unparseable.
+  """
+  logs = monitor.get('logs') or []
+  if logs and logs[0].get('type') == _LOG_TYPE_DOWN:
+    dt = logs[0].get('datetime')
+    if isinstance(dt, (int, float)) and dt > 0:
+      return float(dt)
+  if mid not in _first_seen_down:
+    _first_seen_down[mid] = now
+  return _first_seen_down[mid]
 
 
 def _fetch_monitors() -> list[dict[str, Any]]:
-  """Fetch all monitors from the UptimeRobot API.
+  """Fetch all monitors (with latest log) from the UptimeRobot API.
 
   Returns the list of monitor dicts from the response. Raises
   IntegrationDataUnavailableError on API errors.
@@ -74,7 +106,12 @@ def _fetch_monitors() -> list[dict[str, Any]]:
     r = fetch_with_retry(
       'POST',
       _API_URL,
-      data={'api_key': api_key, 'format': 'json'},
+      data={
+        'api_key': api_key,
+        'format': 'json',
+        'logs': '1',
+        'logs_limit': '1',
+      },
       timeout=10,
     )
     r.raise_for_status()
@@ -103,33 +140,32 @@ def get_variables() -> dict[str, list[list[str]]]:
     return _cache.value
 
   monitors = _fetch_monitors()
+  now = time.time()
 
-  # Find monitors in down state.
-  current_down: dict[int, str] = {}
+  # Find monitors in down state and resolve outage start for each.
+  down_starts: dict[int, float] = {}
+  down_names: dict[int, str] = {}
   for m in monitors:
-    status = m.get('status', 0)
-    if status in _DOWN_STATUSES:
-      current_down[int(m['id'])] = str(m.get('friendly_name', '')).strip()
+    if m.get('status', 0) not in _DOWN_STATUSES:
+      continue
+    mid = int(m['id'])
+    down_names[mid] = str(m.get('friendly_name', '')).strip()
+    down_starts[mid] = _outage_start(m, mid, now)
 
-  if not current_down:
-    # All monitors up — clean up tracking state.
+  if not down_names:
+    # All monitors up — clean up fallback tracking state.
     _first_seen_down.clear()
     raise IntegrationDataUnavailableError('UptimeRobot: all monitors up', expected=True)
 
-  # Track first-seen time for newly down monitors.
-  now = time.monotonic()
-  for mid in current_down:
-    if mid not in _first_seen_down:
-      _first_seen_down[mid] = now
-  # Clean up monitors that recovered.
+  # Clean up fallback entries for monitors that recovered.
   for mid in list(_first_seen_down):
-    if mid not in current_down:
+    if mid not in down_names:
       del _first_seen_down[mid]
 
-  # Show the monitor that has been down the longest.
-  longest_id = min(_first_seen_down, key=lambda k: _first_seen_down[k])
-  display_name = _vb.truncate_line(current_down[longest_id].upper(), _vb.model.cols, 'ellipsis')
-  duration = int(now - _first_seen_down[longest_id])
+  # Show the monitor whose outage started earliest.
+  longest_id = min(down_starts, key=lambda k: down_starts[k])
+  display_name = _vb.truncate_line(down_names[longest_id].upper(), _vb.model.cols, 'ellipsis')
+  duration = int(now - down_starts[longest_id])
 
   result: dict[str, list[list[str]]] = {
     'monitor': [[display_name]],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.21.1"
+version = "1.21.2"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/test_uptimerobot.py
+++ b/tests/test_uptimerobot.py
@@ -28,13 +28,20 @@ def _monitor(
   id: int = 1,
   friendly_name: str = 'My API',
   status: int = 2,
+  down_seconds_ago: int | None = None,
+  logs: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-  return {
+  m: dict[str, Any] = {
     'id': id,
     'friendly_name': friendly_name,
     'url': 'https://api.example.com',
     'status': status,
   }
+  if logs is not None:
+    m['logs'] = logs
+  elif down_seconds_ago is not None:
+    m['logs'] = [{'type': 1, 'datetime': int(time.time()) - down_seconds_ago, 'duration': 0}]
+  return m
 
 
 @pytest.fixture(autouse=True)
@@ -66,8 +73,8 @@ def test_all_up_raises_unavailable() -> None:
       uptimerobot.get_variables()
 
 
-def test_all_up_clears_first_seen_state() -> None:
-  uptimerobot._first_seen_down[1] = time.monotonic() - 600
+def test_all_up_clears_fallback_state() -> None:
+  uptimerobot._first_seen_down[1] = time.time() - 600
   resp = _mock_response(_api_response([_monitor(status=2)]))
   with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
     with pytest.raises(IntegrationDataUnavailableError):
@@ -95,40 +102,95 @@ def test_empty_monitors_raises_unavailable() -> None:
 
 
 def test_down_monitor_returns_variables() -> None:
-  resp = _mock_response(_api_response([_monitor(id=1, friendly_name='Prod API', status=9)]))
+  resp = _mock_response(_api_response([_monitor(id=1, friendly_name='Prod API', status=9, down_seconds_ago=120)]))
   with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
     result = uptimerobot.get_variables()
   assert result['monitor'] == [['PROD API']]
-  assert result['detail'][0][0].startswith('DOWN ')
+  assert result['detail'] == [['DOWN 2 MINUTES']]
 
 
 def test_seems_down_treated_as_down() -> None:
-  resp = _mock_response(_api_response([_monitor(id=1, friendly_name='Staging', status=8)]))
+  resp = _mock_response(_api_response([_monitor(id=1, friendly_name='Staging', status=8, down_seconds_ago=60)]))
   with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
     result = uptimerobot.get_variables()
   assert result['monitor'] == [['STAGING']]
 
 
 def test_monitor_name_uppercased() -> None:
-  resp = _mock_response(_api_response([_monitor(friendly_name='my api', status=9)]))
+  resp = _mock_response(_api_response([_monitor(friendly_name='my api', status=9, down_seconds_ago=60)]))
   with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
     result = uptimerobot.get_variables()
   assert result['monitor'] == [['MY API']]
 
 
-def test_down_monitor_tracks_first_seen() -> None:
-  resp = _mock_response(_api_response([_monitor(id=42, status=9)]))
-  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
-    uptimerobot.get_variables()
-  assert 42 in uptimerobot._first_seen_down
-
-
-def test_duration_increases_on_subsequent_calls() -> None:
-  uptimerobot._first_seen_down[1] = time.monotonic() - 900  # 15 min ago
-  resp = _mock_response(_api_response([_monitor(id=1, status=9)]))
+def test_duration_uses_api_log_datetime() -> None:
+  """First detection should reflect actual outage start, not observation time."""
+  resp = _mock_response(_api_response([_monitor(id=1, status=9, down_seconds_ago=900)]))
   with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
     result = uptimerobot.get_variables()
-  assert result['detail'] == [['DOWN 15 MIN']]
+  # 15 minutes — rounded-to-5 tier
+  assert result['detail'] == [['DOWN 15 MINUTES']]
+
+
+def test_duration_survives_restart() -> None:
+  """Even with no prior observation state, the API log gives true elapsed time."""
+  assert len(uptimerobot._first_seen_down) == 0
+  resp = _mock_response(_api_response([_monitor(id=1, status=9, down_seconds_ago=3600)]))
+  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
+    result = uptimerobot.get_variables()
+  assert result['detail'] == [['DOWN 1 HOUR']]
+  # Fallback dict is not used when API logs are present.
+  assert len(uptimerobot._first_seen_down) == 0
+
+
+# ---------------------------------------------------------------------------
+# Fallback: API logs missing or unparseable
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_when_logs_missing() -> None:
+  """No `logs` field → falls back to first-observation time."""
+  resp = _mock_response(_api_response([_monitor(id=1, status=9, logs=None)]))
+  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
+    result = uptimerobot.get_variables()
+  assert 1 in uptimerobot._first_seen_down
+  assert result['detail'] == [['DOWN 0 MINUTES']]
+
+
+def test_fallback_when_logs_empty() -> None:
+  resp = _mock_response(_api_response([_monitor(id=1, status=9, logs=[])]))
+  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
+    result = uptimerobot.get_variables()
+  assert 1 in uptimerobot._first_seen_down
+  assert result['detail'] == [['DOWN 0 MINUTES']]
+
+
+def test_fallback_when_top_log_is_up() -> None:
+  """Most recent log is type=2 (up); fall back rather than picking older down log."""
+  resp = _mock_response(
+    _api_response(
+      [
+        _monitor(
+          id=1,
+          status=9,
+          logs=[
+            {'type': 2, 'datetime': int(time.time()) - 100, 'duration': 0},
+            {'type': 1, 'datetime': int(time.time()) - 9999, 'duration': 100},
+          ],
+        )
+      ]
+    )
+  )
+  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
+    uptimerobot.get_variables()
+  assert 1 in uptimerobot._first_seen_down
+
+
+def test_fallback_when_log_datetime_invalid() -> None:
+  resp = _mock_response(_api_response([_monitor(id=1, status=9, logs=[{'type': 1, 'datetime': 0, 'duration': 0}])]))
+  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
+    uptimerobot.get_variables()
+  assert 1 in uptimerobot._first_seen_down
 
 
 # ---------------------------------------------------------------------------
@@ -136,38 +198,34 @@ def test_duration_increases_on_subsequent_calls() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_shows_longest_down_monitor() -> None:
-  now = time.monotonic()
-  uptimerobot._first_seen_down[1] = now - 600  # 10 min ago
-  uptimerobot._first_seen_down[2] = now - 60  # 1 min ago
+def test_shows_earliest_outage_monitor() -> None:
   resp = _mock_response(
     _api_response(
       [
-        _monitor(id=1, friendly_name='Old Down', status=9),
-        _monitor(id=2, friendly_name='New Down', status=9),
+        _monitor(id=1, friendly_name='Old Down', status=9, down_seconds_ago=600),
+        _monitor(id=2, friendly_name='New Down', status=9, down_seconds_ago=60),
       ]
     )
   )
   with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
     result = uptimerobot.get_variables()
   assert result['monitor'] == [['OLD DOWN']]
-  assert result['detail'] == [['DOWN 10 MIN']]
+  assert result['detail'] == [['DOWN 10 MINUTES']]
 
 
-def test_recovered_monitor_removed_from_tracking() -> None:
-  uptimerobot._first_seen_down[1] = time.monotonic() - 300
-  uptimerobot._first_seen_down[2] = time.monotonic() - 60
+def test_recovered_monitor_removed_from_fallback() -> None:
+  uptimerobot._first_seen_down[1] = time.time() - 300
+  uptimerobot._first_seen_down[2] = time.time() - 60
   resp = _mock_response(
     _api_response(
       [
-        _monitor(id=1, friendly_name='Still Down', status=9),
+        _monitor(id=1, friendly_name='Still Down', status=9, down_seconds_ago=300),
         _monitor(id=2, friendly_name='Recovered', status=2),
       ]
     )
   )
   with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp):
     uptimerobot.get_variables()
-  assert 1 in uptimerobot._first_seen_down
   assert 2 not in uptimerobot._first_seen_down
 
 
@@ -192,6 +250,17 @@ def test_api_stat_fail_raises_unavailable() -> None:
       uptimerobot.get_variables()
 
 
+def test_fetch_requests_logs() -> None:
+  """The API request includes `logs=1, logs_limit=1` so the latest log is returned."""
+  resp = _mock_response(_api_response([]))
+  with patch('integrations.uptimerobot.fetch_with_retry', return_value=resp) as mock_fetch:
+    with pytest.raises(IntegrationDataUnavailableError):
+      uptimerobot.get_variables()
+  kwargs = mock_fetch.call_args.kwargs
+  assert kwargs['data']['logs'] == '1'
+  assert kwargs['data']['logs_limit'] == '1'
+
+
 # ---------------------------------------------------------------------------
 # Cache
 # ---------------------------------------------------------------------------
@@ -203,7 +272,7 @@ def test_cache_hit_avoids_fetch() -> None:
   uptimerobot._cache = CacheEntry(
     {
       'monitor': [['CACHED']],
-      'detail': [['DOWN 5 MIN']],
+      'detail': [['DOWN 5 MINUTES']],
     }
   )
   with patch('integrations.uptimerobot.fetch_with_retry') as mock_fetch:
@@ -220,20 +289,38 @@ def test_cache_hit_avoids_fetch() -> None:
 @pytest.mark.parametrize(
   'seconds,expected',
   [
-    (0, '0 SEC'),
-    (1, '1 SEC'),
-    (59, '59 SEC'),
-    (60, '1 MIN'),
-    (840, '14 MIN'),
-    (3599, '59 MIN'),
-    (3600, '1 HR'),
-    (3660, '1H 1M'),
-    (7200, '2 HR'),
-    (7380, '2H 3M'),
+    # Sub-minute floors to 0 MINUTES
+    (-5, '0 MINUTES'),
+    (0, '0 MINUTES'),
+    (1, '0 MINUTES'),
+    (59, '0 MINUTES'),
+    # Per-minute tier (1-9 min) with singular at 1
+    (60, '1 MINUTE'),
+    (119, '1 MINUTE'),
+    (120, '2 MINUTES'),
+    (540, '9 MINUTES'),
+    (599, '9 MINUTES'),
+    # 5-minute rounding tier (10-59 min)
+    (600, '10 MINUTES'),
+    (840, '10 MINUTES'),
+    (899, '10 MINUTES'),
+    (900, '15 MINUTES'),
+    (3299, '50 MINUTES'),
+    (3300, '55 MINUTES'),
+    (3599, '55 MINUTES'),
+    # Hour tier (1-23 hr) with singular at 1
+    (3600, '1 HOUR'),
+    (5400, '1 HOUR'),
+    (6600, '1 HOUR'),
+    (7199, '1 HOUR'),
+    (7200, '2 HOURS'),
+    (82800, '23 HOURS'),
+    (86399, '23 HOURS'),
+    # Day tier with singular at 1
     (86400, '1 DAY'),
+    (129600, '1 DAY'),
+    (172799, '1 DAY'),
     (172800, '2 DAYS'),
-    (90000, '1 DAY'),
-    (-5, '0 SEC'),
   ],
 )
 def test_fmt_duration(seconds: int, expected: str) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -314,7 +314,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.21.1"
+version = "1.21.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Closes #551.

## Summary

- Use the UptimeRobot API's `logs[0].datetime` to derive the true outage start, eliminating the `DOWN 0 SEC` first-detection bug and making duration robust across process restarts.
- Replace `_fmt_duration` with a single-unit, rounded-down formatter that coarsens as the outage ages (`0 MINUTES` → per-minute → 5-min rounding → hours → days, with proper singular/plural).
- Drop sub-minute precision entirely; minimum is now `0 MINUTES`.
- Fallback to first-observation tracking only when the API omits or malforms the log entry.

## Verification

Verified end-to-end against a real outage on the live `e-note-ion` monitor:

```
Live result:
 monitor: E-NOTE-ION
 detail:  DOWN 20 MINUTES
```

Previously this would have shown `DOWN 0 SEC` on the first poll.

## Test plan

- [x] Unit tests pass (`uv run pytest tests/test_uptimerobot.py`) — 46 cases, 100% coverage
- [x] Full test suite green (1517 passed)
- [x] Ruff, format, pyright, bandit, pip-audit, JSON-format all clean
- [x] Live integration test against real API passes
- [x] Live end-to-end check against active outage renders correct duration
- [x] Coverage shows `integrations/uptimerobot.py` at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)