### PR TITLE
feat: GET /state endpoint + HomeBridge push notifier (#566)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ on this project collaboratively with the user.
 scheduler.py                # Entry point — scheduler, queue, worker (argparse CLI)
 public.py                   # Runtime public mode state (thread-safe, persisted to config.toml)
 quiet.py                    # Software-side quiet mode state (thread-safe, persisted to config.toml)
+homebridge.py               # Optional outbound push notifier for HomeBridge/Apple Home (fires on quiet/public transitions)
 health.py                   # Integration health tracking (thread-safe, persisted to data/health.jsonl)
 config.py                   # TOML config loader (load_config, get, get_optional, get_schedule_override, write_section_values — in-place token persistence)
 exceptions.py               # Custom exception types (IntegrationDataUnavailableError)
@@ -137,6 +138,7 @@ data/                       # Runtime state directory (Docker VOLUME, git-ignore
   health.jsonl              # Persisted health events (JSONL, auto-managed, purged after 7 days)
 docs/
   webhook-reverse-proxy.md  # Webhook TLS setup guide (Cloudflare Tunnel, reverse proxy)
+  homebridge.md             # Apple Home / HomeBridge setup (GET /state, [homebridge] push, companion plugin)
 .env.example                # Template for local integration test secrets (copy to .env, fill in, git-ignored)
 Dockerfile                  # Single-stage image using ghcr.io/astral-sh/uv
 .github/workflows/

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev
 
 # Copy source, config example, and bundled contrib content.
-COPY scheduler.py config.py exceptions.py health.py public.py quiet.py config.example.toml ./
+COPY scheduler.py config.py exceptions.py health.py public.py quiet.py homebridge.py config.example.toml ./
 COPY integrations/ ./integrations/
 COPY content/contrib/ ./content/contrib/
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,35 @@ is needed for persistence across stop/start cycles.
 A periodic health summary also logs to the console every hour, showing
 non-healthy integrations and their recent error rates.
 
+## Board state endpoint
+
+When the [webhook listener](#configuration) is enabled, `GET /state` returns the
+current board content plus the runtime mode toggles:
+
+```json
+{
+  "modes": { "quiet": false, "public": false },
+  "source": "board",
+  "grid": [[8, 0, 0]],
+  "rendered": "HELLO",
+  "timestamp": "2026-01-01T12:00:00-08:00"
+}
+```
+
+`modes` is always present; `grid`/`rendered`/`timestamp` are `null` when no
+content is known. `source` is `board` (last grid sent), `virtual` (quiet-mode
+buffer), or `empty`. Add `?refresh=true` to force an authoritative fetch from the
+Vestaboard API. Authentication uses the auto-generated `state` credential
+(`X-Webhook-Secret` header or `?secret=`), like `/health`.
+
+## Apple Home (HomeBridge)
+
+Quiet and Public modes can be exposed as native Apple Home switches via
+HomeBridge — manual toggles, Siri, and Home automations. The `GET /state`
+endpoint above keeps the switches in sync, and an optional `[homebridge]` config
+section pushes mode changes to HomeBridge instantly. See
+[`docs/homebridge.md`](docs/homebridge.md) for the full setup.
+
 ## Installing from PyPI
 
 **Requirements:** Python 3.14+

--- a/config.example.toml
+++ b/config.example.toml
@@ -376,6 +376,13 @@ city = "San Francisco"
 # secret_hash = "$argon2id$v=19$m=65536,t=3,p=4$..."
 # webhooks = ["scheduler"]
 #
+# [webhook.credentials.state]
+# secret_hash = "$argon2id$v=19$m=65536,t=3,p=4$..."
+# webhooks = ["state"]
+# Auto-generated on first startup. Used to authenticate the GET /state endpoint
+# (current board content + quiet/public toggle state — read by HomeBridge etc.).
+# Check the log for the plaintext secret.
+#
 # [webhook.credentials.plex]
 # secret_hash = "$argon2id$v=19$m=65536,t=3,p=4$..."
 # webhooks = ["plex"]
@@ -395,3 +402,17 @@ city = "San Francisco"
 # [webhook.credentials.message.friend.alice]
 # secret_hash = "$argon2id$v=19$m=65536,t=3,p=4$..."
 # webhooks = ["message"]
+
+# [homebridge]
+# Optional: push quiet/public mode transitions to HomeBridge so the Apple Home
+# switches update instantly instead of waiting for the next poll of GET /state.
+# When this section is absent, no outbound notifications are sent (the plugin can
+# still poll /state). See docs/homebridge.md for the full setup.
+#
+# url — the HomeBridge endpoint that receives the push. On each transition,
+#   e-note-ion sends POST <url> with JSON {"characteristic": "quiet"|"public",
+#   "value": true|false}. Failures are logged and never block toggling.
+# url = "http://homebridge.local:51828/e-note-ion"
+#
+# secret — optional; sent as the X-Webhook-Secret header on the push.
+# secret = "your-shared-secret"

--- a/content/contrib/scheduler.md
+++ b/content/contrib/scheduler.md
@@ -240,6 +240,15 @@ be delayed in low-power mode.
 All automations should have **Notify When Run** deselected so they run
 silently.
 
+## Apple Home (HomeBridge)
+
+Both modes can also be exposed as native **Apple Home** switches via HomeBridge,
+giving manual toggles, Siri control, and Home automations alongside the iOS
+Shortcuts path above. The scheduler exposes a read-side `GET /state` endpoint
+(current `quiet`/`public` state plus board content) for switch sync and an
+optional `[homebridge]` push so the switches update instantly on a mode change.
+See [`docs/homebridge.md`](../../docs/homebridge.md) for the full setup.
+
 ## Interaction with hardware quiet hours
 
 If the Vestaboard's hardware quiet hours overlap with software quiet mode,

--- a/docs/homebridge.md
+++ b/docs/homebridge.md
@@ -1,0 +1,98 @@
+# HomeBridge / Apple Home setup
+
+Control the Vestaboard's **Quiet** and **Public** modes from the Apple Home app
+(and Siri, Control Center, and Home automations) via [HomeBridge](https://homebridge.io/).
+
+This complements the iOS Shortcuts / Focus automation path documented in
+[`content/contrib/scheduler.md`](../content/contrib/scheduler.md) — the same two
+modes, exposed as native Home switches.
+
+---
+
+## What e-note-ion provides
+
+The scheduler already exposes everything HomeBridge needs:
+
+| Direction | Endpoint | Purpose |
+|---|---|---|
+| **Set** | `POST /webhook/scheduler` | `{"action": "quiet"｜"wake"｜"public"｜"private"}` — toggle a mode |
+| **Read** | `GET /state` | Current `modes` (`quiet`/`public`) plus board content, for switch state sync |
+| **Push** | `[homebridge]` config (optional) | e-note-ion notifies HomeBridge instantly on a mode change |
+
+Both endpoints authenticate with named webhook credentials
+(`X-Webhook-Secret` header or `?secret=` query param). The `scheduler` and
+`state` credentials are auto-generated on first startup — check the log for the
+plaintext secrets.
+
+### `GET /state` response
+
+```json
+{
+  "modes": { "quiet": false, "public": false },
+  "source": "board",
+  "grid": [[8, 0, 0], ...],
+  "rendered": "HELLO          ",
+  "timestamp": "2026-06-14T09:30:00-07:00"
+}
+```
+
+- `modes` is always present — the primary payload for the HomeKit switches.
+- `source` is `board` (last grid sent), `virtual` (quiet-mode buffer), or `empty`.
+- `grid`/`rendered`/`timestamp` are `null` when no content is known.
+- `?refresh=true` forces an authoritative fetch from the Vestaboard API (rate-limited).
+
+### Optional push (`[homebridge]`)
+
+When `[homebridge]` is configured, each **real** quiet/public transition fires:
+
+```
+POST <url>
+X-Webhook-Secret: <secret>   (if configured)
+
+{"characteristic": "quiet"｜"public", "value": true｜false}
+```
+
+The request runs on a background thread with a short timeout; a HomeBridge
+outage is logged and never blocks toggling. Without push, a HomeBridge switch
+still stays in sync by polling `GET /state` on its pull interval — set a slow
+interval (e.g. 5 minutes) when push is enabled, as a self-healing safety net.
+
+```toml
+[homebridge]
+url = "http://homebridge.local:51828/e-note-ion"
+secret = "your-shared-secret"
+```
+
+---
+
+## Recommended: the companion plugin (single "Vestaboard" device)
+
+The companion plugin [`homebridge-e-note-ion`](https://github.com/JasonPuglisi/homebridge-e-note-ion)
+(separate repo) publishes a **single "Vestaboard" accessory** exposing both the
+**Quiet** and **Public** switches together, consuming `GET /state` (poll) and the
+push notifications above (instant). This is the only way to group both toggles
+under one Home device — generic HTTP plugins create one accessory per switch.
+
+> **Note:** with two same-type switches on one accessory, Apple's Home app may
+> still render two tiles, but they stay grouped under the one "Vestaboard"
+> accessory (shared device info, moved between rooms as a unit).
+
+---
+
+## Alternative: off-the-shelf `homebridge-http-webhooks`
+
+If you don't want the companion plugin, [`homebridge-http-webhooks`](https://www.npmjs.com/package/homebridge-http-webhooks)
+works today — at the cost of **two separate switch tiles** (no single grouped
+device). Define two switches, point their on/off URLs at `POST /webhook/scheduler`,
+and enable push by setting `[homebridge].url` to the plugin's webhook listener so
+state stays in sync. Consult the plugin's README for the exact `config.json`
+shape, which changes between versions.
+
+---
+
+## Networking
+
+HomeBridge usually runs on the same LAN (often the same host, e.g. Unraid), so
+**plain HTTP to the webhook port is fine** — the secret never leaves your
+network. TLS is only required for senders outside your LAN; see
+[`docs/webhook-reverse-proxy.md`](webhook-reverse-proxy.md).

--- a/homebridge.py
+++ b/homebridge.py
@@ -1,0 +1,76 @@
+# homebridge.py
+#
+# Optional outbound push notifier for the HomeBridge / Apple Home integration.
+# When [homebridge] is configured in config.toml, a quiet- or public-mode
+# transition fires a small HTTP POST to a configured endpoint so HomeKit
+# switches update instantly instead of waiting for the next poll of /state.
+#
+# Fully optional: a no-op when [homebridge] is absent. The POST runs in a daemon
+# thread so toggling latency never depends on HomeBridge being reachable, and
+# all failures are caught and logged — a HomeBridge outage must never break mode
+# toggling. The shared secret is never logged.
+
+import logging
+import threading
+
+import config as _config_mod
+
+logger = logging.getLogger(__name__)
+
+# Bounded so a slow/unreachable HomeBridge can't tie up the notify thread.
+_TIMEOUT = 5
+_RETRIES = 2
+
+
+def notify_mode_change(characteristic: str, value: bool) -> None:
+  """Push a mode transition to HomeBridge, if configured.
+
+  Args:
+    characteristic: 'quiet' or 'public'.
+    value: the new state.
+
+  No-op when [homebridge] is not configured (or has no url). Never raises:
+  the request is dispatched to a daemon thread and any error is logged there.
+  """
+  if not _config_mod.has_section('homebridge'):
+    return
+  url = _config_mod.get_optional('homebridge', 'url')
+  if not url:
+    return
+  secret = _config_mod.get_optional('homebridge', 'secret')
+  _dispatch(url, secret, characteristic, value)
+
+
+def _dispatch(url: str, secret: str, characteristic: str, value: bool) -> None:
+  """Run _send on a short-lived daemon thread (decouples toggling latency)."""
+  thread = threading.Thread(
+    target=_send,
+    args=(url, secret, characteristic, value),
+    daemon=True,
+    name='homebridge-notify',
+  )
+  thread.start()
+
+
+def _send(url: str, secret: str, characteristic: str, value: bool) -> None:
+  """POST the mode transition to HomeBridge. Catches and logs all errors."""
+  import integrations.http as _http  # local import: keep this module light
+
+  headers = {'Content-Type': 'application/json'}
+  if secret:
+    headers['X-Webhook-Secret'] = secret
+  try:
+    resp = _http.fetch_with_retry(
+      'POST',
+      url,
+      json={'characteristic': characteristic, 'value': value},
+      headers=headers,
+      timeout=_TIMEOUT,
+      retries=_RETRIES,
+    )
+    if resp.status_code >= 400:
+      logger.warning('HomeBridge notify %s=%s returned HTTP %d', characteristic, value, resp.status_code)
+    else:
+      logger.debug('HomeBridge notified: %s=%s', characteristic, value)
+  except Exception as e:  # noqa: BLE001 — never let a HomeBridge outage break toggling
+    logger.warning('HomeBridge notify failed for %s=%s: %s', characteristic, value, e)

--- a/integrations/vestaboard.py
+++ b/integrations/vestaboard.py
@@ -262,6 +262,38 @@ def render_grid(
   return '\n'.join(lines)
 
 
+# Single-letter codes for color squares, used by render_grid_text for a
+# column-aligned, ANSI-free preview (one character per tile).
+_COLOR_LETTERS: dict[int, str] = {63: 'R', 64: 'O', 65: 'Y', 66: 'G', 67: 'B', 68: 'V', 69: 'W', 70: 'K'}
+
+
+def render_grid_text(grid: list[list[int]]) -> str:
+  """Render a character-code grid as plain, ANSI-free text (no border).
+
+  One character per tile so rows stay column-aligned: letters/digits/punctuation
+  map to their characters, blanks to spaces, color squares to a single letter
+  (R/O/Y/G/B/V/W/K), code 71 (filled) to '#', and code 62 to the model glyph
+  ('°' on the Flagship, '❤' on the Note). Intended for machine-readable output
+  such as the /state endpoint, where ANSI escapes are undesirable.
+  """
+  rows: list[str] = []
+  for row in grid:
+    cells: list[str] = []
+    for code in row:
+      if code in _COLOR_LETTERS:
+        cells.append(_COLOR_LETTERS[code])
+      elif code == 71:
+        cells.append('#')
+      elif code == 62:
+        cells.append('°' if model is VestaboardModel.FLAGSHIP else '❤')
+      elif 0 <= code < len(_CHAR_MAP) and _CHAR_MAP[code]:
+        cells.append(_CHAR_MAP[code])
+      else:
+        cells.append(' ')
+    rows.append(''.join(cells))
+  return '\n'.join(rows)
+
+
 # --- State ---
 
 
@@ -311,6 +343,33 @@ def _await_post_gate() -> None:
         logger.debug('Vestaboard pacing gate: waiting %.1fs', wait)
         time.sleep(wait)
     _last_post_time = time.monotonic()
+
+
+# --- Last-sent grid cache (for the read-side /state endpoint) ---
+# Updated on every successful set_state_raw so the read-side endpoint can serve
+# the current board content without an extra (rate-limited) API round-trip.
+_last_grid: list[list[int]] | None = None
+_last_grid_at: float = 0.0  # epoch seconds (time.time()) of the last cache update
+_last_grid_lock = threading.Lock()
+
+
+def _cache_grid(grid: list[list[int]]) -> None:
+  """Store a copy of the last grid written to the board, with a timestamp."""
+  global _last_grid, _last_grid_at
+  with _last_grid_lock:
+    _last_grid = [row[:] for row in grid]
+    _last_grid_at = time.time()
+
+
+def get_cached_grid() -> tuple[list[list[int]] | None, float]:
+  """Return (a copy of the last grid sent to the board, epoch timestamp).
+
+  Returns (None, 0.0) if nothing has been written since process start.
+  """
+  with _last_grid_lock:
+    if _last_grid is None:
+      return None, 0.0
+    return [row[:] for row in _last_grid], _last_grid_at
 
 
 def get_state(color: VestaboardColor = VestaboardColor.BLACK) -> VestaboardState:
@@ -683,6 +742,7 @@ def set_state_raw(grid: list[list[int]]) -> None:
       r.raise_for_status()
     except requests.HTTPError:
       raise requests.HTTPError(f'Vestaboard API error: {r.status_code} {r.reason}') from None
+    _cache_grid(grid)
     return
 
 

--- a/public.py
+++ b/public.py
@@ -11,6 +11,7 @@ import logging
 import threading
 
 import config as _config_mod
+import homebridge as _homebridge_mod
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,9 @@ def set_public(value: bool) -> None:
     logger.info('Public mode %s', 'activated' if value else 'deactivated')
     if value:
       _changed.set()
+  # Notify HomeBridge outside the lock (network I/O) and only on a real
+  # transition (the no-op case returned above).
+  _homebridge_mod.notify_mode_change('public', value)
 
 
 def is_public() -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e-note-ion"
-version = "1.21.5"
+version = "1.22.0"
 description = "Automation for Vestaboard displays — with emotion"
 keywords = ["vestaboard", "note", "flagship", "automation", "schedule", "scheduling"]
 authors = [

--- a/quiet.py
+++ b/quiet.py
@@ -14,6 +14,7 @@ import logging
 import threading
 
 import config as _config_mod
+import homebridge as _homebridge_mod
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +54,9 @@ def set_quiet(value: bool) -> None:
     _config_mod.write_config_section('scheduler', {'quiet': value})
     logger.info('Quiet mode %s', 'activated' if value else 'deactivated')
     _changed.set()
+  # Notify HomeBridge outside the lock (network I/O) and only on a real
+  # transition (the no-op case returned above).
+  _homebridge_mod.notify_mode_change('quiet', value)
 
 
 def is_quiet() -> bool:

--- a/scheduler.py
+++ b/scheduler.py
@@ -747,6 +747,57 @@ def _authenticate_webhook(provided: str, integration: str) -> str | None:
   return None
 
 
+def _build_state_payload(refresh: bool = False) -> dict[str, Any]:
+  """Assemble the GET /state response: current mode toggles + board content.
+
+  Always includes `modes` (quiet/public) — the primary payload for the HomeKit
+  switches, so the endpoint returns 200 with modes even when no board content is
+  known. Board content is best-effort: the quiet-mode virtual state when quiet is
+  active, an authoritative fetch when refresh=True, otherwise the in-memory cache
+  of the last grid the worker sent. `source` is 'virtual', 'board', or 'empty';
+  `grid`/`rendered`/`timestamp` are null when nothing is known.
+  """
+  modes = {'quiet': _quiet_mod.is_quiet(), 'public': _public_mod.is_public()}
+  grid: list[list[int]] | None = None
+  grid_at = 0.0
+  source = 'empty'
+  refresh_error = False
+
+  if modes['quiet']:
+    grid = _quiet_mod.get_virtual_state()
+    if grid is not None:
+      source = 'virtual'
+      grid_at = time.time()
+  elif refresh:
+    try:
+      grid = vestaboard.get_state().layout
+      source = 'board'
+      grid_at = time.time()
+    except vestaboard.EmptyBoardError:
+      source = 'empty'
+    except Exception as e:  # noqa: BLE001 — refresh is best-effort; fall back to cache
+      logger.warning('State: refresh fetch failed: %s', e)
+      refresh_error = True
+      grid, grid_at = vestaboard.get_cached_grid()
+      if grid is not None:
+        source = 'board'
+  else:
+    grid, grid_at = vestaboard.get_cached_grid()
+    if grid is not None:
+      source = 'board'
+
+  payload: dict[str, Any] = {
+    'modes': modes,
+    'source': source,
+    'grid': grid,
+    'rendered': vestaboard.render_grid_text(grid) if grid is not None else None,
+    'timestamp': (datetime.fromtimestamp(grid_at, tz=_config_mod.get_timezone()).isoformat() if grid_at else None),
+  }
+  if refresh_error:
+    payload['refresh_error'] = True
+  return payload
+
+
 def _make_webhook_handler() -> type:
   """Return a BaseHTTPRequestHandler subclass for the webhook listener."""
 
@@ -895,7 +946,25 @@ def _make_webhook_handler() -> type:
       status_code = 200 if summary['status'] == 'healthy' else 503
       return status_code, summary
 
+    def _handle_state(self, parsed: Any) -> None:
+      """GET /state — current mode toggles + board content (auth: 'state' cred)."""
+      header_secret = self.headers.get('X-Webhook-Secret', '')
+      query = parse_qs(parsed.query)
+      query_secret = query.get('secret', [''])[0]
+      provided = header_secret or query_secret
+      credential_name = _authenticate_webhook(provided, 'state')
+      if credential_name is None:
+        logger.warning('State: rejected request — invalid or missing secret')
+        self._respond(401, 'Unauthorized')
+        return
+      refresh = query.get('refresh', [''])[0].lower() in ('1', 'true', 'yes')
+      self._respond_json(200, _build_state_payload(refresh=refresh))
+
     def do_GET(self) -> None:  # noqa: N802
+      parsed = urlparse(self.path)
+      if parsed.path.strip('/') == 'state':
+        self._handle_state(parsed)
+        return
       result = self._handle_health()
       if result is not None:
         self._respond_json(result[0], result[1])
@@ -941,6 +1010,7 @@ _WEBHOOK_AUTOGEN: dict[str, str] = {
   'notion': 'notion',
   'plex': 'plex',
   'scheduler': 'scheduler',
+  'state': 'state',
 }
 
 

--- a/tests/core/test_vestaboard.py
+++ b/tests/core/test_vestaboard.py
@@ -1181,3 +1181,82 @@ def test_get_state_404_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
     with pytest.raises(vb.EmptyBoardError):
       vb.get_state()
   assert mock_get.call_count == 1
+
+
+# --- render_grid_text (plain-text /state rendering) ---
+
+
+def test_render_grid_text_letters_and_blanks() -> None:
+  # code 1 → 'A' (first letter); code 0 → blank.
+  row = [1, 0, 0]
+  out = vb.render_grid_text([row])
+  assert out[0] == vb._CHAR_MAP[1]  # noqa: SLF001
+  assert out[1] == ' '
+  assert len(out) == 3
+
+
+def test_render_grid_text_color_squares_use_letters() -> None:
+  # codes 63-70 → single color letters, keeping rows column-aligned.
+  out = vb.render_grid_text([[63, 66, 67]])
+  assert out == 'RGB'
+
+
+def test_render_grid_text_no_ansi_escapes() -> None:
+  out = vb.render_grid_text([[1, 63, 71], [62, 0, 2]])
+  assert '\033' not in out
+
+
+def test_render_grid_text_rows_joined_with_newline() -> None:
+  out = vb.render_grid_text([[0, 0], [0, 0]])
+  assert out.count('\n') == 1
+
+
+def test_render_grid_text_heart_on_note() -> None:
+  vb.model = vb.VestaboardModel.NOTE
+  out = vb.render_grid_text([[62]])
+  assert out == '❤'
+
+
+def test_render_grid_text_degree_on_flagship() -> None:
+  original = vb.model
+  vb.model = vb.VestaboardModel.FLAGSHIP
+  try:
+    out = vb.render_grid_text([[62]])
+    assert out == '°'
+  finally:
+    vb.model = original
+
+
+# --- last-grid cache (for the /state endpoint) ---
+
+
+def test_get_cached_grid_none_initially() -> None:
+  vb._last_grid = None  # noqa: SLF001
+  grid, ts = vb.get_cached_grid()
+  assert grid is None
+  assert ts == 0.0
+
+
+def test_set_state_raw_caches_grid(monkeypatch: pytest.MonkeyPatch) -> None:
+  import config as _config_mod
+
+  monkeypatch.setattr(_config_mod, '_config', {'vestaboard': {'api_key': 'test-key'}})
+  vb._last_grid = None  # noqa: SLF001
+  grid = [[1, 2, 3], [0, 0, 0]]
+  ok = MagicMock()
+  ok.status_code = 200
+  ok.raise_for_status = MagicMock()
+  with (
+    patch('integrations.vestaboard.requests.post', return_value=ok),
+    patch('integrations.vestaboard.time.sleep'),
+  ):
+    vb.set_state_raw(grid)
+  cached, ts = vb.get_cached_grid()
+  assert cached == grid
+  assert ts > 0
+  # Returned grid is a copy — mutating it must not corrupt the cache.
+  assert cached is not None
+  cached[0][0] = 99
+  again, _ = vb.get_cached_grid()
+  assert again is not None
+  assert again[0][0] == 1

--- a/tests/core/test_webhook.py
+++ b/tests/core/test_webhook.py
@@ -1256,3 +1256,174 @@ def test_head_health_401_without_secret() -> None:
     finally:
       _stop_test_server(server)
       _health_mod.reset()
+
+
+# ---------------------------------------------------------------------------
+# GET /state endpoint
+# ---------------------------------------------------------------------------
+
+
+def _state_cred_config() -> dict[str, Any]:
+  """Config with a test credential scoped to the state endpoint."""
+  return {
+    'webhook': {
+      'credentials': {
+        'test': {'secret_hash': _CRED_HASH, 'webhooks': ['state']},
+      },
+    },
+  }
+
+
+@pytest.mark.skipif(_CRED_HASH is None, reason='argon2-cffi not installed')
+def test_state_endpoint_returns_modes() -> None:
+  """/state always reports the current quiet/public toggle state."""
+  with patch.dict('config._config', _state_cred_config()):
+    with (
+      patch.object(_mod._quiet_mod, 'is_quiet', return_value=False),
+      patch.object(_mod._public_mod, 'is_public', return_value=True),
+      patch.object(_mod.vestaboard, 'get_cached_grid', return_value=(None, 0.0)),
+    ):
+      server, port = _start_test_server()
+      try:
+        status, body = _get(port, '/state')
+        assert status == 200
+        data = json.loads(body)
+        assert data['modes'] == {'quiet': False, 'public': True}
+        assert data['source'] == 'empty'
+        assert data['grid'] is None
+        assert data['rendered'] is None
+        assert data['timestamp'] is None
+      finally:
+        _stop_test_server(server)
+
+
+@pytest.mark.skipif(_CRED_HASH is None, reason='argon2-cffi not installed')
+def test_state_source_board_from_cache() -> None:
+  """With cached content and no quiet mode, /state serves the cached grid."""
+  grid = [[8, 0, 0], [0, 63, 0]]  # 'H', blank, blank / blank, red, blank
+  with patch.dict('config._config', _state_cred_config()):
+    with (
+      patch.object(_mod._quiet_mod, 'is_quiet', return_value=False),
+      patch.object(_mod._public_mod, 'is_public', return_value=False),
+      patch.object(_mod.vestaboard, 'get_cached_grid', return_value=(grid, 1_700_000_000.0)),
+    ):
+      server, port = _start_test_server()
+      try:
+        status, body = _get(port, '/state')
+        assert status == 200
+        data = json.loads(body)
+        assert data['source'] == 'board'
+        assert data['grid'] == grid
+        assert data['rendered'] is not None
+        assert data['timestamp'] is not None
+      finally:
+        _stop_test_server(server)
+
+
+@pytest.mark.skipif(_CRED_HASH is None, reason='argon2-cffi not installed')
+def test_state_source_virtual_when_quiet() -> None:
+  """In quiet mode, /state returns the virtual state (what wakes on the board)."""
+  virtual = [[8, 9, 0], [0, 0, 0]]
+  with patch.dict('config._config', _state_cred_config()):
+    with (
+      patch.object(_mod._quiet_mod, 'is_quiet', return_value=True),
+      patch.object(_mod._quiet_mod, 'get_virtual_state', return_value=virtual),
+      patch.object(_mod._public_mod, 'is_public', return_value=False),
+    ):
+      server, port = _start_test_server()
+      try:
+        status, body = _get(port, '/state')
+        assert status == 200
+        data = json.loads(body)
+        assert data['modes']['quiet'] is True
+        assert data['source'] == 'virtual'
+        assert data['grid'] == virtual
+      finally:
+        _stop_test_server(server)
+
+
+@pytest.mark.skipif(_CRED_HASH is None, reason='argon2-cffi not installed')
+def test_state_refresh_calls_get_state() -> None:
+  """?refresh=true fetches authoritative board state via the Vestaboard API."""
+  fetched = [[1, 2, 3], [4, 5, 6]]
+  fake_state = MagicMock()
+  fake_state.layout = fetched
+  with patch.dict('config._config', _state_cred_config()):
+    with (
+      patch.object(_mod._quiet_mod, 'is_quiet', return_value=False),
+      patch.object(_mod._public_mod, 'is_public', return_value=False),
+      patch.object(_mod.vestaboard, 'get_state', return_value=fake_state) as mock_get,
+      patch.object(_mod.vestaboard, 'get_cached_grid', return_value=(None, 0.0)),
+    ):
+      server, port = _start_test_server()
+      try:
+        status, body = _get(port, '/state?refresh=true')
+        assert status == 200
+        data = json.loads(body)
+        assert data['source'] == 'board'
+        assert data['grid'] == fetched
+        mock_get.assert_called_once()
+      finally:
+        _stop_test_server(server)
+
+
+@pytest.mark.skipif(_CRED_HASH is None, reason='argon2-cffi not installed')
+def test_state_refresh_error_falls_back_to_cache() -> None:
+  """A failed refresh fetch falls back to the cache and still returns 200 + modes."""
+  cached = [[7, 7, 7], [0, 0, 0]]
+  with patch.dict('config._config', _state_cred_config()):
+    with (
+      patch.object(_mod._quiet_mod, 'is_quiet', return_value=False),
+      patch.object(_mod._public_mod, 'is_public', return_value=False),
+      patch.object(_mod.vestaboard, 'get_state', side_effect=RuntimeError('API down')),
+      patch.object(_mod.vestaboard, 'get_cached_grid', return_value=(cached, 1_700_000_000.0)),
+    ):
+      server, port = _start_test_server()
+      try:
+        status, body = _get(port, '/state?refresh=true')
+        assert status == 200
+        data = json.loads(body)
+        assert data['source'] == 'board'
+        assert data['grid'] == cached
+        assert data['refresh_error'] is True
+      finally:
+        _stop_test_server(server)
+
+
+@pytest.mark.skipif(_CRED_HASH is None, reason='argon2-cffi not installed')
+def test_state_endpoint_401_without_secret() -> None:
+  with patch.dict('config._config', _state_cred_config()):
+    server, port = _start_test_server()
+    try:
+      status, _ = _get(port, '/state', secret='')
+      assert status == 401
+    finally:
+      _stop_test_server(server)
+
+
+@pytest.mark.skipif(_CRED_HASH is None, reason='argon2-cffi not installed')
+def test_state_endpoint_401_wrong_secret() -> None:
+  with patch.dict('config._config', _state_cred_config()):
+    server, port = _start_test_server()
+    try:
+      status, _ = _get(port, '/state', secret='wrong-secret')
+      assert status == 401
+    finally:
+      _stop_test_server(server)
+
+
+@pytest.mark.skipif(_CRED_HASH is None, reason='argon2-cffi not installed')
+def test_state_endpoint_query_param_auth() -> None:
+  with patch.dict('config._config', _state_cred_config()):
+    with (
+      patch.object(_mod._quiet_mod, 'is_quiet', return_value=False),
+      patch.object(_mod._public_mod, 'is_public', return_value=False),
+      patch.object(_mod.vestaboard, 'get_cached_grid', return_value=(None, 0.0)),
+    ):
+      server, port = _start_test_server()
+      try:
+        status, body = _get(port, f'/state?secret={_CRED_SECRET}', secret='')
+        assert status == 200
+        assert json.loads(body)['modes'] == {'quiet': False, 'public': False}
+      finally:
+        _stop_test_server(server)

--- a/tests/test_homebridge.py
+++ b/tests/test_homebridge.py
@@ -1,0 +1,99 @@
+from unittest.mock import MagicMock, patch
+
+import config as _config_mod
+import homebridge as _mod
+
+# ---------------------------------------------------------------------------
+# notify_mode_change — config gating + dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_notify_noop_when_no_section() -> None:
+  """No [homebridge] section → nothing is dispatched."""
+  with patch.object(_config_mod, '_config', {}):
+    with patch.object(_mod, '_dispatch') as mock_dispatch:
+      _mod.notify_mode_change('quiet', True)
+      mock_dispatch.assert_not_called()
+
+
+def test_notify_noop_when_no_url() -> None:
+  """[homebridge] present but without a url → nothing is dispatched."""
+  with patch.object(_config_mod, '_config', {'homebridge': {'secret': 's'}}):
+    with patch.object(_mod, '_dispatch') as mock_dispatch:
+      _mod.notify_mode_change('public', False)
+      mock_dispatch.assert_not_called()
+
+
+def test_notify_dispatches_when_configured() -> None:
+  with patch.object(_config_mod, '_config', {'homebridge': {'url': 'http://hb:51828/x', 'secret': 'sec'}}):
+    with patch.object(_mod, '_dispatch') as mock_dispatch:
+      _mod.notify_mode_change('quiet', True)
+      mock_dispatch.assert_called_once_with('http://hb:51828/x', 'sec', 'quiet', True)
+
+
+def test_notify_dispatches_without_secret() -> None:
+  with patch.object(_config_mod, '_config', {'homebridge': {'url': 'http://hb:51828/x'}}):
+    with patch.object(_mod, '_dispatch') as mock_dispatch:
+      _mod.notify_mode_change('public', True)
+      mock_dispatch.assert_called_once_with('http://hb:51828/x', '', 'public', True)
+
+
+# ---------------------------------------------------------------------------
+# _send — outbound HTTP behaviour (runs synchronously in tests)
+# ---------------------------------------------------------------------------
+
+
+def test_send_posts_payload_with_secret_header() -> None:
+  with patch('integrations.http.fetch_with_retry') as mock_fetch:
+    mock_fetch.return_value = MagicMock(status_code=200)
+    _mod._send('http://hb/x', 'shh', 'quiet', True)
+    mock_fetch.assert_called_once()
+    args, kwargs = mock_fetch.call_args
+    assert args[0] == 'POST'
+    assert args[1] == 'http://hb/x'
+    assert kwargs['json'] == {'characteristic': 'quiet', 'value': True}
+    assert kwargs['headers']['X-Webhook-Secret'] == 'shh'
+    assert kwargs['timeout'] == _mod._TIMEOUT
+
+
+def test_send_omits_secret_header_when_absent() -> None:
+  with patch('integrations.http.fetch_with_retry') as mock_fetch:
+    mock_fetch.return_value = MagicMock(status_code=200)
+    _mod._send('http://hb/x', '', 'public', False)
+    _, kwargs = mock_fetch.call_args
+    assert 'X-Webhook-Secret' not in kwargs['headers']
+
+
+def test_send_swallows_exception() -> None:
+  """A transport error must never propagate (toggling must not break)."""
+  with patch('integrations.http.fetch_with_retry', side_effect=RuntimeError('boom')):
+    _mod._send('http://hb/x', 'shh', 'quiet', True)  # must not raise
+
+
+def test_send_warns_on_error_status() -> None:
+  import logging
+
+  with patch('integrations.http.fetch_with_retry') as mock_fetch:
+    mock_fetch.return_value = MagicMock(status_code=401)
+    with patch.object(_mod.logger, 'warning') as mock_warn:
+      _mod._send('http://hb/x', 'shh', 'quiet', True)
+      mock_warn.assert_called_once()
+      assert logging  # keep import used
+
+
+def test_send_never_logs_secret(caplog) -> None:  # type: ignore[no-untyped-def]
+  secret = 'super-secret-value-123'
+  with patch('integrations.http.fetch_with_retry', side_effect=RuntimeError('network down')):
+    with caplog.at_level('DEBUG'):
+      _mod._send('http://hb/x', secret, 'quiet', True)
+  assert secret not in caplog.text
+
+
+def test_dispatch_starts_daemon_thread() -> None:
+  with patch('threading.Thread') as mock_thread:
+    instance = MagicMock()
+    mock_thread.return_value = instance
+    _mod._dispatch('http://hb/x', 'sec', 'quiet', True)
+    mock_thread.assert_called_once()
+    assert mock_thread.call_args.kwargs['daemon'] is True
+    instance.start.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -272,7 +272,7 @@ wheels = [
 
 [[package]]
 name = "cyclonedx-python-lib"
-version = "11.8.0"
+version = "11.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "license-expression" },
@@ -280,9 +280,9 @@ dependencies = [
     { name = "py-serializable" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/45/5ce2515e092656ada3959897681a24a7299f13638d4805de3d1fd9f91342/cyclonedx_python_lib-11.8.0.tar.gz", hash = "sha256:a8935b06dfe53d80efd47b5f6a202eb678cea00f2930e94e3710f2c1510166c9", size = 1422887, upload-time = "2026-06-04T10:38:27.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/54/40d741cb605229cddcf9ec689b0fd401e39e2e70c2fe9cc728923b983b8e/cyclonedx_python_lib-11.10.0.tar.gz", hash = "sha256:d03d6ea271e26feaf123b8b1b34468a305f33a338c5763f56e397a8408f9b290", size = 1429036, upload-time = "2026-06-11T10:36:27.633Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/af/333ad82adec8121dae568f7d094a3b08ba485340cf19fe10674f2db14774/cyclonedx_python_lib-11.8.0-py3-none-any.whl", hash = "sha256:a326b575acbb3aa1040986307a4ae282ff27f99ffcbdfdaaf8de10ee85e97f01", size = 523911, upload-time = "2026-06-04T10:38:26.248Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/21/01c9b957ec3a778de86e010c1b54ea433ebf2fc50b810a3ca0ce8000782f/cyclonedx_python_lib-11.10.0-py3-none-any.whl", hash = "sha256:ffb9510b8d00a0896cfbe0a78b97c545d28f7d2a54e9d9dd5e5dc6e91ca9b375", size = 527798, upload-time = "2026-06-11T10:36:25.985Z" },
 ]
 
 [[package]]
@@ -296,11 +296,11 @@ wheels = [
 
 [[package]]
 name = "distlib"
-version = "0.4.1"
+version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/b2/d6fc3f2347f43dada79e5ff118493e8109c98400a0e29a1d5264a3aa479b/distlib-0.4.1.tar.gz", hash = "sha256:c3804d0d2d4b5fcd44036eb860cb6660485fcdf5c2aba53dc324d805837ea65b", size = 610526, upload-time = "2026-06-02T11:17:40.691Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/18/3497c4fa83a76dcb154923fd2075522e8dd6995ecee4093c00ae18160046/distlib-0.4.1-py2.py3-none-any.whl", hash = "sha256:9c2c552c68cbadc619f2d0ed3a69e27c351a3f4c9baa9ffb7df9e9cdc3d19a97", size = 469216, upload-time = "2026-06-02T11:17:38.779Z" },
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
 ]
 
 [[package]]
@@ -314,7 +314,7 @@ wheels = [
 
 [[package]]
 name = "e-note-ion"
-version = "1.21.5"
+version = "1.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },
@@ -361,11 +361,11 @@ dev = [
 
 [[package]]
 name = "filelock"
-version = "3.29.1"
+version = "3.29.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1f/f9/f38573ed5844586db374d085911740a501ccfa373b455fc9413f09f85237/filelock-3.29.1.tar.gz", hash = "sha256:d97e6b1b9757569626c58caa07dc4beb1613f4a2938b1e8cc81afca398906c9e", size = 59335, upload-time = "2026-06-03T15:19:04.053Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/a0/614c5fe402fd88951df45f4dda2fa3b4e17a99ecd92340771929169b3b95/filelock-3.29.1-py3-none-any.whl", hash = "sha256:85199dfd706869641b72b2e8955d5416a4b2b7dc4b0e8e6d97b4cc1299a6983b", size = 40750, upload-time = "2026-06-03T15:19:02.959Z" },
+    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
 ]
 
 [[package]]
@@ -548,42 +548,46 @@ wheels = [
 
 [[package]]
 name = "msgpack"
-version = "1.1.2"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/23/6139781ca7aadf656fa8e384fa84693ffb13f299e6931b6526427fe5e297/msgpack-1.2.0.tar.gz", hash = "sha256:8e17af38197bf58e7e819041678f6178f4491493f5b8c8580414f40f7c2c3c41", size = 183017, upload-time = "2026-06-11T04:16:10.775Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e23ce8d5f7aa6ea6d2a2b326b4ba46c985dbb204523759984430db7114f8aa00", size = 81127, upload-time = "2025-10-08T09:15:24.408Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c15b7d74c939ebe620dd8e559384be806204d73b4f9356320632d783d1f7939", size = 84981, upload-time = "2025-10-08T09:15:25.812Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a9/3536e385167b88c2cc8f4424c49e28d49a6fc35206d4a8060f136e71f94c/msgpack-1.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99e2cb7b9031568a2a5c73aa077180f93dd2e95b4f8d3b8e14a73ae94a9e667e", size = 411885, upload-time = "2025-10-08T09:15:27.22Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:180759d89a057eab503cf62eeec0aa61c4ea1200dee709f3a8e9397dbb3b6931", size = 419658, upload-time = "2025-10-08T09:15:28.4Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/ef/2b92e286366500a09a67e03496ee8b8ba00562797a52f3c117aa2b29514b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:04fb995247a6e83830b62f0b07bf36540c213f6eac8e851166d8d86d83cbd014", size = 403290, upload-time = "2025-10-08T09:15:29.764Z" },
-    { url = "https://files.pythonhosted.org/packages/78/90/e0ea7990abea5764e4655b8177aa7c63cdfa89945b6e7641055800f6c16b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e22ab046fa7ede9e36eeb4cfad44d46450f37bb05d5ec482b02868f451c95e2", size = 415234, upload-time = "2025-10-08T09:15:31.022Z" },
-    { url = "https://files.pythonhosted.org/packages/72/4e/9390aed5db983a2310818cd7d3ec0aecad45e1f7007e0cda79c79507bb0d/msgpack-1.1.2-cp314-cp314-win32.whl", hash = "sha256:80a0ff7d4abf5fecb995fcf235d4064b9a9a8a40a3ab80999e6ac1e30b702717", size = 66391, upload-time = "2025-10-08T09:15:32.265Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f1/abd09c2ae91228c5f3998dbd7f41353def9eac64253de3c8105efa2082f7/msgpack-1.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:9ade919fac6a3e7260b7f64cea89df6bec59104987cbea34d34a2fa15d74310b", size = 73787, upload-time = "2025-10-08T09:15:33.219Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/b0/9d9f667ab48b16ad4115c1935d94023b82b3198064cb84a123e97f7466c1/msgpack-1.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:59415c6076b1e30e563eb732e23b994a61c159cec44deaf584e5cc1dd662f2af", size = 66453, upload-time = "2025-10-08T09:15:34.225Z" },
-    { url = "https://files.pythonhosted.org/packages/16/67/93f80545eb1792b61a217fa7f06d5e5cb9e0055bed867f43e2b8e012e137/msgpack-1.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:897c478140877e5307760b0ea66e0932738879e7aa68144d9b78ea4c8302a84a", size = 85264, upload-time = "2025-10-08T09:15:35.61Z" },
-    { url = "https://files.pythonhosted.org/packages/87/1c/33c8a24959cf193966ef11a6f6a2995a65eb066bd681fd085afd519a57ce/msgpack-1.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a668204fa43e6d02f89dbe79a30b0d67238d9ec4c5bd8a940fc3a004a47b721b", size = 89076, upload-time = "2025-10-08T09:15:36.619Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/6b/62e85ff7193663fbea5c0254ef32f0c77134b4059f8da89b958beb7696f3/msgpack-1.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5559d03930d3aa0f3aacb4c42c776af1a2ace2611871c84a75afe436695e6245", size = 435242, upload-time = "2025-10-08T09:15:37.647Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/47/5c74ecb4cc277cf09f64e913947871682ffa82b3b93c8dad68083112f412/msgpack-1.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70c5a7a9fea7f036b716191c29047374c10721c389c21e9ffafad04df8c52c90", size = 432509, upload-time = "2025-10-08T09:15:38.794Z" },
-    { url = "https://files.pythonhosted.org/packages/24/a4/e98ccdb56dc4e98c929a3f150de1799831c0a800583cde9fa022fa90602d/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20", size = 415957, upload-time = "2025-10-08T09:15:40.238Z" },
-    { url = "https://files.pythonhosted.org/packages/da/28/6951f7fb67bc0a4e184a6b38ab71a92d9ba58080b27a77d3e2fb0be5998f/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d62ce1f483f355f61adb5433ebfd8868c5f078d1a52d042b0a998682b4fa8c27", size = 422910, upload-time = "2025-10-08T09:15:41.505Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
-    { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
-    { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
+    { url = "https://files.pythonhosted.org/packages/35/3d/a7e3cdafa8c0cf36c81e2fa848ec4d30cf089459af45b390ad03f9ce6f49/msgpack-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f854fa1a8b55d75d82ef9a905d9cdbeffdf7897c088f6020bd221867da5e56a5", size = 83032, upload-time = "2026-06-11T04:15:39.38Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/aa/53ddfba0e347cc4b484e95f629c5850b9e800ca8390c91ffc604407acf87/msgpack-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e90df581f80f53b372d5d9d9349078d729851a3a0d0bd74f53ccb598d01e45b8", size = 82600, upload-time = "2026-06-11T04:15:40.609Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fd/e64c2c776e6dbad0af3c963fe0c0dd1ee1ba09efac478b233ab1db41868f/msgpack-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b276ed50d8ac75d1f134a433ae79af8557d0fa25ee5b4737da533dfc2ce382e8", size = 404342, upload-time = "2026-06-11T04:15:41.87Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/60/fb9a08e6ccba882dfd370a5837fe3a07572938fdfe954f0f17fdf3e574b9/msgpack-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:544d972459c92aa32e63b800d07c2d9cf2734a3be29cee3a0b478a622850e9f5", size = 412351, upload-time = "2026-06-11T04:15:43.253Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4d/df5c575c274fedc68ac9c6c61d045161899efad2afcdc25138efa7edde69/msgpack-1.2.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a070147cc2cf6b8a891734e0f5c8fe8f70ed8739ab30ba140b058005a6e86af4", size = 373331, upload-time = "2026-06-11T04:15:44.754Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a4/c8b98f8191e985ed2003d87664ce3c95cca41db5d0cf6bf4f54327d32ec8/msgpack-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7685e23b0f51745a751629c31713fbefdef8896b31b2bb38299dfa4ae6c0740c", size = 394654, upload-time = "2026-06-11T04:15:46.423Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/49/76f036720a602ea24428cfec5ec806f2487c0380b1bff0a2aa3094e15f87/msgpack-1.2.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b9204daeee8d91a7ae5acf2d2a8e3983be9a3025f38aa21bfaefbd7eea84a7dc", size = 370624, upload-time = "2026-06-11T04:15:48.062Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/38/40af3d29232833705a43b0fce0d07425cc280a7b92ab2b29932425b40df4/msgpack-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bfc057248609742ebbabf6bcd27fea4fd99c4980584e613c168c9b002318298f", size = 408038, upload-time = "2026-06-11T04:15:49.669Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b2/f140ca450524dff4d8d0eb81eb9ed75f8f3e0b1f12e49c5b01617cfa0b1c/msgpack-1.2.0-cp314-cp314-win32.whl", hash = "sha256:a3faa7edf2388337ae849239878e92f0298b4dab4488e4f1834062f9d0c410c9", size = 65823, upload-time = "2026-06-11T04:15:51.062Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/13/6517bf966b841c7675ded30701a068ce141f3e698a27aaa35c702d8e078b/msgpack-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:1a3effc392a57744e4681e55d05f97d5ee7b598747d718340a9b4b8a970c40e1", size = 72484, upload-time = "2026-06-11T04:15:52.289Z" },
+    { url = "https://files.pythonhosted.org/packages/45/8c/1d948420fdaa24de4efdb8012a6a5bebe09c82ee002b8c2ca745e9917f1f/msgpack-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:56a318f7df6bec7b40928d6b0519961f20a510d8baabf6baa393a70444588f0a", size = 66657, upload-time = "2026-06-11T04:15:53.583Z" },
+    { url = "https://files.pythonhosted.org/packages/39/16/1674faa1b7bddc19e79b465fd8e88e2cf4e3f7cae90723740701e8541068/msgpack-1.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:afa4a65ab2097795e771a74a3a81ea49534aaeba874eaf426a3332268e045ae6", size = 86093, upload-time = "2026-06-11T04:15:54.98Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/24/f241bcfdd9e96b2246289357c5a5e5a496189fd41c5844bee802c116aac7/msgpack-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:409550770632bb28daa70a11d0ed5763f7db38f40b06f7db9f11dd2794d01102", size = 86372, upload-time = "2026-06-11T04:15:56.381Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c9/57f8ab98a1b21808c27b6dd6029053e0a796ffbb9b371e460dbe997011a9/msgpack-1.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf47e3cd11ce044965a9736a322afdd390b31ed602d1c1b10211d1a841f1d587", size = 428207, upload-time = "2026-06-11T04:15:57.739Z" },
+    { url = "https://files.pythonhosted.org/packages/17/6b/4fd4aa739f131ded751ca7167c8ee87d2aab32506ebbeea893b60b51d343/msgpack-1.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:204bc9f5d6e59c1718c0a4a84fc8ff71b5b4562faac257c1a68bca611ecf9b72", size = 426082, upload-time = "2026-06-11T04:15:59.356Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/00/db88e9a08fcd6513decaad06cbd5c168142bc3e662fb2f1aca3a563b7aa1/msgpack-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:610154307b27267266368bc1d1c7bb8aeb71da7be9356d403cb2442d9e6399f5", size = 378355, upload-time = "2026-06-11T04:16:00.916Z" },
+    { url = "https://files.pythonhosted.org/packages/54/84/eee4dd703d7a600cf46159d621c070b0b9468cf3dbade4ea8272bf5232a4/msgpack-1.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6799f157bb63e79f11e2e590cfdb28423fc18dd60c270c3914b5b4586ae36f7e", size = 410848, upload-time = "2026-06-11T04:16:02.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/0a/195e2c549fd4631eb7f157d016ff15a10c4c1cf82b6d0a9b1edaef5174b1/msgpack-1.2.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:72bd844902cf0a5ac3af2ef742f253cd0b1e5bcd184f49b4fb9a6a1f7bf305e8", size = 376152, upload-time = "2026-06-11T04:16:04.041Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9b/bdd143fa79baec411dc658f5686fed680a18b36fcea5fccb6af1b8c7d832/msgpack-1.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3c0bd450f78d0d81722c80da6cdbf674a856967870a9db2f6c4debc4d8b3c67c", size = 417061, upload-time = "2026-06-11T04:16:05.63Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/ce/011ffcd8b919f55196ec53f12ae162e21c879d95afba226894314ff62c07/msgpack-1.2.0-cp314-cp314t-win32.whl", hash = "sha256:378caf74c4c718dfc17590ce68a6d710ed398ff6fcf08237de23b77755730b55", size = 70782, upload-time = "2026-06-11T04:16:07.105Z" },
+    { url = "https://files.pythonhosted.org/packages/57/a8/9b8791ca96b1be6b9f659c718271e2cb7f99f73f58aad2dd0b30f750f6c0/msgpack-1.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:553b42598165c4dd3235994fd6e4b0dfb1ce5f3fd33d94ba9609442643015f38", size = 77899, upload-time = "2026-06-11T04:16:08.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/04/3fa2dffb87bf598696b86bde7cd642d0a7590520c3fa24cd19611dfebeb7/msgpack-1.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2825bb1da548d214ab8a810906b7dd69a10f3838b615a2cc46e5172d3cb44f6e", size = 71004, upload-time = "2026-06-11T04:16:09.556Z" },
 ]
 
 [[package]]
 name = "niquests"
-version = "3.19.0"
+version = "3.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "charset-normalizer" },
     { name = "urllib3-future" },
     { name = "wassima", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/c3/9c37961443c4f5e2bcf2c7b31ede2bbed7667f2d552c98f3eac7c3966c6b/niquests-3.19.0.tar.gz", hash = "sha256:e3c9fc8aa7c77c3d066dd6a0551d15eee1660ac14a497264577115c3296022ff", size = 1034890, upload-time = "2026-06-01T12:25:38.162Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/6a/b3b4d63a2d80a067dd87d6e01e071733df128b95d6806d2eb7852c35e4d2/niquests-3.19.1.tar.gz", hash = "sha256:2c34591744c7ade45f5f3a65a637cf1366d399eb514200005a8823de0d66b91e", size = 1035701, upload-time = "2026-06-08T07:53:15.754Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/78/3ae749f05c392d670d8381302d07e8b5c147bf6bbe20725f69a4adc02cb0/niquests-3.19.0-py3-none-any.whl", hash = "sha256:d75efeedda74be9718b2e3508d8c900bd411a3f554c57e3b4d24d9245fc37a1f", size = 210982, upload-time = "2026-06-01T12:25:36.53Z" },
+    { url = "https://files.pythonhosted.org/packages/80/27/498b676bf5e4824d84c6bae37bf948c164bcad0484b30851a935f165756b/niquests-3.19.1-py3-none-any.whl", hash = "sha256:ed04a8e2813f0b12f2ec82982c500fd115499b88d1abfa689fc9116ecdc68ede", size = 211349, upload-time = "2026-06-08T07:53:13.938Z" },
 ]
 
 [[package]]
@@ -669,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "pip-audit"
-version = "2.10.0"
+version = "2.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachecontrol", extra = ["filecache"] },
@@ -683,9 +687,9 @@ dependencies = [
     { name = "tomli" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/89/0e999b413facab81c33d118f3ac3739fd02c0622ccf7c4e82e37cebd8447/pip_audit-2.10.0.tar.gz", hash = "sha256:427ea5bf61d1d06b98b1ae29b7feacc00288a2eced52c9c58ceed5253ef6c2a4", size = 53776, upload-time = "2025-12-01T23:42:40.612Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/a4/f21d5f0a0edabcbce31560b73c7c5a6f72ae87af4236fd1069c8f59a353d/pip_audit-2.10.1.tar.gz", hash = "sha256:1eb4565d19ebe5d48996f4b770b4d2b32887e12cb12cfa637f1a064011b55ffc", size = 54275, upload-time = "2026-06-10T22:17:01.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/f3/4888f895c02afa085630a3a3329d1b18b998874642ad4c530e9a4d7851fe/pip_audit-2.10.0-py3-none-any.whl", hash = "sha256:16e02093872fac97580303f0848fa3ad64f7ecf600736ea7835a2b24de49613f", size = 61518, upload-time = "2025-12-01T23:42:39.193Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/a7/b0c504148114047bd1bc9d97447453c6850ca176bb2f3c0038835994e8b7/pip_audit-2.10.1-py3-none-any.whl", hash = "sha256:99ef3f600a317c1945f1e89e227ef26e1c2d618429b8bd3fa6f4f7c440c4611a", size = 62023, upload-time = "2026-06-10T22:17:00.309Z" },
 ]
 
 [[package]]
@@ -789,7 +793,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -798,9 +802,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
 ]
 
 [[package]]
@@ -831,15 +835,15 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.4.0"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/12/38c1a0b1e64806780c9563e3fc9f6e472251839662587cfbe9bfaf2ae10a/python_discovery-1.4.0.tar.gz", hash = "sha256:eb8bc7daad3c226c147e45bb4e970a1feb1bf4048ee178e6db59e197b8010ce3", size = 68455, upload-time = "2026-05-28T01:15:37.639Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/1a/cbbaf13b730abb0a16b964d984e19f2fe520c21a4dc664051359a3f5a9e7/python_discovery-1.4.2.tar.gz", hash = "sha256:8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690", size = 70277, upload-time = "2026-06-11T16:10:42.383Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/8d/3d316429f65029532bb1e28ff77b797d86b5ac3915bb44ca4e19aa283d43/python_discovery-1.4.0-py3-none-any.whl", hash = "sha256:26ed78d703e234879a66244c7d4114563fb13ec5cd30a2d1357e5fb4850782da", size = 33217, upload-time = "2026-05-28T01:15:36.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/82/a70006589557f267f15bd384c0642ad49f0d97b690c3a05b166b9dcbad3b/python_discovery-1.4.2-py3-none-any.whl", hash = "sha256:475803f53b7b2ed6e490e27373f9d8340f7d2eebf9acdaf645d7d714c97bb500", size = 33886, upload-time = "2026-06-11T16:10:41.192Z" },
 ]
 
 [[package]]
@@ -955,27 +959,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.16"
+version = "0.15.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/a9/3abdf488f1bf3d24c699415e454ed554a6350d5d89ce183be1ee0a3361ac/ruff-0.15.17.tar.gz", hash = "sha256:2ec446937fd16c8c4de2674a209cc5af64d9c6f17d21fbf1151054fa0bcf5219", size = 4743346, upload-time = "2026-06-11T17:54:47.663Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
-    { url = "https://files.pythonhosted.org/packages/93/9a/a79159346f19134a956607754e57d8d128f7a4c00f4ad2f7514d224c172c/ruff-0.15.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:197c207ed75ffba54a0dec23db4aa939a27a3053073e085e0042433cbdc58e4a", size = 11063550, upload-time = "2026-06-04T16:32:42.24Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/72/3ce2ac000a5299ec238e01f51397b3b653c93b077d9b1bfe8715bb895f20/ruff-0.15.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a39fec45ab316cc23e7558f23fea4a70403ddb5648ea9a4a3854a16973d0071", size = 10421345, upload-time = "2026-06-04T16:32:37.251Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c2/cc7fad3ec9169373f5b6a18f1917b91080feec40c3f9658334a1d28e2f03/ruff-0.15.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba93191d79003116b95128c9d306e045200fdbd0bccb782b110f3cd1d4abc5cf", size = 10757217, upload-time = "2026-06-04T16:32:54.722Z" },
-    { url = "https://files.pythonhosted.org/packages/69/d2/3474009eaa0a65b31fa7152a2fad5e2f050c640ceb1e6b02ee6922e94c82/ruff-0.15.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6ee4b90520630120ef032aa5cc10db483852dff950e78b1d717e2993a61ac8d", size = 10507035, upload-time = "2026-06-04T16:33:05.343Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/81/b7ae6ccbd11f0c8dc3d5d67fc4be9b57ff57ca86ba56152021378e1277f2/ruff-0.15.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e4215bc938bc3c8215c1472c1aa437e310fee20cd427335fec9d7e609563628", size = 11255291, upload-time = "2026-06-04T16:32:49.49Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/e1/46e526f1a7cc90857ce6ddf25fbb77eb6568651ac38d71b033af07076dd5/ruff-0.15.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c8d26be963b090f10e29abc8b3e74a2a321f6fa34e02424e30b5af89350ecbb", size = 12124922, upload-time = "2026-06-04T16:33:07.821Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/da/5c791b088b596b24d0deb967fa28ae02ad751a140c0b9ea81c5ab915d6c0/ruff-0.15.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f198cf4123602a2280ed46c307bcbafe41758d6fee5b456b6b6058ca1514b3b4", size = 11332186, upload-time = "2026-06-04T16:33:02.971Z" },
-    { url = "https://files.pythonhosted.org/packages/72/11/5da87abe20047c8962361473923ebb2f62b595250126aadfad8c20649c1e/ruff-0.15.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb27515fa6240fb586ae82b901a59e67d24acff86f2190b433dc542fe0435aeb", size = 11373541, upload-time = "2026-06-04T16:32:47.007Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/2a/8554754c23a854ae3fd6b507e36ad61ddb121e298c6d5d617dec94ed0f14/ruff-0.15.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a267c46ba1593fc26b8eecbea050b39d40c0b6bb7781ee11c90a02cd10032951", size = 11353014, upload-time = "2026-06-04T16:32:34.795Z" },
-    { url = "https://files.pythonhosted.org/packages/62/25/62ea41529ec89f742ea3fed9cb1059c72877ec7cf9b9e99ac9cf3294d1d9/ruff-0.15.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:528c68f39a91498a8d50e91ff5985df3d105782bab49cc378e73ac26bff083e8", size = 10737467, upload-time = "2026-06-04T16:32:26.348Z" },
-    { url = "https://files.pythonhosted.org/packages/90/17/334d3ad9de4d40f9dd58fdd09e35ce64553bb501e2f19a839e2fb6be14fc/ruff-0.15.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ed55c58950df60589a9a7a5d2f8fa5f54ebd287163be805adfe6ee95a9de123", size = 10521910, upload-time = "2026-06-04T16:32:32.54Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/bd/3ac7c6ae77a885c1004b3dda2446ea401768d24f851c14b4ad4b24f6639c/ruff-0.15.16-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d482feaf51512b50f9790ceb417a56a61dd1e9d9bf967662b9ed27c01b34f53a", size = 10979190, upload-time = "2026-06-04T16:32:57.492Z" },
-    { url = "https://files.pythonhosted.org/packages/33/d7/609546e6a413c3f216fbf2a50c928f97c80939154f6a0503114094a86191/ruff-0.15.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e15bc8c94513dae2a40cc9ef07c94fdd4ecc9e29dabebeebe170f952322c9e3", size = 11477014, upload-time = "2026-06-04T16:32:44.687Z" },
-    { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
-    { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4d/e11259f5da07cb6afb2d074c31bf09da9671993f7329d4f15d2fdc458301/ruff-0.15.17-py3-none-linux_armv6l.whl", hash = "sha256:d9feddb927fc68bd295f5eebc587a7e42cfaf9b65f60ca4a2386febff575da8f", size = 10856677, upload-time = "2026-06-11T17:54:49.533Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3e/772d679e1a0dc058e58875bd2c0cb713a0530877b4a76fee3c7966df0d49/ruff-0.15.17-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:25805a226d741c47d274a35ad5c10a7dde175fcddfa511d7cf3da0a21eb3eab7", size = 11223443, upload-time = "2026-06-11T17:55:00.573Z" },
+    { url = "https://files.pythonhosted.org/packages/68/58/bd41f7688b2fd5623012605130ed70e60aa7f2244baa3d5066bdd61530c8/ruff-0.15.17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f6ad73b14c2d18a3bf8ad7cb6974294d7f613a7898604826058e6ac64918ef4d", size = 10566458, upload-time = "2026-06-11T17:55:07.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5b/733371013fcf1ec339e477ece6ab42bfe10bdd9bba8ee88a9516aa56bfc0/ruff-0.15.17-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ba0c1e4f95bcb3869d0d30cbd5917071ef2e28665abfec970cdab0492c713ed", size = 10914483, upload-time = "2026-06-11T17:55:05.501Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/cc/6f24251cc0252f7239391ccb85833f320efad14ebe5b443943f37ced6332/ruff-0.15.17-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81647960f10bff57d2e51cadd0c3950fe598400c852863a038720ef5b8cca91e", size = 10647497, upload-time = "2026-06-11T17:54:57.733Z" },
+    { url = "https://files.pythonhosted.org/packages/68/dd/0d10c17ce1a1624d6fc3156309c3f834fdb5dfaad026ec90c85684f3990e/ruff-0.15.17-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e01a84ddbc8c16c23055ba3924476850f1bbc1917cebbb9376665a63e74260d", size = 11416967, upload-time = "2026-06-11T17:54:51.461Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/91/556bfb156f6144f355e831c23db00b2fc4120f86b3ce81cc5f7fd2df51f3/ruff-0.15.17-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84fe9f653152f8f294f9f7e03bf3a453d8b4a27f7a59c78c8666167f2b17b96c", size = 12335770, upload-time = "2026-06-11T17:54:45.793Z" },
+    { url = "https://files.pythonhosted.org/packages/88/82/8b5999aa13355e926f06d9f42a32dcca862f623bf0363785ff89d607dffd/ruff-0.15.17-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c0fe88a7676e7a05b73174d4d4a59cb2ac21ff8263583f87a81a6018475a978", size = 11575441, upload-time = "2026-06-11T17:54:32.661Z" },
+    { url = "https://files.pythonhosted.org/packages/11/93/f10377bb04109ca0e8cbc483ff1982c54b6d418210041776f93e8cdc7fa9/ruff-0.15.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecfc3c7878fff94633ab0348524e093f9ce3243080416dd7d14f8ba400174719", size = 11557614, upload-time = "2026-06-11T17:54:34.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a6/eeeae7f7d5493df41649ab3db92f086b2d0a30199e4efdf8e3dd7a033f24/ruff-0.15.17-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b8461180b22420b1bdc289909410930761629fddf2a5aaf60fae1ab26cedc4c4", size = 11544450, upload-time = "2026-06-11T17:54:39.042Z" },
+    { url = "https://files.pythonhosted.org/packages/32/88/5991ce565129a24dd4a00db1254b3b5db2e53018cbe4018ea5a89738e727/ruff-0.15.17-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6eccbe50a038b503e7140b441aa9c7fc8c1f36edf23ebef9f4165c2f28f568b7", size = 10892524, upload-time = "2026-06-11T17:55:09.432Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1d/0fdd248313425f55223968af04b0a42125466a8d88d21c1d99c6af0a51e8/ruff-0.15.17-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:382fc0521025f5a8ad447d8bdd523545d0d7646adb718eb1c2dac5065ec27c0f", size = 10659573, upload-time = "2026-06-11T17:54:36.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/0e/072e8260deb9461062ce9311ced27a8e541229a6ffd483013dd37661e43e/ruff-0.15.17-py3-none-musllinux_1_2_i686.whl", hash = "sha256:456d41fcd1b2777ad63f09a6e7121d43f7b688bbc76a800c10f7f8fb1f912c3f", size = 11127818, upload-time = "2026-06-11T17:55:03.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b4/55060a34163121498014696b5f656db5b8c6963768f227dbf0d76b311073/ruff-0.15.17-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1a04bcc94ae6194e9db05d16ad31f298a7194bfbcb08258bbe589cee1d587b8", size = 11655901, upload-time = "2026-06-11T17:54:53.562Z" },
+    { url = "https://files.pythonhosted.org/packages/49/71/9b29d6b87cef468d697f43c6a91e3fae4a80185779d7d5a4ef27d173439f/ruff-0.15.17-py3-none-win32.whl", hash = "sha256:596065960ab1ff593f744220c9fe6580eda00a95003cffa9f4048bb5b1bf0392", size = 10925574, upload-time = "2026-06-11T17:54:55.723Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b2/8fc77f3723228836fa5d12497eb71c808f83782e10d058d2b15cfa14640b/ruff-0.15.17-py3-none-win_amd64.whl", hash = "sha256:6769e5fa1710b179b92e0bfa5a51735b35baea9013dadb06d5f44cbcf9547084", size = 12058788, upload-time = "2026-06-11T17:54:41.042Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c7/c53e8dbff9c9dc4b7928773421ae294a5d28fcb8dcda1a089579d3a7e510/ruff-0.15.17-py3-none-win_arm64.whl", hash = "sha256:f3be1fbb34bcdfd146240d8fb92a709d4c2c8191348580a3c044ec60fa0b4456", size = 11355275, upload-time = "2026-06-11T17:54:43.635Z" },
 ]
 
 [[package]]
@@ -1096,7 +1100,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.4.2"
+version = "21.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -1104,18 +1108,18 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0d/4e93c8e6d1001a75763f87d8f5ecda8ebc7f4aa2153dddfaf4ae8892821a/virtualenv-21.4.2.tar.gz", hash = "sha256:38e6ee0a555615c0ea9da2ac7e9998fe8dc3b911dd33ad8eaad2020957653b0c", size = 7613326, upload-time = "2026-05-31T17:01:22.827Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/0e/933bacb37b57ae7928b0030eef205a3dbb3e37afdbdde5be2e113318958f/virtualenv-21.5.0.tar.gz", hash = "sha256:98847aadf5e2037e0e4d2e19528eb3aca6f23906422e59a510bff231a6d32fce", size = 4577424, upload-time = "2026-06-13T20:36:45.066Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/c4/557dc082be035381b85fdb2b74e21d3d21b57750b74f2b47a32f3a639ff9/virtualenv-21.4.2-py3-none-any.whl", hash = "sha256:854210ca524a1a4d0d744734f4acbc721c3ffe163b85bbf5d56d14d5ae2f0fae", size = 7594079, upload-time = "2026-05-31T17:01:20.735Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl", hash = "sha256:8f7c38605023688c89789f566959006af6d61c99eeeb9e58342eb780c5761e5e", size = 4557937, upload-time = "2026-06-13T20:36:42.967Z" },
 ]
 
 [[package]]
 name = "wassima"
-version = "2.1.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/e0/10e0ff85dc4d48b5000aa76567dfacf33b9518c2fadd410e850e213c36b9/wassima-2.1.0.tar.gz", hash = "sha256:709f375c778d9be84568d802d1e1b62a2ed3942b1fa4c83830533a69cf36c243", size = 135950, upload-time = "2026-05-10T04:07:21.576Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/34/68ab01470c1cef170e8370a8a05e598d621d3657bf925b62bc9a18b4509a/wassima-2.1.1.tar.gz", hash = "sha256:9c6ad4aa3cfbe91fd75f9eae315ba563bbc7d9d2479aef0c288fa7f1ca3b0c53", size = 140395, upload-time = "2026-06-08T02:44:41.424Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/f9/077b0aacd337c31d3f97eef7acfa89bcd522360b56614f961af84db0a3ca/wassima-2.1.0-py3-none-any.whl", hash = "sha256:4e8bc4b439f91f4da24bd2260be662fcb42d1cc439d7678420237d314e55a854", size = 128092, upload-time = "2026-05-10T04:07:19.9Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9e/472991fc66d940d3ba3268fc8c2866a44b6870a9711ab74fcf1f29e817e1/wassima-2.1.1-py3-none-any.whl", hash = "sha256:ab0f12c091ff697f111eea5f925aafd83736909a1c9c764a8bbf874b2e4d4a42", size = 131435, upload-time = "2026-06-08T02:44:39.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
— *Claude Code*

Part A of #566 (HomeBridge / Apple Home integration): the plugin-neutral
e-note-ion foundation. Implements the approved plan and folds in #522's
`GET /state` design.

## What's in this PR

- **`GET /state`** — returns the runtime `modes` (`quiet`/`public`) plus current
  board content (`grid`, `rendered`, `source`, `timestamp`). `?refresh=true`
  forces an authoritative Vestaboard fetch; otherwise content is served from an
  in-memory cache updated on every successful `set_state_raw` (no extra,
  rate-limited API calls). Authenticated with a new auto-generated `state`
  credential, mirroring `/health`.
- **`homebridge.py`** — optional, config-gated (`[homebridge]`) outbound push
  notifier fired on real quiet/public transitions. Runs on a daemon thread with
  a short timeout; failures are logged and **never block toggling**; the secret
  is **never logged**.
- **`vestaboard.py`** — last-grid cache (`get_cached_grid`) and `render_grid_text`
  (ANSI-free, one-char-per-tile plain text for the API).

## Deviation from #522 (flagging for review)

#522 specified `404` on empty board / `503` on refresh-fetch error. Since the
toggle state is now the **primary** payload (HomeKit reads it every poll), `/state`
instead returns **`200` with `modes` always present**, marking missing content as
`source: "empty"` and falling back to cache (with `refresh_error: true`) on a
failed refresh. A `404`/`503` there would break the switch read. Easy to change
back if you'd rather keep strict #522 semantics.

## Naming / polarity

Switches map to **Quiet** (on = `quiet`) and **Public** (on = `public`, i.e.
private content hidden), per your decision.

## Tests

- `tests/core/test_webhook.py`: `/state` modes, source board/virtual/empty,
  `?refresh` success + error-fallback, 401 (no/wrong secret), query-param auth.
- `tests/test_homebridge.py`: notifier gating (no section / no url), dispatch
  args, `_send` payload + secret header (and omission), error-swallowing,
  **secret never logged**, daemon-thread dispatch.
- `tests/core/test_vestaboard.py`: `render_grid_text` (letters/blanks/colors/
  heart/degree, no ANSI) and the last-grid cache (incl. copy isolation).
- Full suite: **1570 passed**; `homebridge.py` 100%, total 95%.

## Follow-ups (not in this PR)

- **Part B:** the custom `homebridge-e-note-ion` plugin (separate repo) — single
  grouped "Vestaboard" device. Tracking issue to follow.
- **#522** stays open; to be closed alongside the plugin work per plan.

Bundles a dev-only `uv lock --upgrade`. Minor version bump (`1.21.5` → `1.22.0`).

Closes part of #566.
