### PR TITLE
fix(trakt,plex): canonicalize anime specials (S0) and Plex broadcast seasons via TMDb

### DIFF
--- a/integrations/plex.py
+++ b/integrations/plex.py
@@ -106,57 +106,67 @@ def _canonicalize_plex_title(
   media_type: str,
   season: int | None = None,
   episode: int | None = None,
-) -> tuple[str, str | None]:
-  """Return (canonical_title, tmdb_episode_title_or_None) from TMDb.
+) -> tuple[str, str | None, int | None, int | None]:
+  """Return (canonical_title, tmdb_episode_title, canonical_season, canonical_episode).
 
   For episodes, tries in order:
     1. tvdb:// guid (episode-level TVDb ID)
     2. imdb:// guid (episode-level IMDb ID)
     3. TMDb title search + S/E lookup (when season and episode are provided)
 
-  Returns both the canonical show name and the TMDb episode title when
-  resolved. The episode title is None for movies and when all lookups fail.
+  When TMDb resolves the episode via tvdb:// or imdb://, the returned season
+  and episode reflect TMDb's broadcast-season numbering (via the type-6
+  episode group when available, falling back to TMDb base data). This corrects
+  flat-numbered anime libraries (e.g. Re:Zero on TVDb) to canonical broadcast
+  seasons. Callers should fall back to Plex's parentIndex/index when the
+  returned season/episode are None.
 
-  For movies, the tmdb:// entry is the TMDb movie ID.
-  Episode title is always None for movies.
+  For movies, the tmdb:// entry is the TMDb movie ID. Episode title and
+  canonical S/E are always None for movies.
 
-  Falls back to (raw_title, None) when TMDb is unconfigured, the Guid array
-  has no usable entry, or all lookups fail.
+  Falls back to (raw_title, None, None, None) when TMDb is unconfigured, the
+  Guid array has no usable entry, or all lookups fail.
 
   media_type must be 'episode' or 'movie'.
   """
   import integrations.tmdb as _tmdb
 
   if not _tmdb.is_configured():
-    return raw_title, None
+    return raw_title, None, None, None
 
   if media_type == 'episode':
     tvdb_id = _parse_guid_id(guids, 'tvdb://')
     if tvdb_id is not None:
       ep_result = _tmdb.find_episode_by_tvdb_id(tvdb_id)
       if ep_result is not None:
-        _, _, ep_title, show_id, _ = ep_result
+        res_season, res_episode, ep_title, show_id, tmdb_ep_id = ep_result
+        group_pos = _tmdb.get_episode_group_position(show_id, tmdb_ep_id)
+        if group_pos:
+          res_season, res_episode = group_pos
         canonical = _tmdb.get_show_title(show_id)
         if canonical:
-          logger.debug('plex: tmdb canonical %r -> %r', raw_title, canonical)
+          logger.debug('plex: tmdb canonical %r -> %r S%dE%d', raw_title, canonical, res_season, res_episode)
         else:
           logger.debug('plex: tmdb show lookup failed for id=%d, using raw title %r', show_id, raw_title)
-        return canonical if canonical else raw_title, ep_title or None
+        return canonical if canonical else raw_title, ep_title or None, res_season, res_episode
       logger.debug('plex: tvdb ep lookup failed for id=%d, using raw title %r', tvdb_id, raw_title)
-      return raw_title, None
+      return raw_title, None, None, None
     # No tvdb:// guid — fall back to imdb://
     logger.debug('plex: no tvdb:// guid for episode %r, trying imdb://', raw_title)
     imdb_id = _parse_guid_id_str(guids, 'imdb://')
     if imdb_id:
       ep_result = _tmdb.find_episode_by_imdb_id(imdb_id)
       if ep_result is not None:
-        _, _, ep_title, show_id, _ = ep_result
+        res_season, res_episode, ep_title, show_id, tmdb_ep_id = ep_result
+        group_pos = _tmdb.get_episode_group_position(show_id, tmdb_ep_id)
+        if group_pos:
+          res_season, res_episode = group_pos
         canonical = _tmdb.get_show_title(show_id)
         if canonical:
-          logger.debug('plex: tmdb canonical (via imdb) %r -> %r', raw_title, canonical)
+          logger.debug('plex: tmdb canonical (via imdb) %r -> %r S%dE%d', raw_title, canonical, res_season, res_episode)
         else:
           logger.debug('plex: tmdb imdb lookup show %d title failed, using raw title %r', show_id, raw_title)
-        return canonical if canonical else raw_title, ep_title or None
+        return canonical if canonical else raw_title, ep_title or None, res_season, res_episode
       logger.debug('plex: imdb ep lookup failed for %r, using raw title %r', imdb_id, raw_title)
     else:
       logger.debug('plex: no imdb:// guid for episode %r, trying title search', raw_title)
@@ -186,7 +196,7 @@ def _canonicalize_plex_title(
             episode,
             ep_title,
           )
-          return canonical if canonical else raw_title, ep_title or None
+          return canonical if canonical else raw_title, ep_title or None, season, episode
         # Base lookup failed (show uses flat/different season numbering) — try episode group.
         ep_result_grp = _tmdb.find_episode_in_group(show_id, season, episode)
         if ep_result_grp is not None:
@@ -200,21 +210,21 @@ def _canonicalize_plex_title(
             episode,
             ep_title,
           )
-          return canonical if canonical else raw_title, ep_title or None
+          return canonical if canonical else raw_title, ep_title or None, season, episode
       logger.debug('plex: title search for %r found nothing', raw_title)
-    return raw_title, None
+    return raw_title, None, None, None
 
   else:  # movie
     tmdb_id = _parse_guid_id(guids, 'tmdb://')
     if tmdb_id is None:
       logger.debug('plex: no tmdb:// guid for %r, using raw title', raw_title)
-      return raw_title, None
+      return raw_title, None, None, None
     canonical = _tmdb.get_movie_title(tmdb_id)
     if canonical:
       logger.debug('plex: tmdb canonical %r -> %r', raw_title, canonical)
     else:
       logger.debug('plex: tmdb lookup failed, using raw title %r', raw_title)
-    return canonical if canonical else raw_title, None
+    return canonical if canonical else raw_title, None, None, None
 
 
 def _load_template_config(template_name: str) -> dict[str, Any]:
@@ -518,7 +528,7 @@ def _build_metadata(
       metadata.get('guid'),
       metadata.get('grandparentGuid'),
     )
-    raw_show, tmdb_ep_title = _canonicalize_plex_title(
+    raw_show, tmdb_ep_title, canonical_season, canonical_episode = _canonicalize_plex_title(
       metadata['grandparentTitle'],
       guids,
       'episode',
@@ -526,14 +536,23 @@ def _build_metadata(
       episode=metadata.get('index'),
     )
     show_name_rows = [_vb.truncate_line(raw_show.upper(), _vb.model.cols, 'ellipsis')]
-    episode_ref = _media.format_episode_ref(metadata.get('parentIndex'), metadata['index'])
+    # Prefer TMDb's broadcast-season numbering when canonicalization succeeded;
+    # otherwise fall back to Plex's parentIndex/index for non-anime libraries
+    # and the path where TMDb returned no usable mapping.
+    if canonical_episode is not None:
+      ref_season = canonical_season
+      ref_episode = canonical_episode
+    else:
+      ref_season = metadata.get('parentIndex')
+      ref_episode = metadata['index']
+    episode_ref = _media.format_episode_ref(ref_season, ref_episode)
     plex_ep_title = (metadata.get('title') or '').strip()
     episode_title = tmdb_ep_title or plex_ep_title
     episode_detail = _media.strip_leading_article_if_needed(episode_title.upper(), _vb.model.cols, f'{episode_ref} ')
     episode_line = f'{episode_ref} {episode_detail}'.strip()
   elif media_type == 'movie' and metadata:
     guids = metadata.get('Guid') or []
-    raw_movie, _ = _canonicalize_plex_title(metadata['title'], guids, 'movie')
+    raw_movie, _, _, _ = _canonicalize_plex_title(metadata['title'], guids, 'movie')
     show_name_rows = _media.wrap_title_to_rows(raw_movie.upper(), _vb.model.cols, 2)
     episode_line = ''
   else:

--- a/integrations/trakt.py
+++ b/integrations/trakt.py
@@ -458,7 +458,13 @@ def get_variables_calendar() -> dict[str, list[list[str]]]:
   if not future_entries:
     raise IntegrationDataUnavailableError('No upcoming episodes in calendar window', expected=True)
 
-  future_entries.sort(key=lambda e: e['first_aired'])
+  # Tiebreaker: when first_aired matches, prefer canonical (season != 0) over
+  # Season 0 specials. Anime shows like Re:Zero list parallel "Break Time"
+  # companion shorts in S0 with the same air date as the canonical broadcast
+  # episode; the specials carry no tvdb/imdb IDs and can't be canonicalized,
+  # so they'd render as 'S0Ex' if they win the sort. Specials still surface
+  # when they're the only entry in the window.
+  future_entries.sort(key=lambda e: (e['first_aired'], e['episode'].get('season') == 0))
   entry = future_entries[0]
 
   ep = entry['episode']
@@ -644,6 +650,18 @@ def get_variables_next_up() -> dict[str, list[list[str]]]:
 
     ep = r2.json().get('next_episode')
     if ep is not None:
+      # Skip Season 0 specials that lack tvdb/imdb episode IDs needed for
+      # canonicalization. Without them the special would render as raw 'S0Ex'.
+      # See _canonicalize_episode for the lookup chain; this mirrors the
+      # calendar's preference for canonical episodes over specials.
+      if ep.get('season') == 0:
+        ep_ids = ep.get('ids') or {}
+        if not ep_ids.get('tvdb') and not ep_ids.get('imdb'):
+          logger.debug(
+            'Trakt: next-up for %s is un-canonicalizable S0 special — skipping',
+            entry['show']['title'],
+          )
+          continue
       # Skip episodes that haven't aired yet — the user can't watch them.
       first_aired = ep.get('first_aired')
       if not first_aired:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.21.2"
+version = "1.21.3"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_plex.py
+++ b/tests/core/test_plex.py
@@ -1039,18 +1039,19 @@ def _episode_payload_with_imdb_guid(imdb_id: str, show: str = 'Jujutsu Kaisen') 
 
 
 def test_handle_webhook_episode_uses_tmdb_episode_title(monkeypatch: pytest.MonkeyPatch) -> None:
-  """TMDb episode title is used instead of Plex's native episode title."""
+  """TMDb episode title and canonical S/E replace Plex's native metadata."""
   monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: (1, 51, 'Perfect Preparation', 95479, 6827061))
+  # No type-6 episode group — fall back to TMDb base S/E (1, 51).
+  monkeypatch.setattr(_tmdb, 'get_episode_group_position', lambda show_id, ep_id: None)
   monkeypatch.setattr(_tmdb, 'get_show_title', lambda show_id: 'Jujutsu Kaisen')
 
   with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
     _plex.handle_webhook(_episode_payload_with_guid(tvdb_id=11547510, show='JUJUTSU KAISEN'))
     _fire_play_timer()
 
-  # S/E ref is always from Plex metadata (parentIndex=1, index=3 in the fixture);
-  # only the episode title comes from TMDb.
-  assert mock_enqueue.call_args.kwargs['data']['variables']['episode_line'] == [['S1E3 PERFECT PREPARATION']]
+  # S/E now comes from TMDb (canonical), not Plex's parentIndex/index.
+  assert mock_enqueue.call_args.kwargs['data']['variables']['episode_line'] == [['S1E51 PERFECT PREPARATION']]
 
 
 def test_handle_webhook_episode_falls_back_to_plex_title_when_no_tmdb_ep_title(
@@ -1060,6 +1061,7 @@ def test_handle_webhook_episode_falls_back_to_plex_title_when_no_tmdb_ep_title(
   monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   # empty string title from TMDb (episode exists but title not yet filled in)
   monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: (1, 3, '', 40290, 99001))
+  monkeypatch.setattr(_tmdb, 'get_episode_group_position', lambda show_id, ep_id: None)
   monkeypatch.setattr(_tmdb, 'get_show_title', lambda show_id: 'MasterChef')
 
   with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
@@ -1071,7 +1073,7 @@ def test_handle_webhook_episode_falls_back_to_plex_title_when_no_tmdb_ep_title(
 
 
 def test_handle_webhook_episode_uses_imdb_fallback_when_no_tvdb_guid(monkeypatch: pytest.MonkeyPatch) -> None:
-  """When no tvdb:// guid is present, imdb:// is tried and the TMDb title is used."""
+  """When no tvdb:// guid is present, imdb:// is tried and TMDb canonical S/E is used."""
   monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
   imdb_calls: list[str] = []
 
@@ -1081,6 +1083,7 @@ def test_handle_webhook_episode_uses_imdb_fallback_when_no_tvdb_guid(monkeypatch
 
   monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: None)
   monkeypatch.setattr(_tmdb, 'find_episode_by_imdb_id', _mock_find_imdb)
+  monkeypatch.setattr(_tmdb, 'get_episode_group_position', lambda show_id, ep_id: None)
   monkeypatch.setattr(_tmdb, 'get_show_title', lambda show_id: 'Jujutsu Kaisen')
 
   with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
@@ -1089,7 +1092,8 @@ def test_handle_webhook_episode_uses_imdb_fallback_when_no_tvdb_guid(monkeypatch
 
   assert imdb_calls == ['tt39370459']
   assert mock_enqueue.call_args.kwargs['data']['variables']['show_name'] == [['JUJUTSU KAISEN']]
-  assert mock_enqueue.call_args.kwargs['data']['variables']['episode_line'] == [['S3E4 PERFECT PREPARATION']]
+  # S/E from TMDb canonical (1, 51), not Plex parentIndex=3/index=4.
+  assert mock_enqueue.call_args.kwargs['data']['variables']['episode_line'] == [['S1E51 PERFECT PREPARATION']]
 
 
 def test_handle_webhook_episode_falls_back_when_no_tvdb_and_no_imdb_guid(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1184,3 +1188,63 @@ def test_handle_webhook_episode_uses_episode_group_fallback_when_base_lookup_fai
   # "A" leading article stripped; "an" preserved mid-title
   ep_line = mock_enqueue.call_args.kwargs['data']['variables']['episode_line']
   assert ep_line == [['S2E7 GRAVESTONE AND AN AUTUMNAL JOURNEY']]
+
+
+def test_handle_webhook_episode_tvdb_uses_episode_group_for_broadcast_season(
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  """For anime with TVDb flat numbering, TMDb type-6 group remaps S/E to broadcast season.
+
+  Mirrors the Re:Zero scenario: Plex sends parentIndex=1, index=73 (flat TVDb
+  numbering); TMDb's base data also flat-files the episode at S1E73; the
+  type-6 episode group splits it into Season 4 episode 7 of the real
+  broadcast. Display must render the broadcast S/E, not the flat one.
+  """
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_tmdb, 'find_episode_by_tvdb_id', lambda tvdb_id: (1, 73, 'Episode 73', 65942, 7130064))
+  monkeypatch.setattr(_tmdb, 'get_episode_group_position', lambda show_id, ep_id: (4, 7))
+  monkeypatch.setattr(_tmdb, 'get_show_title', lambda show_id: 'Re:ZERO')
+
+  payload = {
+    'event': 'media.play',
+    'Metadata': {
+      'type': 'episode',
+      'grandparentTitle': 'Re:ZERO',
+      'parentIndex': 1,
+      'index': 73,
+      'title': 'Episode 73',
+      'Guid': [{'id': 'tvdb://11714309'}],
+    },
+  }
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(payload)
+    _fire_play_timer()
+
+  ep_line = mock_enqueue.call_args.kwargs['data']['variables']['episode_line']
+  assert ep_line == [['S4E7 EPISODE 73']]
+
+
+def test_handle_webhook_episode_no_guid_no_tmdb_resolution_keeps_plex_se(
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  """When TMDb resolves nothing, fall back to Plex's parentIndex/index for S/E."""
+  monkeypatch.setattr(_config_mod, '_config', {'tmdb': {'api_read_access_token': 'tok'}})
+  monkeypatch.setattr(_tmdb, 'find_episode_by_imdb_id', lambda imdb_id: None)
+  monkeypatch.setattr(_tmdb, 'search_show_by_title', lambda title: None)
+
+  payload = {
+    'event': 'media.play',
+    'Metadata': {
+      'type': 'episode',
+      'grandparentTitle': 'Some Show',
+      'parentIndex': 2,
+      'index': 5,
+      'title': 'Pilot',
+      'Guid': [{'id': 'tmdb://12345'}],  # only tmdb://, no tvdb:// or imdb://
+    },
+  }
+  with patch('scheduler.enqueue') as mock_enqueue, patch('scheduler.fire_hold_interrupt'):
+    _plex.handle_webhook(payload)
+    _fire_play_timer()
+
+  assert mock_enqueue.call_args.kwargs['data']['variables']['episode_line'] == [['S2E5 PILOT']]

--- a/tests/core/test_trakt.py
+++ b/tests/core/test_trakt.py
@@ -957,6 +957,77 @@ def test_get_variables_calendar_skips_past_entries(
   assert result['episode_ref'] == [['S2E5']]
 
 
+def test_get_variables_calendar_prefers_canonical_over_special_on_tie(
+  config_with_tokens: Path,
+) -> None:
+  """When two entries share first_aired, the canonical (season != 0) wins.
+
+  Reproduces the Re:Zero scenario: Trakt's calendar returns both an S0 special
+  and the canonical S1 episode for the same air date. The special carries no
+  tvdb/imdb episode IDs and would render as 'S0Ex', so the tiebreaker must
+  prefer the canonical entry.
+  """
+  response = [
+    {
+      'first_aired': '2099-09-16T01:00:00.000Z',
+      'episode': {
+        'season': 0,
+        'number': 73,
+        'title': 'Break Time',
+        'ids': {'tvdb': None, 'imdb': None, 'tmdb': 7284163},
+      },
+      'show': {'title': 'Re:Zero'},
+    },
+    {
+      'first_aired': '2099-09-16T01:00:00.000Z',
+      'episode': {
+        'season': 1,
+        'number': 73,
+        'title': 'Episode 73',
+        'ids': {'tvdb': 11714309, 'imdb': 'tt41799460', 'tmdb': 7130064},
+      },
+      'show': {'title': 'Re:Zero'},
+    },
+  ]
+  mock_response = MagicMock()
+  mock_response.status_code = 200
+  mock_response.json.return_value = response
+
+  with patch('integrations.trakt.fetch_with_retry', return_value=mock_response):
+    result = trakt.get_variables_calendar()
+
+  # Canonical S1 wins regardless of Trakt's array order; canonicalization is
+  # untouched by TMDb mocks in this test, so episode_ref stays at S1E73.
+  assert result['episode_ref'] == [['S1E73']]
+  assert result['episode_title'] == [['EPISODE 73']]
+
+
+def test_get_variables_calendar_falls_through_to_special_when_only_entry(
+  config_with_tokens: Path,
+) -> None:
+  """If only an S0 special is in the window, it still surfaces (no regression)."""
+  response = [
+    {
+      'first_aired': '2099-09-16T01:00:00.000Z',
+      'episode': {
+        'season': 0,
+        'number': 12,
+        'title': 'Halloween Special',
+        'ids': {'tvdb': None, 'imdb': None},
+      },
+      'show': {'title': 'Specials Only'},
+    },
+  ]
+  mock_response = MagicMock()
+  mock_response.status_code = 200
+  mock_response.json.return_value = response
+
+  with patch('integrations.trakt.fetch_with_retry', return_value=mock_response):
+    result = trakt.get_variables_calendar()
+
+  assert result['episode_ref'] == [['S0E12']]
+
+
 def test_get_variables_calendar_missing_season_drops_prefix(
   config_with_tokens: Path,
 ) -> None:
@@ -1555,6 +1626,57 @@ def test_get_variables_next_up_skips_no_air_date(config_with_tokens: Path) -> No
     result = trakt.get_variables_next_up()
 
   assert result['show_name'] == [['THE WIRE']]
+
+
+def test_get_variables_next_up_skips_uncanonicalizable_s0_special(config_with_tokens: Path) -> None:
+  """A Season 0 next_episode with no tvdb/imdb IDs is skipped to the next show.
+
+  Mirrors the calendar's preference for canonical episodes over un-canonicalizable
+  specials. Without the skip, the special would render as raw 'S0Ex'.
+  """
+  watched = _mock_watched_ok(_WATCHED_SHOWS_RESPONSE)
+  progress_s0_special = _mock_progress_ok(
+    {
+      'next_episode': {
+        'season': 0,
+        'number': 12,
+        'title': 'Break Time',
+        'first_aired': '2000-01-01T00:00:00.000Z',
+        'ids': {'tvdb': None, 'imdb': None, 'tmdb': 7284163},
+      }
+    }
+  )
+  progress_canonical = _mock_progress_ok(_PROGRESS_WITH_NEXT)
+
+  with patch('integrations.trakt.fetch_with_retry', side_effect=[watched, progress_s0_special, progress_canonical]):
+    result = trakt.get_variables_next_up()
+
+  assert result['show_name'] == [['THE WIRE']]
+  assert result['episode_ref'] == [['S3E1']]
+
+
+def test_get_variables_next_up_keeps_s0_special_with_tvdb_id(config_with_tokens: Path) -> None:
+  """A Season 0 next_episode WITH a tvdb id passes through (TMDb can canonicalize)."""
+  watched = _mock_watched_ok([_WATCHED_SHOWS_RESPONSE[0]])
+  progress_s0_with_tvdb = _mock_progress_ok(
+    {
+      'next_episode': {
+        'season': 0,
+        'number': 5,
+        'title': 'Pilot Special',
+        'first_aired': '2000-01-01T00:00:00.000Z',
+        'ids': {'tvdb': 12345, 'imdb': None, 'tmdb': 67890},
+      }
+    }
+  )
+
+  with patch('integrations.trakt.fetch_with_retry', side_effect=[watched, progress_s0_with_tvdb]):
+    result = trakt.get_variables_next_up()
+
+  # No TMDb mock — _canonicalize_episode preserves Trakt S/E, so this still
+  # renders as S0E5; the point is the entry was NOT skipped.
+  assert result['show_name'] == [['BREAKING BAD']]
+  assert result['episode_ref'] == [['S0E5']]
 
 
 def test_get_variables_next_up_all_unaired_raises_unavailable(config_with_tokens: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -314,7 +314,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.21.2"
+version = "1.21.3"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- Calendar tiebreaker prefers canonical episodes over un-canonicalizable Season 0 specials when `first_aired` matches.
- Next-up skips a show's `next_episode` when it's a Season 0 special with no `tvdb`/`imdb` IDs.
- Plex `_canonicalize_plex_title` now propagates TMDb's canonical `(season, episode)` — including the type-6 broadcast-season group — into `episode_ref`.

Closes #554.

## Test plan

- [ ] CI: `check`, `docker`, CodeQL (actions/python/CodeQL)
- [ ] Local: `uv run pytest` — 1523 passed
- [ ] Local: `uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run bandit -c pyproject.toml -r . && uv run pip-audit`
- [ ] Manual sanity (post-merge): observe next Re:Zero Trakt calendar fire on the Vestaboard; expect canonical broadcast season ref, not `S0E…`. Run `get_variables_calendar()` ad-hoc if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)