### PR TITLE
docs: clarify HomeBridge push url + secret

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -411,8 +411,13 @@ city = "San Francisco"
 #
 # url — the HomeBridge endpoint that receives the push. On each transition,
 #   e-note-ion sends POST <url> with JSON {"characteristic": "quiet"|"public",
-#   "value": true|false}. Failures are logged and never block toggling.
-# url = "http://homebridge.local:51828/e-note-ion"
+#   "value": true|false}. Use http://<homebridge-host>:<port>/ where <port>
+#   matches the plugin's pushPort; the path is ignored. Failures are logged and
+#   never block toggling.
+# url = "http://homebridge.local:51828/"
 #
-# secret — optional; sent as the X-Webhook-Secret header on the push.
-# secret = "your-shared-secret"
+# secret — sent as the X-Webhook-Secret header on the push. The companion plugin
+#   auto-generates this and prints the plaintext in the Homebridge log once
+#   (storing only a hash); copy that value here. Required when the plugin has a
+#   secret set (it always does), or the push is rejected with 401.
+# secret = "paste-the-plaintext-from-the-homebridge-log"

--- a/docs/homebridge.md
+++ b/docs/homebridge.md
@@ -47,7 +47,7 @@ When `[homebridge]` is configured, each **real** quiet/public transition fires:
 
 ```
 POST <url>
-X-Webhook-Secret: <secret>   (if configured)
+X-Webhook-Secret: <secret>
 
 {"characteristic": "quiet"｜"public", "value": true｜false}
 ```
@@ -59,9 +59,18 @@ interval (e.g. 5 minutes) when push is enabled, as a self-healing safety net.
 
 ```toml
 [homebridge]
-url = "http://homebridge.local:51828/e-note-ion"
-secret = "your-shared-secret"
+url = "http://homebridge.local:51828/"
+secret = "<plaintext printed once in the Homebridge log>"
 ```
+
+- **`url`** points at the plugin's push listener: `http://<homebridge-host>:<port>/`.
+  The `<port>` must match the plugin's `pushPort`. The **path is ignored** — the
+  plugin accepts a `POST` on any path of that port, so a bare `/` is fine.
+- **`secret`** is required for the companion plugin: it auto-generates a push
+  secret and prints the plaintext in the Homebridge log once (storing only a
+  hash). Copy that value here. The plugin verifies every push against it, so an
+  absent or mismatched secret yields `401` and the push is dropped (polling
+  still keeps state correct).
 
 ---
 


### PR DESCRIPTION
— *Claude Code*

Fixes two inaccuracies in the push setup docs (`docs/homebridge.md` + `config.example.toml`):

- The push `url` path is **ignored** — the plugin accepts `POST` on any path of `pushPort`. Example now uses `http://<host>:<port>/` and notes the port must match `pushPort`.
- The `secret` is **plugin-generated** (auto-gen + logged-once plaintext, hash stored) and **required** — the plugin always verifies, so a missing/mismatched secret returns 401 (polling still keeps state correct).

Docs-only; no version bump.