### PR TITLE
chore: sync ruff pre-commit hook to 0.16.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         args: [--autofix, --indent=2, --no-sort-keys]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.16
+    rev: v0.16.2
     hooks:
       - id: ruff
       - id: ruff-format


### PR DESCRIPTION
— *Claude Code*

Monthly `pre-commit autoupdate`.

The `ruff-pre-commit` hook was pinned at **v0.15.16** while the dev dependency had moved to **0.16.2**, so the hook and CI were running different formatters.

That gap is not cosmetic: **ruff 0.16 formats Python code blocks inside markdown**, which 0.15 leaves alone. A commit could pass the hook locally and then fail `ruff format --check` in CI — which is exactly what happened on #584, where `.agents/skills/new-integration/SKILL.md` needed reformatting only after the dev dependency was upgraded.

`pre-commit-hooks` (v6.0.0) and `bandit` (1.9.4) were already current.

Verified `uv run pre-commit run --all-files` passes with the new pin.

**No version bump** — tooling config only, nothing in the runtime closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)