### PR TITLE
fix(calendar_schedule): promote tz=None to local before event helpers (#556)

### DIFF
--- a/integrations/calendar_schedule.py
+++ b/integrations/calendar_schedule.py
@@ -161,6 +161,9 @@ def _refresh(now: datetime | None = None) -> None:
   tz = _config_mod.get_timezone()
   if now is None:
     now = _cal._get_now(tz)
+  # Promote None to local tzinfo so downstream event helpers produce aware
+  # datetimes — matches the convention in calendar.get_variables.
+  tz = tz or now.tzinfo
 
   events = _fetch_active_events(now, tz)
   resolved = _resolve_overrides(events)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.21.3"
+version = "1.21.4"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_calendar_schedule.py
+++ b/tests/core/test_calendar_schedule.py
@@ -316,3 +316,48 @@ def test_recurring_weekday_only_today() -> None:
   today_evening = _NOW.replace(hour=10, minute=0)
   ev = _make_event(description='vestaboard:bart.departures', start=today_morning, end=today_evening)
   assert cs._resolve_overrides([ev]) == {'bart.departures': True}
+
+
+# ── tz=None config + all-day CalDAV event (regression for #556) ───────────────
+
+
+def test_refresh_resolves_all_day_caldav_event_with_unset_timezone(
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  # Regression: when [scheduler].timezone is unset, get_timezone() returns
+  # None. _refresh must promote tz to now.tzinfo before downstream event
+  # helpers run, or _is_active_now compares naive (constructed from
+  # tzinfo=None) against aware now and raises TypeError.
+  import config as _config_mod
+  import integrations.calendar as _cal
+
+  monkeypatch.setattr(
+    _config_mod,
+    '_config',
+    {
+      'scheduler': {'calendar_schedule': {'gated_templates': []}},
+      'calendar': {
+        'caldav_url': 'https://example.com/',
+        'username': 'u',
+        'password': 'p',
+      },
+    },
+  )
+  # get_timezone() returns None for unset [scheduler].timezone.
+  assert _config_mod.get_timezone() is None
+
+  # Multi-day all-day event spanning yesterday → tomorrow (covers today).
+  ev = _make_event(
+    description='vestaboard:bart.departures',
+    start=_NOW - timedelta(days=1),
+    end=_NOW + timedelta(days=1),
+    all_day=True,
+  )
+  monkeypatch.setattr(_cal, '_collect_candidates_caldav', lambda *a, **kw: [(ev, None, 0)])
+
+  # Pass an aware now (matching what _get_now produces in production) so the
+  # promotion `tz = tz or now.tzinfo` has a concrete tzinfo to fall back on.
+  cs._refresh(now=_NOW)
+
+  with cs._cache_lock:
+    assert dict(cs._cache) == {'bart.departures': True}

--- a/uv.lock
+++ b/uv.lock
@@ -314,7 +314,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.21.3"
+version = "1.21.4"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary
- Fixes #556 — \`calendar_schedule: CalDAV fetch failed: can't compare offset-naive and offset-aware datetimes\` warning seen in live logs whenever \`[scheduler].timezone\` is unset and a CalDAV all-day event is currently active. Gating was silently failing open.
- One-line fix in \`calendar_schedule._refresh\`: \`tz = tz or now.tzinfo\` — same idiom \`calendar.get_variables\` already uses at \`integrations/calendar.py:810\`. No new abstraction.
- Adds a regression test (\`test_refresh_resolves_all_day_caldav_event_with_unset_timezone\`) that reproduces the exact warning without the fix.

## Test plan
- [x] \`uv run pytest tests/core/test_calendar_schedule.py\` — 34 passed
- [x] Confirmed new test fails on \`main\` with the original warning (\`can't compare offset-naive and offset-aware datetimes\`) and passes with the fix
- [x] Full suite: \`uv run pytest --cov=integrations --cov=. --cov-report=term-missing\` — 1539 passed, 95% coverage
- [x] \`uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run bandit -c pyproject.toml -r .\` — clean
- [x] Verified live against \`config.toml\`: \`cs._refresh()\` no longer logs the warning and now correctly resolves a real \`vestaboard:\` keyword from an active CalDAV event

— *Claude Code*