### PR TITLE
chore: release 1.21.5 — ship dep refresh, de-flake webhook sockets, clarify release policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,6 +385,32 @@ Semver rules (strict post-1.0):
 - **Major** (`x+1.0.0`): breaking changes to content JSON, CLI, config.toml
   keys, or Docker env vars
 
+### Dependency updates and releases
+
+Runtime dependency changes (including transitive deps that change in
+`uv.lock`) are release-worthy for a concrete reason: the Docker image is the
+only consumer that needs a release to pick them up. The image is built with
+`uv sync --frozen --no-dev`, baking in the locked **runtime closure**, and is
+rebuilt only when a release is cut (a `version` bump). Without a bump, Docker
+users stay on whatever was locked at the last release — including missed
+dependency CVE fixes. (PyPI installs resolve the `>=` floors fresh, so they
+already get newest-compatible deps without a release; a release is only needed
+on PyPI to publish tightened floors.)
+
+Rules:
+- **Runtime-closure change** — a runtime dep in `[project.dependencies]` or
+  any of its transitive deps in `uv.lock` → **bump patch and release.** Always
+  release for a dependency **security** fix in the runtime closure.
+- **Dev-only change** — anything under `[dependency-groups] dev` and its
+  dev-only transitives (ruff, pyright, pytest, bandit, pip-audit, etc.) →
+  **no release.** `--no-dev` keeps these out of the image and they don't affect
+  PyPI consumers. (A pip CVE surfaced via the pip-audit dev tool, for example,
+  never ships in the runtime image.)
+- **Dependabot grouped PRs** mix both. If the PR's `uv.lock` diff touches the
+  runtime closure, bump patch on merge; if it's purely dev, merge without a
+  bump. Routine runtime bumps may be batched into a periodic roll-up patch
+  release rather than one release per PR — but never sit on a security fix.
+
 Two types of milestones are used:
 
 - **Batch milestones** (e.g. "Batch 1", "Batch 2") — numbered work queues

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.21.4"
+version = "1.21.5"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/tests/core/test_webhook.py
+++ b/tests/core/test_webhook.py
@@ -51,6 +51,17 @@ def _start_test_server() -> tuple[HTTPServer, int]:
   return server, port
 
 
+def _stop_test_server(server: HTTPServer) -> None:
+  """Stop the serve_forever loop and close the listening socket.
+
+  shutdown() alone leaves the listening socket open, which surfaces as a
+  ResourceWarning when the server is garbage-collected; server_close()
+  releases it. Always pair them in teardown.
+  """
+  server.shutdown()
+  server.server_close()
+
+
 def _post(
   port: int,
   path: str,
@@ -181,7 +192,7 @@ def test_valid_secret_returns_200() -> None:
         status, _ = _post(port, '/webhook/bart')
         assert status == 200
       finally:
-        server.shutdown()
+        _stop_test_server(server)
 
 
 def test_wrong_secret_returns_401() -> None:
@@ -191,7 +202,7 @@ def test_wrong_secret_returns_401() -> None:
     assert status == 401
     assert 'Unauthorized' in body
   finally:
-    server.shutdown()
+    _stop_test_server(server)
 
 
 def test_missing_secret_returns_401() -> None:
@@ -212,7 +223,7 @@ def test_missing_secret_returns_401() -> None:
     resp = conn.getresponse()
     assert resp.status == 401
   finally:
-    server.shutdown()
+    _stop_test_server(server)
 
 
 def test_query_param_secret_accepted() -> None:
@@ -235,7 +246,7 @@ def test_query_param_secret_accepted() -> None:
         resp = conn.getresponse()
         assert resp.status == 200
       finally:
-        server.shutdown()
+        _stop_test_server(server)
 
 
 def test_query_param_wrong_secret_returns_401() -> None:
@@ -252,7 +263,7 @@ def test_query_param_wrong_secret_returns_401() -> None:
     resp = conn.getresponse()
     assert resp.status == 401
   finally:
-    server.shutdown()
+    _stop_test_server(server)
 
 
 def test_header_takes_precedence_over_query_param() -> None:
@@ -280,7 +291,7 @@ def test_header_takes_precedence_over_query_param() -> None:
         resp = conn.getresponse()
         assert resp.status == 200
       finally:
-        server.shutdown()
+        _stop_test_server(server)
 
 
 # ---------------------------------------------------------------------------
@@ -295,7 +306,7 @@ def test_unknown_integration_returns_404() -> None:
       status, _ = _post(port, '/webhook/notareal')
       assert status == 404
     finally:
-      server.shutdown()
+      _stop_test_server(server)
 
 
 def test_bad_path_returns_404() -> None:
@@ -305,7 +316,7 @@ def test_bad_path_returns_404() -> None:
     status, _ = _post(port, '/notwebhook/bart')
     assert status == 404
   finally:
-    server.shutdown()
+    _stop_test_server(server)
 
 
 def test_get_non_health_path_returns_404() -> None:
@@ -317,7 +328,7 @@ def test_get_non_health_path_returns_404() -> None:
     resp = conn.getresponse()
     assert resp.status == 404
   finally:
-    server.shutdown()
+    _stop_test_server(server)
 
 
 def test_integration_without_handle_webhook_returns_404() -> None:
@@ -331,7 +342,7 @@ def test_integration_without_handle_webhook_returns_404() -> None:
         assert status == 404
         assert 'does not support webhooks' in body
       finally:
-        server.shutdown()
+        _stop_test_server(server)
 
 
 # ---------------------------------------------------------------------------
@@ -353,7 +364,7 @@ def test_handle_webhook_none_returns_200_no_enqueue() -> None:
           assert 'Discarded' in body
           mock_enqueue.assert_not_called()
         finally:
-          server.shutdown()
+          _stop_test_server(server)
 
 
 def test_handle_webhook_result_enqueues_message() -> None:
@@ -386,7 +397,7 @@ def test_handle_webhook_result_enqueues_message() -> None:
             interrupt=False,
           )
         finally:
-          server.shutdown()
+          _stop_test_server(server)
 
 
 def test_enqueue_uses_default_name_when_blank() -> None:
@@ -410,7 +421,7 @@ def test_enqueue_uses_default_name_when_blank() -> None:
           call_kwargs = mock_enqueue.call_args.kwargs
           assert call_kwargs['name'] == 'webhook.bart'
         finally:
-          server.shutdown()
+          _stop_test_server(server)
 
 
 # ---------------------------------------------------------------------------
@@ -438,7 +449,7 @@ def test_interrupt_false_does_not_set_event() -> None:
           time.sleep(0.05)  # allow handler thread to complete
           assert not _mod._hold_interrupt.is_set()
         finally:
-          server.shutdown()
+          _stop_test_server(server)
 
 
 def test_interrupt_true_sets_hold_interrupt_event() -> None:
@@ -461,7 +472,7 @@ def test_interrupt_true_sets_hold_interrupt_event() -> None:
           time.sleep(0.05)  # allow handler thread to complete
           assert _mod._hold_interrupt.is_set()
         finally:
-          server.shutdown()
+          _stop_test_server(server)
 
 
 def test_interrupt_only_sets_hold_interrupt_without_enqueue() -> None:
@@ -487,7 +498,7 @@ def test_interrupt_only_sets_hold_interrupt_without_enqueue() -> None:
           mock_enqueue.assert_not_called()
           assert _mod._hold_interrupt.is_set()
         finally:
-          server.shutdown()
+          _stop_test_server(server)
 
 
 def test_interrupt_blocked_when_current_hold_is_high_priority() -> None:
@@ -516,7 +527,7 @@ def test_interrupt_blocked_when_current_hold_is_high_priority() -> None:
           time.sleep(0.05)
           assert not _mod._hold_interrupt.is_set()
         finally:
-          server.shutdown()
+          _stop_test_server(server)
 
 
 def test_interrupt_bypasses_threshold_when_same_supersede_tag() -> None:
@@ -549,7 +560,7 @@ def test_interrupt_bypasses_threshold_when_same_supersede_tag() -> None:
           time.sleep(0.05)
           assert _mod._hold_interrupt.is_set()
         finally:
-          server.shutdown()
+          _stop_test_server(server)
 
 
 def test_interrupt_blocked_for_different_tag_high_priority_hold() -> None:
@@ -578,7 +589,7 @@ def test_interrupt_blocked_for_different_tag_high_priority_hold() -> None:
           time.sleep(0.05)
           assert not _mod._hold_interrupt.is_set()
         finally:
-          server.shutdown()
+          _stop_test_server(server)
 
 
 def test_interrupt_allowed_when_current_hold_is_low_priority() -> None:
@@ -605,7 +616,7 @@ def test_interrupt_allowed_when_current_hold_is_low_priority() -> None:
           time.sleep(0.05)
           assert _mod._hold_interrupt.is_set()
         finally:
-          server.shutdown()
+          _stop_test_server(server)
 
 
 def test_interrupt_only_blocked_when_current_hold_is_high_priority() -> None:
@@ -635,7 +646,7 @@ def test_interrupt_only_blocked_when_current_hold_is_high_priority() -> None:
           mock_enqueue.assert_not_called()
           assert not _mod._hold_interrupt.is_set()
         finally:
-          server.shutdown()
+          _stop_test_server(server)
 
 
 def test_interrupt_only_allowed_when_current_hold_is_low_priority() -> None:
@@ -665,7 +676,7 @@ def test_interrupt_only_allowed_when_current_hold_is_low_priority() -> None:
           mock_enqueue.assert_not_called()
           assert _mod._hold_interrupt.is_set()
         finally:
-          server.shutdown()
+          _stop_test_server(server)
 
 
 def test_webhook_normal_indefinite_enqueues_with_indefinite_flag() -> None:
@@ -693,7 +704,7 @@ def test_webhook_normal_indefinite_enqueues_with_indefinite_flag() -> None:
           call_kwargs = mock_enqueue.call_args.kwargs
           assert call_kwargs['indefinite'] is True
         finally:
-          server.shutdown()
+          _stop_test_server(server)
 
 
 # ---------------------------------------------------------------------------
@@ -720,7 +731,7 @@ def test_malformed_json_returns_400() -> None:
       resp = conn.getresponse()
       assert resp.status == 400
     finally:
-      server.shutdown()
+      _stop_test_server(server)
 
 
 def test_handle_webhook_exception_returns_500_server_survives() -> None:
@@ -737,7 +748,7 @@ def test_handle_webhook_exception_returns_500_server_survives() -> None:
         status2, _ = _post(port, '/webhook/bart')
         assert status2 == 500  # still responding (integration still throws)
       finally:
-        server.shutdown()
+        _stop_test_server(server)
 
 
 # ---------------------------------------------------------------------------
@@ -885,7 +896,7 @@ def test_multipart_payload_field_is_parsed_as_json() -> None:
         call_args = mock_mod.handle_webhook.call_args
         assert call_args.args[0].get('event') == 'media.play'
       finally:
-        server.shutdown()
+        _stop_test_server(server)
 
 
 def test_multipart_missing_payload_field_returns_400() -> None:
@@ -908,7 +919,7 @@ def test_multipart_missing_payload_field_returns_400() -> None:
       resp = conn.getresponse()
       assert resp.status == 400
     finally:
-      server.shutdown()
+      _stop_test_server(server)
 
 
 def test_multipart_invalid_json_in_payload_returns_400() -> None:
@@ -918,7 +929,7 @@ def test_multipart_invalid_json_in_payload_returns_400() -> None:
       status, _ = _post_multipart(port, '/webhook/plex', 'not json{')
       assert status == 400
     finally:
-      server.shutdown()
+      _stop_test_server(server)
 
 
 # ---------------------------------------------------------------------------
@@ -947,7 +958,7 @@ def test_named_credential_authenticates_scoped_endpoint() -> None:
         status, _ = _post(port, '/webhook/message', secret=friend_secret)
         assert status == 200
       finally:
-        server.shutdown()
+        _stop_test_server(server)
 
 
 def test_named_credential_rejected_for_wrong_endpoint() -> None:
@@ -967,7 +978,7 @@ def test_named_credential_rejected_for_wrong_endpoint() -> None:
       status, _ = _post(port, '/webhook/notion', secret=friend_secret)
       assert status == 401
     finally:
-      server.shutdown()
+      _stop_test_server(server)
 
 
 def test_unknown_credential_secret_returns_401() -> None:
@@ -986,7 +997,7 @@ def test_unknown_credential_secret_returns_401() -> None:
       status, _ = _post(port, '/webhook/message', secret='wrong-secret')
       assert status == 401
     finally:
-      server.shutdown()
+      _stop_test_server(server)
 
 
 def test_credential_name_passed_to_handle_webhook() -> None:
@@ -1013,7 +1024,7 @@ def test_credential_name_passed_to_handle_webhook() -> None:
           _, kwargs = mock_hw.call_args
           assert kwargs.get('credential_name') == 'alice'
         finally:
-          server.shutdown()
+          _stop_test_server(server)
 
 
 # ---------------------------------------------------------------------------
@@ -1088,7 +1099,7 @@ def test_health_endpoint_returns_200_when_healthy() -> None:
       assert data['vestaboard'] is not None
       assert 'vestaboard' not in data['integrations']
     finally:
-      server.shutdown()
+      _stop_test_server(server)
       _health_mod.reset()
 
 
@@ -1111,7 +1122,7 @@ def test_health_endpoint_returns_503_when_vestaboard_errored() -> None:
       assert data['vestaboard']['status'] == 'error'
       assert data['integrations']['weather']['status'] == 'healthy'
     finally:
-      server.shutdown()
+      _stop_test_server(server)
       _health_mod.reset()
 
 
@@ -1130,7 +1141,7 @@ def test_health_endpoint_returns_503_when_unhealthy() -> None:
       data = json.loads(body)
       assert data['status'] == 'error'
     finally:
-      server.shutdown()
+      _stop_test_server(server)
       _health_mod.reset()
 
 
@@ -1145,7 +1156,7 @@ def test_health_endpoint_401_without_secret() -> None:
       status, _ = _get(port, '/health', secret='')
       assert status == 401
     finally:
-      server.shutdown()
+      _stop_test_server(server)
       _health_mod.reset()
 
 
@@ -1160,7 +1171,7 @@ def test_health_endpoint_401_wrong_secret() -> None:
       status, _ = _get(port, '/health', secret='wrong-secret')
       assert status == 401
     finally:
-      server.shutdown()
+      _stop_test_server(server)
       _health_mod.reset()
 
 
@@ -1171,7 +1182,7 @@ def test_health_endpoint_404_wrong_path() -> None:
       status, _ = _get(port, '/notfound', secret='')
       assert status == 404
     finally:
-      server.shutdown()
+      _stop_test_server(server)
 
 
 @pytest.mark.skipif(_CRED_HASH is None, reason='argon2-cffi not installed')
@@ -1187,7 +1198,7 @@ def test_health_endpoint_query_param_auth() -> None:
       data = json.loads(body)
       assert data['status'] == 'healthy'
     finally:
-      server.shutdown()
+      _stop_test_server(server)
       _health_mod.reset()
 
 
@@ -1211,7 +1222,7 @@ def test_head_health_returns_200_no_body() -> None:
       assert headers['content-type'] == 'application/json'
       assert int(headers['content-length']) > 0
     finally:
-      server.shutdown()
+      _stop_test_server(server)
       _health_mod.reset()
 
 
@@ -1228,7 +1239,7 @@ def test_head_health_returns_503_when_unhealthy() -> None:
       status, _ = _head(port, '/health')
       assert status == 503
     finally:
-      server.shutdown()
+      _stop_test_server(server)
       _health_mod.reset()
 
 
@@ -1243,5 +1254,5 @@ def test_head_health_401_without_secret() -> None:
       status, _ = _head(port, '/health', secret='')
       assert status == 401
     finally:
-      server.shutdown()
+      _stop_test_server(server)
       _health_mod.reset()

--- a/uv.lock
+++ b/uv.lock
@@ -314,7 +314,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.21.4"
+version = "1.21.5"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
— *Claude Code*

Three things together, per our discussion on dependency releases.

### 1. Release 1.21.5 — ship the runtime dep refresh (#562, #563)

The runtime dependency updates and tightened floors from #562/#563 are sitting on `main` but haven't shipped: the Docker image (`uv sync --frozen --no-dev`) only rebuilds when a `version` bump cuts a release, so Docker users are still on the deps locked at 1.21.4. This patch bump releases them (and republishes the tightened floors to PyPI).

### 2. De-flake webhook socket teardown

Webhook tests called `server.shutdown()` (stops `serve_forever()`) but never `server.server_close()`, leaking the listening socket → `ResourceWarning: unclosed socket` across the suite. Added a `_stop_test_server()` helper pairing both, routed all 42 teardown sites through it. Suite now runs warning-clean (`pytest -W default` → 0 ResourceWarnings).

### 3. Clarify the dependency-release policy (AGENTS.md)

The release table already lists runtime dep changes as release-worthy, but didn't say *why* or how to handle Dependabot's grouped PRs. Added a "Dependency updates and releases" subsection: runtime-closure changes (incl. transitive `uv.lock` deps) → patch + release, because the Docker image only picks them up on release; dev-only changes → no release (`--no-dev` excludes them); grouped Dependabot PRs → bump if the `uv.lock` diff touches the runtime closure, otherwise merge clean.

### Verification

- `ruff` / `ruff format` / `pyright` / `bandit` / `uv run pip-audit` → clean
- `uv run pytest` → 1544 passed, 0 ResourceWarnings
- Merging this bumps `version`, so Auto Release will cut **v1.21.5** → Docker image (GHCR) + PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
